### PR TITLE
HEXL now builds without error.

### DIFF
--- a/src/core/include/lattice/hal/hexl/hexldcrtpoly.h
+++ b/src/core/include/lattice/hal/hexl/hexldcrtpoly.h
@@ -242,8 +242,7 @@ class HexlDCRTPoly : public DCRTPolyImpl<VecType> {
 
 };  // HexlDCRTPoly
 
-/// @todo - Not sure if this is needed, was in DCRTPoly.h
-// typedef HexlDCRTPoly<BigVector> DCRTPoly;
+using DCRTPoly = HexlDCRTPoly<BigVector>;
 
 }  // namespace lbcrypto
 

--- a/src/core/lib/math/hal/intnat-hexl/benativehexl-math-impl.cpp
+++ b/src/core/lib/math/hal/intnat-hexl/benativehexl-math-impl.cpp
@@ -39,7 +39,6 @@
 #ifdef WITH_INTEL_HEXL
 
 #include "math/hal.h"
-//#include "math/hal/intnat-hexl/backendnathexl.h"
 #include "math/binaryuniformgenerator.cpp"
 #include "math/discretegaussiangenerator.cpp"
 #include "math/discreteuniformgenerator.cpp"


### PR DESCRIPTION
We were missing a typedef / using in lattice/hal/hexl's DCRTPoly declarations.  This has been re-added.  WITH_INTEL_HEXL=ON now builds without warning or error.