### PR TITLE
Restore EvalConstant for BinFHE

### DIFF
--- a/src/binfhe/include/binfhecontext.h
+++ b/src/binfhe/include/binfhecontext.h
@@ -328,6 +328,14 @@ class BinFHEContext : public Serializable {
    */
   LWECiphertext EvalNOT(ConstLWECiphertext ct1) const;
 
+  /**
+   * Evaluates constant gate
+   *
+   * @param value the Boolean value to output
+   * @return a shared pointer to the resulting ciphertext
+   */
+  LWECiphertext EvalConstant(bool value) const;
+
   const std::shared_ptr<RingGSWCryptoParams> GetParams() { return m_params; }
 
   const std::shared_ptr<LWEEncryptionScheme> GetLWEScheme() {

--- a/src/binfhe/lib/binfhecontext.cpp
+++ b/src/binfhe/lib/binfhecontext.cpp
@@ -270,6 +270,10 @@ LWECiphertext BinFHEContext::EvalNOT(ConstLWECiphertext ct) const {
     return m_RingGSWscheme->EvalNOT(m_params, ct);
 }
 
+LWECiphertext BinFHEContext::EvalConstant(bool value) const {
+  return m_LWEscheme->NoiselessEmbedding(m_params->GetLWEParams(), value);
+}
+
 LWECiphertext BinFHEContext::EvalFunc(ConstLWECiphertext ct1, const std::vector<NativeInteger>& LUT) const {
     NativeInteger beta = GetBeta();
     return m_RingGSWscheme->EvalFunc(m_params, m_BTKey, ct1, m_LWEscheme, LUT, beta, 0);

--- a/src/binfhe/lib/lwe.cpp
+++ b/src/binfhe/lib/lwe.cpp
@@ -279,5 +279,22 @@ std::shared_ptr<LWECiphertextImpl> LWEEncryptionScheme::KeySwitch(
   return std::make_shared<LWECiphertextImpl>(LWECiphertextImpl(a, b));
 }
 
+// noiseless LWE embedding
+// a is a zero vector of dimension n; with integers mod q
+// b = m floor(q/4) is an integer mod q
+std::shared_ptr<LWECiphertextImpl> LWEEncryptionScheme::NoiselessEmbedding(
+    const std::shared_ptr<LWECryptoParams> params,
+    const LWEPlaintext &m) const {
+  NativeInteger q = params->Getq();
+  uint32_t n = params->Getn();
+
+  NativeVector a(n, q);
+  for (uint32_t i = 0; i < n; ++i) a[i] = 0;
+
+  NativeInteger b = m * (q >> 2);
+
+  return std::make_shared<LWECiphertextImpl>(LWECiphertextImpl(a, b));
+}
+
 
 };  // namespace lbcrypto


### PR DESCRIPTION
Unoptimized boolean circuits sometimes need access to embeddings of constant values. Since they are constant, no encryption/noise is required.

(Also, this somehow got partially dropped in moving from PALISADE to OpenFHE.)