### PR TITLE
Fix uninitialized memory issues

### DIFF
--- a/src/binfhe/include/binfhecontext.h
+++ b/src/binfhe/include/binfhecontext.h
@@ -411,7 +411,7 @@ private:
     std::map<uint32_t, RingGSWEvalKey> m_BTKey_map;
 
     // Whether to optimize time for sign eval
-    bool m_timeOptimization;
+    bool m_timeOptimization = false;
 };
 
 }  // namespace lbcrypto


### PR DESCRIPTION
m_timeOptimization is not initialized on all paths, so risks uninitialized memory problems unless initialized by default.