### PR TITLE
DEBUG -> OPENFHE_DEBUG

### DIFF
--- a/src/core/examples/parallel.cpp
+++ b/src/core/examples/parallel.cpp
@@ -65,15 +65,15 @@ void verify(float* foo, uint32_t array_size) {
 }
 
 int main(int argc, char* argv[]) {
-    // note if you set dbg_flag = true then all  the following DEBUG() statments
+    // note if you set dbg_flag = true then all  the following OPENFHE_DEBUG() statments
     // print to stdout.
-    DEBUG_FLAG(true);
+    OPENFHE_DEBUG_FLAG(true);
 
     lbcrypto::OpenFHEParallelControls.Enable();
 
     uint32_t array_size = 1000;
-    DEBUGEXP(argc);
-    DEBUGEXP(argv[0]);
+    OPENFHE_DEBUGEXP(argc);
+    OPENFHE_DEBUGEXP(argv[0]);
 
     if (argc < 2) {
         std::cout << "running " << argv[0] << " with default array size of 1000" << std::endl;
@@ -121,18 +121,18 @@ int main(int argc, char* argv[]) {
     }
 
     // demonstrate debug functions (only active when dbg_flag = true)
-    std::cout << "demonstrating DEBUG()" << std::endl;
-    DEBUG("array_size = " << array_size);
-    DEBUGEXP(array_size);
-    DEBUGWHERE(array_size);
+    std::cout << "demonstrating OPENFHE_DEBUG()" << std::endl;
+    OPENFHE_DEBUG("array_size = " << array_size);
+    OPENFHE_DEBUGEXP(array_size);
+    OPENFHE_DEBUGWHERE(array_size);
 
 #if !defined(NDEBUG)
     dbg_flag = false;
 #endif
     // these three no longer report any value
-    DEBUG("array_size = " << array_size);
-    DEBUGEXP(array_size);
-    DEBUGWHERE(array_size);
+    OPENFHE_DEBUG("array_size = " << array_size);
+    OPENFHE_DEBUGEXP(array_size);
+    OPENFHE_DEBUGWHERE(array_size);
 
     std::cout << std::endl;
     // now run the parallel job

--- a/src/core/extras/ntt1.cpp
+++ b/src/core/extras/ntt1.cpp
@@ -70,7 +70,7 @@ int main(int argc, char* argv[]) {
                 res = (fn);                                                                         \
             }                                                                                       \
             time2 = TOC(t);                                                                         \
-            DEBUG(#t << ": " << nloop << " loops " << #res << " = " << #fn << " computation time: " \
+            OPENFHE_DEBUG(#t << ": " << nloop << " loops " << #res << " = " << #fn << " computation time: " \
                      << "\t" << time2 << " us");                                                    \
             if (res != testval) {                                                                   \
                 std::cout << "Bad " << #res << " = " << #fn << std::endl;                           \

--- a/src/core/include/lattice/elemparamfactory.h
+++ b/src/core/include/lattice/elemparamfactory.h
@@ -82,8 +82,8 @@ public:
    */
     template <typename P>
     static std::shared_ptr<P> GenElemParams(ElementOrder o) {
-        DEBUG_FLAG(false);
-        DEBUG("in GenElemParams(ElementOrder o)");
+        OPENFHE_DEBUG_FLAG(false);
+        OPENFHE_DEBUG("in GenElemParams(ElementOrder o)");
         return std::make_shared<P>(DefaultSet[static_cast<int>(o)].m,
                                    typename P::Integer(DefaultSet[static_cast<int>(o)].q),
                                    typename P::Integer(DefaultSet[static_cast<int>(o)].ru));
@@ -98,8 +98,8 @@ public:
    */
     template <typename P>
     static std::shared_ptr<P> GenElemParams(usint m) {
-        DEBUG_FLAG(false);
-        DEBUG("in GenElemParams(usint m)");
+        OPENFHE_DEBUG_FLAG(false);
+        OPENFHE_DEBUG("in GenElemParams(usint m)");
         size_t sIdx = GetNearestIndex(m);
 
         return std::make_shared<P>(DefaultSet[sIdx].m, typename P::Integer(DefaultSet[sIdx].q),
@@ -117,8 +117,8 @@ public:
    */
     template <typename P>
     static std::shared_ptr<P> GenElemParams(usint m, usint bits, usint towersize = 1) {
-        DEBUG_FLAG(false);
-        DEBUG("in GenElemParams(usint m, usint bits, usint towers)");
+        OPENFHE_DEBUG_FLAG(false);
+        OPENFHE_DEBUG("in GenElemParams(usint m, usint bits, usint towers)");
         typename P::Integer q  = FirstPrime<typename P::Integer>(bits, m);
         typename P::Integer ru = RootOfUnity<typename P::Integer>(m, q);
         return std::make_shared<P>(m, q, ru);
@@ -135,8 +135,8 @@ public:
     template <typename P>
     static std::shared_ptr<P> GenElemParams(usint m, const typename P::Integer& ctModulus,
                                             const typename P::Integer& rootUnity) {
-        DEBUG_FLAG(false);
-        DEBUG("in GenElemParams(usint m, const typename P::Integer etc)");
+        OPENFHE_DEBUG_FLAG(false);
+        OPENFHE_DEBUG("in GenElemParams(usint m, const typename P::Integer etc)");
         return std::make_shared<P>(m, ctModulus, rootUnity);
     }
 };
@@ -144,39 +144,39 @@ public:
 template <>
 inline std::shared_ptr<ILDCRTParams<M2Integer>> ElemParamFactory::GenElemParams<ILDCRTParams<M2Integer>>(
     usint m, usint bits, usint towersize) {
-    DEBUG_FLAG(false);
-    DEBUG(
+    OPENFHE_DEBUG_FLAG(false);
+    OPENFHE_DEBUG(
         "in GenElemParams<ILDCRTParams<M2Integer>>(usint m, usint bits, usint "
         "towersize)");
-    DEBUGEXP(m);
-    DEBUGEXP(bits);
-    DEBUGEXP(towersize);
+    OPENFHE_DEBUGEXP(m);
+    OPENFHE_DEBUGEXP(bits);
+    OPENFHE_DEBUGEXP(towersize);
     return GenerateDCRTParams<M2Integer>(m, towersize, bits);
 }
 
 template <>
 inline std::shared_ptr<ILDCRTParams<M4Integer>> ElemParamFactory::GenElemParams<ILDCRTParams<M4Integer>>(
     usint m, usint bits, usint towersize) {
-    DEBUG_FLAG(false);
-    DEBUG(
+    OPENFHE_DEBUG_FLAG(false);
+    OPENFHE_DEBUG(
         "in GenElemParams<ILDCRTParams<M4Integer>>(usint m, usint bits, usint "
         "towersize)");
-    DEBUGEXP(m);
-    DEBUGEXP(bits);
-    DEBUGEXP(towersize);
+    OPENFHE_DEBUGEXP(m);
+    OPENFHE_DEBUGEXP(bits);
+    OPENFHE_DEBUGEXP(towersize);
     return GenerateDCRTParams<M4Integer>(m, towersize, bits);
 }
 #ifdef WITH_NTL
 template <>
 inline std::shared_ptr<ILDCRTParams<M6Integer>> ElemParamFactory::GenElemParams<ILDCRTParams<M6Integer>>(
     usint m, usint bits, usint towersize) {
-    DEBUG_FLAG(false);
-    DEBUG(
+    OPENFHE_DEBUG_FLAG(false);
+    OPENFHE_DEBUG(
         "in GenElemParams<ILDCRTParams<M6Integer>>(usint m, usint bits, usint "
         "towersize)");
-    DEBUGEXP(m);
-    DEBUGEXP(bits);
-    DEBUGEXP(towersize);
+    OPENFHE_DEBUGEXP(m);
+    OPENFHE_DEBUGEXP(bits);
+    OPENFHE_DEBUGEXP(towersize);
     return GenerateDCRTParams<M6Integer>(m, towersize, bits);
 }
 #endif

--- a/src/core/include/lattice/ildcrtparams.h
+++ b/src/core/include/lattice/ildcrtparams.h
@@ -93,13 +93,13 @@ public:
         if (cyclotomic_order == 0)
             return;
 
-        DEBUG_FLAG(false);
-        DEBUG(
+        OPENFHE_DEBUG_FLAG(false);
+        OPENFHE_DEBUG(
             "in ILDCRTParams(const usint cyclotomic_order, const IntType &modulus, "
             "const IntType& rootOfUnity");
-        DEBUGEXP(cyclotomic_order);
-        DEBUGEXP(modulus);
-        DEBUGEXP(rootOfUnity);
+        OPENFHE_DEBUGEXP(cyclotomic_order);
+        OPENFHE_DEBUGEXP(modulus);
+        OPENFHE_DEBUGEXP(rootOfUnity);
         usint numOfTower = 1;
         std::vector<NativeInteger> moduli;
         std::vector<NativeInteger> rootsOfUnity;
@@ -118,16 +118,16 @@ public:
             numOfTower++;
         }
         originalModulus = modulus;
-        DEBUGEXP(compositeModulus);
-        DEBUGEXP(moduli);
-        DEBUGEXP(rootsOfUnity);
-        DEBUGEXP(m_parms.size());
+        OPENFHE_DEBUGEXP(compositeModulus);
+        OPENFHE_DEBUGEXP(moduli);
+        OPENFHE_DEBUGEXP(rootsOfUnity);
+        OPENFHE_DEBUGEXP(m_parms.size());
         for (size_t i = 0; i < moduli.size(); i++) {
             m_parms.push_back(std::make_shared<ILNativeParams>(cyclotomic_order, moduli[i], rootsOfUnity[i]));
         }
 
         RecalculateModulus();
-        DEBUGEXP(m_parms.size());
+        OPENFHE_DEBUGEXP(m_parms.size());
     }
 
     /**

--- a/src/core/include/lattice/trapdoor.h
+++ b/src/core/include/lattice/trapdoor.h
@@ -214,7 +214,7 @@ public:
     static void ZSampleSigmaP(size_t n, double s, double sigma, const RLWETrapdoorPair<Element>& Tprime,
                               const DggType& dgg, const DggType& dggLargeSigma,
                               std::shared_ptr<Matrix<Element>> perturbationVector) {
-        DEBUG_FLAG(false);
+        OPENFHE_DEBUG_FLAG(false);
         TimeVar t1, t1_tot;
 
         TIC(t1);
@@ -226,7 +226,7 @@ public:
         size_t k = Tprime0.GetCols();
 
         const std::shared_ptr<ParmType> params = Tprime0(0, 0).GetParams();
-        DEBUG("z1a: " << TOC(t1));  // 0
+        OPENFHE_DEBUG("z1a: " << TOC(t1));  // 0
         TIC(t1);
         // all three Polynomials are initialized with "0" coefficients
         Element va(params, Format::EVALUATION, 1);
@@ -238,7 +238,7 @@ public:
             vb += Tprime1(0, i) * Tprime0(0, i).Transpose();
             vd += Tprime1(0, i) * Tprime1(0, i).Transpose();
         }
-        DEBUG("z1b: " << TOC(t1));  // 9
+        OPENFHE_DEBUG("z1b: " << TOC(t1));  // 9
         TIC(t1);
 
         // Switch the ring elements (Polynomials) to coefficient representation
@@ -246,7 +246,7 @@ public:
         vb.SetFormat(Format::COEFFICIENT);
         vd.SetFormat(Format::COEFFICIENT);
 
-        DEBUG("z1c: " << TOC(t1));  // 5
+        OPENFHE_DEBUG("z1c: " << TOC(t1));  // 5
         TIC(t1);
 
         // Create field elements from ring elements
@@ -260,14 +260,14 @@ public:
 
         a = a + s * s;
         d = d + s * s;
-        DEBUG("z1d: " << TOC(t1));  // 0
+        OPENFHE_DEBUG("z1d: " << TOC(t1));  // 0
         TIC(t1);
 
         // converts the field elements to DFT representation
         a.SetFormat(Format::EVALUATION);
         b.SetFormat(Format::EVALUATION);
         d.SetFormat(Format::EVALUATION);
-        DEBUG("z1e: " << TOC(t1));  // 0
+        OPENFHE_DEBUG("z1e: " << TOC(t1));  // 0
         TIC(t1);
 
         Matrix<int64_t> p2ZVector([]() { return 0; }, n * k, 1);
@@ -290,18 +290,18 @@ public:
                 p2ZVector(i, 0) = (dggVector.get())[i];
             }
         }
-        DEBUG("z1f1: " << TOC(t1));
+        OPENFHE_DEBUG("z1f1: " << TOC(t1));
         TIC(t1);
 
         // create k ring elements in coefficient representation
         Matrix<Element> p2 = SplitInt64IntoElements<Element>(p2ZVector, n, va.GetParams());
-        DEBUG("z1f2: " << TOC(t1));
+        OPENFHE_DEBUG("z1f2: " << TOC(t1));
         TIC(t1);
 
         // now converting to Format::EVALUATION representation before multiplication
         p2.SetFormat(Format::EVALUATION);
 
-        DEBUG("z1g: " << TOC(t1));  // 17
+        OPENFHE_DEBUG("z1g: " << TOC(t1));  // 17
 
         TIC(t1);
 
@@ -311,11 +311,11 @@ public:
         Tp2(0, 0) = (Tprime0 * p2)(0, 0);
         Tp2(1, 0) = (Tprime1 * p2)(0, 0);
 
-        DEBUG("z1h2: " << TOC(t1));
+        OPENFHE_DEBUG("z1h2: " << TOC(t1));
         TIC(t1);
         // change to coefficient representation before converting to field elements
         Tp2.SetFormat(Format::COEFFICIENT);
-        DEBUG("z1h3: " << TOC(t1));
+        OPENFHE_DEBUG("z1h3: " << TOC(t1));
         TIC(t1);
 
         Matrix<Field2n> c([]() { return Field2n(); }, 2, 1);
@@ -324,25 +324,25 @@ public:
         c(1, 0) = Field2n(Tp2(1, 0)).ScalarMult(-sigma * sigma / (s * s - sigma * sigma));
 
         auto p1ZVector = std::make_shared<Matrix<int64_t>>([]() { return 0; }, n * 2, 1);
-        DEBUG("z1i: " << TOC(t1));
+        OPENFHE_DEBUG("z1i: " << TOC(t1));
         TIC(t1);
         LatticeGaussSampUtility<Element>::ZSampleSigma2x2(a, b, d, c, dgg, p1ZVector);
-        DEBUG("z1j1: " << TOC(t1));  // 14
+        OPENFHE_DEBUG("z1j1: " << TOC(t1));  // 14
         TIC(t1);
 
         // create 2 ring elements in coefficient representation
         Matrix<Element> p1 = SplitInt64IntoElements<Element>(*p1ZVector, n, va.GetParams());
-        DEBUG("z1j2: " << TOC(t1));
+        OPENFHE_DEBUG("z1j2: " << TOC(t1));
         TIC(t1);
 
         p1.SetFormat(Format::EVALUATION);
-        DEBUG("z1j3: " << TOC(t1));
+        OPENFHE_DEBUG("z1j3: " << TOC(t1));
         TIC(t1);
 
         *perturbationVector = p1.VStack(p2);
-        DEBUG("z1j4: " << TOC(t1));
+        OPENFHE_DEBUG("z1j4: " << TOC(t1));
         TIC(t1);
-        DEBUG("z1tot: " << TOC(t1_tot));
+        OPENFHE_DEBUG("z1tot: " << TOC(t1_tot));
     }
 
     /**

--- a/src/core/include/math/hal/bigintdyn/transformdyn-impl.h
+++ b/src/core/include/math/hal/bigintdyn/transformdyn-impl.h
@@ -988,10 +988,10 @@ void ChineseRemainderTransformArbDyn<VecType>::SetPreComputedNTTDivisionModulus(
                                                                                 const IntType& modulus,
                                                                                 const IntType& nttMod,
                                                                                 const IntType& nttRootBig) {
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
 
     usint n = lbcrypto::GetTotient(cyclotoOrder);
-    DEBUG("GetTotient(" << cyclotoOrder << ")= " << n);
+    OPENFHE_DEBUG("GetTotient(" << cyclotoOrder << ")= " << n);
 
     usint power                    = cyclotoOrder - n;
     m_nttDivisionDim[cyclotoOrder] = 2 * std::pow(2, ceil(log2(power)));

--- a/src/core/include/math/hal/bigintfxd/transformfxd-impl.h
+++ b/src/core/include/math/hal/bigintfxd/transformfxd-impl.h
@@ -986,10 +986,10 @@ void ChineseRemainderTransformArbFxd<VecType>::SetPreComputedNTTDivisionModulus(
                                                                                 const IntType& modulus,
                                                                                 const IntType& nttMod,
                                                                                 const IntType& nttRootBig) {
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
 
     usint n = lbcrypto::GetTotient(cyclotoOrder);
-    DEBUG("GetTotient(" << cyclotoOrder << ")= " << n);
+    OPENFHE_DEBUG("GetTotient(" << cyclotoOrder << ")= " << n);
 
     usint power                    = cyclotoOrder - n;
     m_nttDivisionDim[cyclotoOrder] = 2 * std::pow(2, ceil(log2(power)));

--- a/src/core/include/math/hal/bigintntl/transformntl-impl.h
+++ b/src/core/include/math/hal/bigintntl/transformntl-impl.h
@@ -981,10 +981,10 @@ void ChineseRemainderTransformArbNtl<VecType>::SetPreComputedNTTDivisionModulus(
                                                                                 const IntType& modulus,
                                                                                 const IntType& nttMod,
                                                                                 const IntType& nttRootBig) {
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
 
     usint n = lbcrypto::GetTotient(cyclotoOrder);
-    DEBUG("GetTotient(" << cyclotoOrder << ")= " << n);
+    OPENFHE_DEBUG("GetTotient(" << cyclotoOrder << ")= " << n);
 
     usint power                    = cyclotoOrder - n;
     m_nttDivisionDim[cyclotoOrder] = 2 * std::pow(2, ceil(log2(power)));

--- a/src/core/include/math/hal/intnat/transformnat-impl.h
+++ b/src/core/include/math/hal/intnat/transformnat-impl.h
@@ -972,10 +972,10 @@ void ChineseRemainderTransformArbNat<VecType>::SetPreComputedNTTDivisionModulus(
                                                                                 const IntType& modulus,
                                                                                 const IntType& nttMod,
                                                                                 const IntType& nttRootBig) {
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
 
     usint n = lbcrypto::GetTotient(cyclotoOrder);
-    DEBUG("GetTotient(" << cyclotoOrder << ")= " << n);
+    OPENFHE_DEBUG("GetTotient(" << cyclotoOrder << ")= " << n);
 
     usint power                    = cyclotoOrder - n;
     m_nttDivisionDim[cyclotoOrder] = 2 * std::pow(2, ceil(log2(power)));

--- a/src/core/include/utils/blockAllocator/blockAllocator.h
+++ b/src/core/include/utils/blockAllocator/blockAllocator.h
@@ -150,13 +150,13 @@ private:
 #define DECLARE_ALLOCATOR                           \
 public:                                             \
     void* operator new(size_t size) {               \
-        DEBUG_FLAG(false);                          \
-        DEBUG("allocating   " << size << " bytes"); \
+        OPENFHE_DEBUG_FLAG(false);                          \
+        OPENFHE_DEBUG("allocating   " << size << " bytes"); \
         return _allocator.Allocate(size);           \
     }                                               \
     void operator delete(void* pObject) {           \
-        DEBUG_FLAG(false);                          \
-        DEBUG("deallocating  ");                    \
+        OPENFHE_DEBUG_FLAG(false);                          \
+        OPENFHE_DEBUG("deallocating  ");                    \
         _allocator.Deallocate(pObject);             \
     }                                               \
                                                     \

--- a/src/core/include/utils/debug.h
+++ b/src/core/include/utils/debug.h
@@ -43,7 +43,7 @@
 /* defining NDEBUG in the compile line turns everything off.
    unless PROFILE is defined in the file before all includes,'
    in which case TIC/TOC will still work and PROFILELOG() can be
-   used for logging results to std::cout, and DEBUG() will remain
+   used for logging results to std::cout, and OPENFHE_DEBUG() will remain
    silent. dbg_flag does not get used by PROFILELOG()
  */
 
@@ -56,11 +56,11 @@
 #if !defined(NDEBUG)
 
     // note that for the following dbg_flag needs to be defined in some scope using
-    // DEBUG_FLAG
-    #define DEBUG_FLAG(x) bool dbg_flag = x;
+    // OPENFHE_DEBUG_FLAG
+    #define OPENFHE_DEBUG_FLAG(x) bool dbg_flag = x;
 
     // debugging macro prints value of x on cerr
-    #define DEBUG(x)                         \
+    #define OPENFHE_DEBUG(x)                         \
         do {                                 \
             if (dbg_flag) {                  \
                 std::cerr << x << std::endl; \
@@ -68,7 +68,7 @@
         } while (0)
 
     // debugging macro prints typography of x and value of x on cerr
-    #define DEBUGEXP(x)                                   \
+    #define OPENFHE_DEBUGEXP(x)                                   \
         do {                                              \
             if (dbg_flag) {                               \
                 std::cerr << #x << ":" << x << std::endl; \
@@ -76,7 +76,7 @@
         } while (0)
 
     // debugging macro prints value of x and location in codex on cerr
-    #define DEBUGWHERE(x)                                                                        \
+    #define OPENFHE_DEBUGWHERE(x)                                                                        \
         do {                                                                                     \
             if (dbg_flag) {                                                                      \
                 std::cerr << __FILE__ << ":" << __LINE__ << ": " << #x << ":" << x << std::endl; \
@@ -84,7 +84,7 @@
         } while (0)
 
     // debugging macro prints location in codex on cerr
-    #define DEBUGHERE()                                                        \
+    #define OPENFHE_DEBUGHERE()                                                        \
         do {                                                                   \
             if (dbg_flag) {                                                    \
                 std::cerr << __FILE__ << ":" << __LINE__ << ": " << std::endl; \
@@ -138,11 +138,11 @@
 
         // these are turned off functions
 
-        #define DEBUG_FLAG(x)
-        #define DEBUG(x)
-        #define DEBUGEXP(x)
-        #define DEBUGWHERE(x)
-        #define DEBUGHERE()
+        #define OPENFHE_DEBUG_FLAG(x)
+        #define OPENFHE_DEBUG(x)
+        #define OPENFHE_DEBUGEXP(x)
+        #define OPENFHE_DEBUGWHERE(x)
+        #define OPENFHE_DEBUGHERE()
 
         #define PROFILELOG(x)
         #define PROFILELOGEXP(x)
@@ -157,11 +157,11 @@
     #else  // PROFILE
         // if PROFILE is turned on, then TIC TOC still work and
 
-        #define DEBUG_FLAG(x)
-        #define DEBUG(x)
-        #define DEBUGEXP(x)
-        #define DEBUGWHERE(x)
-        #define DEBUGHERE()
+        #define OPENFHE_DEBUG_FLAG(x)
+        #define OPENFHE_DEBUG(x)
+        #define OPENFHE_DEBUGEXP(x)
+        #define OPENFHE_DEBUGWHERE(x)
+        #define OPENFHE_DEBUGHERE()
 
         #define PROFILELOG(x)                    \
             do {                                 \

--- a/src/core/include/utils/parmfactory.h
+++ b/src/core/include/utils/parmfactory.h
@@ -60,11 +60,11 @@ using namespace lbcrypto;
  */
 template <typename I>
 inline std::shared_ptr<ILDCRTParams<I>> GenerateDCRTParams(usint m, usint numOfTower, usint pbits) {
-    DEBUG_FLAG(false);
-    DEBUG("in GenerateDCRTParams");
-    DEBUGEXP(m);
-    DEBUGEXP(numOfTower);
-    DEBUGEXP(pbits);
+    OPENFHE_DEBUG_FLAG(false);
+    OPENFHE_DEBUG("in GenerateDCRTParams");
+    OPENFHE_DEBUGEXP(m);
+    OPENFHE_DEBUGEXP(numOfTower);
+    OPENFHE_DEBUGEXP(pbits);
     if (numOfTower == 0) {
         OPENFHE_THROW(math_error, "Can't make parms with numOfTower == 0");
     }
@@ -76,13 +76,13 @@ inline std::shared_ptr<ILDCRTParams<I>> GenerateDCRTParams(usint m, usint numOfT
     I modulus(1);
 
     usint j = 0;
-    DEBUGEXP(q);
+    OPENFHE_DEBUGEXP(q);
 
     for (;;) {
         moduli[j]       = q;
         rootsOfUnity[j] = RootOfUnity(m, q);
         modulus         = modulus * I(q.ConvertToInt());
-        DEBUG("j " << j << " modulus " << q << " rou " << rootsOfUnity[j]);
+        OPENFHE_DEBUG("j " << j << " modulus " << q << " rou " << rootsOfUnity[j]);
         if (++j == numOfTower)
             break;
 

--- a/src/core/lib/lattice/hal/default/dcrtpoly.cpp
+++ b/src/core/lib/lattice/hal/default/dcrtpoly.cpp
@@ -401,21 +401,21 @@ const std::vector<typename DCRTPolyImpl<VecType>::PolyType>& DCRTPolyImpl<VecTyp
 
 template <typename VecType>
 std::vector<DCRTPolyImpl<VecType>> DCRTPolyImpl<VecType>::BaseDecompose(usint baseBits, bool evalModeAnswer) const {
-    DEBUG_FLAG(false);
-    DEBUG("...::BaseDecompose");
-    DEBUG("baseBits=" << baseBits);
+    OPENFHE_DEBUG_FLAG(false);
+    OPENFHE_DEBUG("...::BaseDecompose");
+    OPENFHE_DEBUG("baseBits=" << baseBits);
 
     PolyLargeType v(CRTInterpolate());
 
-    DEBUG("<v>" << std::endl << v << "</v>");
+    OPENFHE_DEBUG("<v>" << std::endl << v << "</v>");
 
     std::vector<PolyLargeType> bdV = v.BaseDecompose(baseBits, false);
 
 #if !defined(NDEBUG)
-    DEBUG("<bdV>");
+    OPENFHE_DEBUG("<bdV>");
     for (auto i : bdV)
-        DEBUG(i);
-    DEBUG("</bdV>");
+        OPENFHE_DEBUG(i);
+    OPENFHE_DEBUG("</bdV>");
 #endif
 
     std::vector<DCRTPolyImpl<VecType>> result;
@@ -431,10 +431,10 @@ std::vector<DCRTPolyImpl<VecType>> DCRTPolyImpl<VecType>::BaseDecompose(usint ba
     }
 
 #if !defined(NDEBUG)
-    DEBUG("<BaseDecompose.result>");
+    OPENFHE_DEBUG("<BaseDecompose.result>");
     for (auto i : result)
-        DEBUG(i);
-    DEBUG("</BaseDecompose.result>");
+        OPENFHE_DEBUG(i);
+    OPENFHE_DEBUG("</BaseDecompose.result>");
 #endif
 
     return result;
@@ -521,7 +521,7 @@ PolyImpl<NativeVector>& DCRTPolyImpl<VecType>::ElementAtIndex(usint i) {
 
 template <typename VecType>
 std::vector<DCRTPolyImpl<VecType>> DCRTPolyImpl<VecType>::PowersOfBase(usint baseBits) const {
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
 
     std::vector<DCRTPolyImpl<VecType>> result;
 
@@ -538,7 +538,7 @@ std::vector<DCRTPolyImpl<VecType>> DCRTPolyImpl<VecType>::PowersOfBase(usint bas
     std::vector<Integer> mods(this->m_params->GetParams().size());
     for (usint i = 0; i < this->m_params->GetParams().size(); i++) {
         mods[i] = Integer(this->m_params->GetParams()[i]->GetModulus().ConvertToInt());
-        DEBUG("DCRTPolyImpl::PowersOfBase.mods[" << i << "] = " << mods[i]);
+        OPENFHE_DEBUG("DCRTPolyImpl::PowersOfBase.mods[" << i << "] = " << mods[i]);
     }
 
     for (usint i = 0; i < nWindows; i++) {
@@ -546,17 +546,17 @@ std::vector<DCRTPolyImpl<VecType>> DCRTPolyImpl<VecType>::PowersOfBase(usint bas
 
         // Shouldn't this be Integer twoPow ( Integer::ONE << (i*baseBits)  ??
         Integer twoPow(Integer(2).Exp(i * baseBits));
-        DEBUG("DCRTPolyImpl::PowersOfBase.twoPow (" << i << ") = " << twoPow);
+        OPENFHE_DEBUG("DCRTPolyImpl::PowersOfBase.twoPow (" << i << ") = " << twoPow);
         for (usint t = 0; t < this->m_params->GetParams().size(); t++) {
-            DEBUG("@(" << i << ", " << t << ")");
-            DEBUG("twoPow= " << twoPow << ", mods[" << t << "]" << mods[t]);
+            OPENFHE_DEBUG("@(" << i << ", " << t << ")");
+            OPENFHE_DEBUG("twoPow= " << twoPow << ", mods[" << t << "]" << mods[t]);
             Integer pI(twoPow % mods[t]);
-            DEBUG("twoPow= " << twoPow << ", mods[" << t << "]" << mods[t]
+            OPENFHE_DEBUG("twoPow= " << twoPow << ", mods[" << t << "]" << mods[t]
                              << ";   pI.ConvertToInt=" << NativeInteger(pI.ConvertToInt()) << ";   pI=" << pI);
-            DEBUG("m_vectors= " << m_vectors[t]);
+            OPENFHE_DEBUG("m_vectors= " << m_vectors[t]);
 
             x.m_vectors[t] = m_vectors[t] * pI.ConvertToInt();
-            DEBUG("DCRTPolyImpl::PowersOfBase.x.m_vectors[" << t << ", " << i << "]" << x.m_vectors[t]);
+            OPENFHE_DEBUG("DCRTPolyImpl::PowersOfBase.x.m_vectors[" << t << ", " << i << "]" << x.m_vectors[t]);
         }
         result.push_back(std::move(x));
     }
@@ -685,27 +685,27 @@ const DCRTPolyImpl<VecType>& DCRTPolyImpl<VecType>::operator=(DCRTPolyImpl&& rhs
 
 template <typename VecType>
 DCRTPolyImpl<VecType>& DCRTPolyImpl<VecType>::operator=(std::initializer_list<uint64_t> rhs) {
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
     usint len = rhs.size();
     static PolyType::Integer ZERO(0);
     if (!IsEmpty()) {
         usint vectorLength = this->m_vectors[0].GetLength();
-        DEBUGEXP(vectorLength);
+        OPENFHE_DEBUGEXP(vectorLength);
         for (usint i = 0; i < m_vectors.size(); ++i) {  // this loops over each tower
             for (usint j = 0; j < vectorLength; ++j) {  // loops within a tower
                 if (j < len) {
                     this->m_vectors[i][j] = PolyType::Integer(*(rhs.begin() + j));
-                    DEBUGEXP(this->m_vectors[i][j]);
+                    OPENFHE_DEBUGEXP(this->m_vectors[i][j]);
                 }
                 else {
                     this->m_vectors[i][j] = ZERO;
-                    DEBUGEXP(ZERO);
+                    OPENFHE_DEBUGEXP(ZERO);
                 }
             }
         }
     }
     else {
-        DEBUGEXP(m_vectors.size());
+        OPENFHE_DEBUGEXP(m_vectors.size());
         for (size_t i = 0; i < m_vectors.size(); i++) {
             NativeVector temp(this->GetRingDimension());
             temp.SetModulus(m_vectors[i].GetModulus());
@@ -1149,19 +1149,19 @@ const typename DCRTPolyImpl<VecType>::Integer& DCRTPolyImpl<VecType>::operator[]
  */
 template <typename VecType>
 typename DCRTPolyImpl<VecType>::PolyLargeType DCRTPolyImpl<VecType>::CRTInterpolate() const {
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
 
     usint ringDimension = this->GetRingDimension();
     usint nTowers       = m_vectors.size();
 
-    DEBUG("in Interpolate ring " << ringDimension << " towers " << nTowers);
+    OPENFHE_DEBUG("in Interpolate ring " << ringDimension << " towers " << nTowers);
 
     for (usint vi = 0; vi < nTowers; vi++)
-        DEBUG("tower " << vi << " is " << m_vectors[vi]);
+        OPENFHE_DEBUG("tower " << vi << " is " << m_vectors[vi]);
 
     Integer bigModulus(this->GetModulus());  // qT
 
-    DEBUG("bigModulus " << bigModulus);
+    OPENFHE_DEBUG("bigModulus " << bigModulus);
 
     // this is the resulting vector of coefficients
     VecType coefficients(ringDimension, bigModulus);
@@ -1177,7 +1177,7 @@ typename DCRTPolyImpl<VecType>::PolyLargeType DCRTPolyImpl<VecType>::CRTInterpol
         Integer modInv = divBy.ModInverse(qj).Mod(qj);
         multiplier[vi] = divBy * modInv;
 
-        DEBUG("multiplier " << vi << " " << qj << " " << multiplier[vi]);
+        OPENFHE_DEBUG("multiplier " << vi << " " << qj << " " << multiplier[vi]);
     }
 
     // if the vectors are not in COEFFICIENT form, they need to be, so we will
@@ -1195,7 +1195,7 @@ typename DCRTPolyImpl<VecType>::PolyLargeType DCRTPolyImpl<VecType>::CRTInterpol
     }
 
     for (usint vi = 0; vi < nTowers; vi++)
-        DEBUG("tower " << vi << " is " << (*vecs)[vi]);
+        OPENFHE_DEBUG("tower " << vi << " is " << (*vecs)[vi]);
 
     // Precompute the Barrett mu parameter
     Integer mu = bigModulus.ComputeMu();
@@ -1207,18 +1207,18 @@ typename DCRTPolyImpl<VecType>::PolyLargeType DCRTPolyImpl<VecType>::CRTInterpol
         for (usint vi = 0; vi < nTowers; vi++) {
             coefficients[ri] += (Integer((*vecs)[vi].GetValues()[ri].ConvertToInt()) * multiplier[vi]);
         }
-        DEBUG((*vecs)[0].GetValues()[ri] << " * " << multiplier[0] << " == " << coefficients[ri]);
+        OPENFHE_DEBUG((*vecs)[0].GetValues()[ri] << " * " << multiplier[0] << " == " << coefficients[ri]);
         coefficients[ri].ModEq(bigModulus, mu);
     }
 
-    DEBUG("passed loops");
-    DEBUG(coefficients);
+    OPENFHE_DEBUG("passed loops");
+    OPENFHE_DEBUG(coefficients);
 
     // Create an Poly for this BigVector
 
-    DEBUG("elementing after vectoring");
-    DEBUG("m_cyclotomicOrder " << this->GetCyclotomicOrder());
-    DEBUG("modulus " << bigModulus);
+    OPENFHE_DEBUG("elementing after vectoring");
+    OPENFHE_DEBUG("m_cyclotomicOrder " << this->GetCyclotomicOrder());
+    OPENFHE_DEBUG("modulus " << bigModulus);
 
     // Setting the root of unity to ONE as the calculation is expensive and not
     // required.
@@ -1226,7 +1226,7 @@ typename DCRTPolyImpl<VecType>::PolyLargeType DCRTPolyImpl<VecType>::CRTInterpol
         std::make_shared<ILParamsImpl<Integer>>(this->GetCyclotomicOrder(), bigModulus, 1));
     polynomialReconstructed.SetValues(std::move(coefficients), COEFFICIENT);
 
-    DEBUG("answer: " << polynomialReconstructed);
+    OPENFHE_DEBUG("answer: " << polynomialReconstructed);
 
     return polynomialReconstructed;
 }
@@ -1249,19 +1249,19 @@ typename DCRTPolyImpl<VecType>::PolyLargeType DCRTPolyImpl<VecType>::CRTInterpol
  */
 template <typename VecType>
 typename DCRTPolyImpl<VecType>::PolyLargeType DCRTPolyImpl<VecType>::CRTInterpolateIndex(usint i) const {
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
 
     usint ringDimension = this->GetRingDimension();
     usint nTowers       = m_vectors.size();
 
-    DEBUG("in Interpolate ring " << ringDimension << " towers " << nTowers);
+    OPENFHE_DEBUG("in Interpolate ring " << ringDimension << " towers " << nTowers);
 
     for (usint vi = 0; vi < nTowers; vi++)
-        DEBUG("tower " << vi << " is " << m_vectors[vi]);
+        OPENFHE_DEBUG("tower " << vi << " is " << m_vectors[vi]);
 
     Integer bigModulus(this->GetModulus());  // qT
 
-    DEBUG("bigModulus " << bigModulus);
+    OPENFHE_DEBUG("bigModulus " << bigModulus);
 
     // this is the resulting vector of coefficients
     VecType coefficients(ringDimension, bigModulus);
@@ -1277,7 +1277,7 @@ typename DCRTPolyImpl<VecType>::PolyLargeType DCRTPolyImpl<VecType>::CRTInterpol
         Integer modInv = divBy.ModInverse(qj).Mod(qj);
         multiplier[vi] = divBy * modInv;
 
-        DEBUG("multiplier " << vi << " " << qj << " " << multiplier[vi]);
+        OPENFHE_DEBUG("multiplier " << vi << " " << qj << " " << multiplier[vi]);
     }
 
     // if the vectors are not in COEFFICIENT form, they need to be, so we will
@@ -1295,7 +1295,7 @@ typename DCRTPolyImpl<VecType>::PolyLargeType DCRTPolyImpl<VecType>::CRTInterpol
     }
 
     for (usint vi = 0; vi < nTowers; vi++)
-        DEBUG("tower " << vi << " is " << (*vecs)[vi]);
+        OPENFHE_DEBUG("tower " << vi << " is " << (*vecs)[vi]);
 
     // Precompute the Barrett mu parameter
     Integer mu = bigModulus.ComputeMu();
@@ -1308,19 +1308,19 @@ typename DCRTPolyImpl<VecType>::PolyLargeType DCRTPolyImpl<VecType>::CRTInterpol
             for (usint vi = 0; vi < nTowers; vi++) {
                 coefficients[ri] += (Integer((*vecs)[vi].GetValues()[ri].ConvertToInt()) * multiplier[vi]);
             }
-            DEBUG((*vecs)[0].GetValues()[ri] << " * " << multiplier[0] << " == " << coefficients[ri]);
+            OPENFHE_DEBUG((*vecs)[0].GetValues()[ri] << " * " << multiplier[0] << " == " << coefficients[ri]);
             coefficients[ri].ModEq(bigModulus, mu);
         }
     }
 
-    DEBUG("passed loops");
-    DEBUG(coefficients);
+    OPENFHE_DEBUG("passed loops");
+    OPENFHE_DEBUG(coefficients);
 
     // Create an Poly for this BigVector
 
-    DEBUG("elementing after vectoring");
-    DEBUG("m_cyclotomicOrder " << this->GetCyclotomicOrder());
-    DEBUG("modulus " << bigModulus);
+    OPENFHE_DEBUG("elementing after vectoring");
+    OPENFHE_DEBUG("m_cyclotomicOrder " << this->GetCyclotomicOrder());
+    OPENFHE_DEBUG("modulus " << bigModulus);
 
     // Setting the root of unity to ONE as the calculation is expensive and not
     // required.
@@ -1328,7 +1328,7 @@ typename DCRTPolyImpl<VecType>::PolyLargeType DCRTPolyImpl<VecType>::CRTInterpol
         std::make_shared<ILParamsImpl<Integer>>(this->GetCyclotomicOrder(), bigModulus, 1));
     polynomialReconstructed.SetValues(std::move(coefficients), COEFFICIENT);
 
-    DEBUG("answer: " << polynomialReconstructed);
+    OPENFHE_DEBUG("answer: " << polynomialReconstructed);
 
     return polynomialReconstructed;
 }

--- a/src/core/lib/lattice/poly.cpp
+++ b/src/core/lib/lattice/poly.cpp
@@ -138,20 +138,20 @@ PolyImpl<VecType>::PolyImpl(const TernaryUniformGeneratorImpl<VecType>& tug,
 template <typename VecType>
 PolyImpl<VecType>::PolyImpl(const PolyImpl& element, std::shared_ptr<PolyImpl::Params>)
     : m_format(element.m_format), m_params(element.m_params) {
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
     if (!IsEmpty()) {
-        DEBUG("in ctor & m_values was " << *m_values);
+        OPENFHE_DEBUG("in ctor & m_values was " << *m_values);
     }
     else {
-        DEBUG("in ctor & m_values are empty ");
+        OPENFHE_DEBUG("in ctor & m_values are empty ");
     }
     if (element.m_values == nullptr) {
-        DEBUG("in ctor & m_values copy nullptr ");
+        OPENFHE_DEBUG("in ctor & m_values copy nullptr ");
         m_values = nullptr;
     }
     else {
         m_values = make_unique<VecType>(*element.m_values);  // this is a copy
-        DEBUG("in ctor & m_values now " << *m_values);
+        OPENFHE_DEBUG("in ctor & m_values now " << *m_values);
     }
 }
 
@@ -180,19 +180,19 @@ PolyImpl<VecType>::PolyImpl(PolyImpl&& element, std::shared_ptr<PolyImpl::Params
     : m_format(element.m_format), m_params(element.m_params) {
     // m_values(element.m_values) //note this becomes move below
 
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
     if (!IsEmpty()) {
-        DEBUG("in ctor && m_values was " << *m_values);
+        OPENFHE_DEBUG("in ctor && m_values was " << *m_values);
     }
     else {
-        DEBUG("in ctor && m_values was empty");
+        OPENFHE_DEBUG("in ctor && m_values was empty");
     }
     if (!element.IsEmpty()) {
         m_values = std::move(element.m_values);
-        DEBUG("in ctor && m_values was " << *m_values);
+        OPENFHE_DEBUG("in ctor && m_values was " << *m_values);
     }
     else {
-        DEBUG("in ctor && m_values remains empty");
+        OPENFHE_DEBUG("in ctor && m_values remains empty");
         m_values = nullptr;
     }
 }
@@ -601,10 +601,10 @@ PolyImpl<VecType> PolyImpl<VecType>::Times(const PolyImpl& element) const {
 
 template <typename VecType>
 const PolyImpl<VecType>& PolyImpl<VecType>::operator+=(const PolyImpl& element) {
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
     if (!(*this->m_params == *element.m_params)) {
-        DEBUGEXP(*this->m_params);
-        DEBUGEXP(*element.m_params);
+        OPENFHE_DEBUGEXP(*this->m_params);
+        OPENFHE_DEBUGEXP(*element.m_params);
         OPENFHE_THROW(type_error, "operator+= called on PolyImpl's with different params.");
     }
 
@@ -807,7 +807,7 @@ void PolyImpl<VecType>::SwitchModulus(const Integer& modulus, const Integer& roo
 
 template <typename VecType>
 void PolyImpl<VecType>::SwitchFormat() {
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
     if (m_values == nullptr) {
         std::string errMsg = "Poly switch format to empty values";
         OPENFHE_THROW(not_available_error, errMsg);
@@ -821,25 +821,25 @@ void PolyImpl<VecType>::SwitchFormat() {
     if (m_format == Format::COEFFICIENT) {
         m_format = Format::EVALUATION;
 
-        DEBUG("transform to Format::EVALUATION m_values was" << *m_values);
+        OPENFHE_DEBUG("transform to Format::EVALUATION m_values was" << *m_values);
 
         ChineseRemainderTransformFTT<VecType>().ForwardTransformToBitReverseInPlace(
             m_params->GetRootOfUnity(), m_params->GetCyclotomicOrder(), &(*m_values));
-        DEBUG("m_values now in Format::COEFFICIENT " << *m_values);
+        OPENFHE_DEBUG("m_values now in Format::COEFFICIENT " << *m_values);
     }
     else {
         m_format = Format::COEFFICIENT;
-        DEBUG("transform to Format::COEFFICIENT m_values was" << *m_values);
+        OPENFHE_DEBUG("transform to Format::COEFFICIENT m_values was" << *m_values);
 
         ChineseRemainderTransformFTT<VecType>().InverseTransformFromBitReverseInPlace(
             m_params->GetRootOfUnity(), m_params->GetCyclotomicOrder(), &(*m_values));
-        DEBUG("m_values now in Format::EVALUATION " << *m_values);
+        OPENFHE_DEBUG("m_values now in Format::EVALUATION " << *m_values);
     }
 }
 
 template <typename VecType>
 void PolyImpl<VecType>::ArbitrarySwitchFormat() {
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
 
     if (m_values == nullptr) {
         std::string errMsg = "Poly switch format to empty values";
@@ -849,21 +849,21 @@ void PolyImpl<VecType>::ArbitrarySwitchFormat() {
     if (m_format == Format::COEFFICIENT) {
         m_format = Format::EVALUATION;
         // todo:: does this have an extra copy?
-        DEBUG("transform to Format::EVALUATION m_values was" << *m_values);
+        OPENFHE_DEBUG("transform to Format::EVALUATION m_values was" << *m_values);
 
         m_values = make_unique<VecType>(ChineseRemainderTransformArb<VecType>().ForwardTransform(
             *m_values, m_params->GetRootOfUnity(), m_params->GetBigModulus(), m_params->GetBigRootOfUnity(),
             m_params->GetCyclotomicOrder()));
-        DEBUG("m_values now " << *m_values);
+        OPENFHE_DEBUG("m_values now " << *m_values);
     }
     else {
         m_format = Format::COEFFICIENT;
-        DEBUG("transform to Format::COEFFICIENT m_values was" << *m_values);
+        OPENFHE_DEBUG("transform to Format::COEFFICIENT m_values was" << *m_values);
 
         m_values = make_unique<VecType>(ChineseRemainderTransformArb<VecType>().InverseTransform(
             *m_values, m_params->GetRootOfUnity(), m_params->GetBigModulus(), m_params->GetBigRootOfUnity(),
             m_params->GetCyclotomicOrder()));
-        DEBUG("m_values now " << *m_values);
+        OPENFHE_DEBUG("m_values now " << *m_values);
     }
 }
 template <typename VecType>
@@ -940,9 +940,9 @@ double PolyImpl<VecType>::Norm() const {
 
 template <typename VecType>
 std::vector<PolyImpl<VecType>> PolyImpl<VecType>::BaseDecompose(usint baseBits, bool evalModeAnswer) const {
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
 
-    DEBUG("PolyImpl::BaseDecompose");
+    OPENFHE_DEBUG("PolyImpl::BaseDecompose");
     usint nBits = m_params->GetModulus().GetLengthForBase(2);
 
     usint nWindows = nBits / baseBits;
@@ -958,38 +958,38 @@ std::vector<PolyImpl<VecType>> PolyImpl<VecType>::BaseDecompose(usint baseBits, 
     PolyImpl<VecType> x(*this);
     x.SetFormat(Format::COEFFICIENT);
 
-    DEBUG("<x>");
+    OPENFHE_DEBUG("<x>");
     // for( auto i : x ){
-    DEBUG(x);
+    OPENFHE_DEBUG(x);
     //}
-    DEBUG("</x>");
+    OPENFHE_DEBUG("</x>");
 
     // TP: x is same for BACKEND 2 and 6
 
     for (usint i = 0; i < nWindows; ++i) {
-        DEBUG("VecType is '" << type_name<VecType>() << "'");
+        OPENFHE_DEBUG("VecType is '" << type_name<VecType>() << "'");
 
         xDigit.SetValues(x.GetValues().GetDigitAtIndexForBase(i + 1, 1 << baseBits), x.GetFormat());
-        DEBUG("x.GetValue().GetDigitAtIndexForBase(i="
+        OPENFHE_DEBUG("x.GetValue().GetDigitAtIndexForBase(i="
               << i << ")" << std::endl
               << x.GetValues().GetDigitAtIndexForBase(i * baseBits + 1, 1 << baseBits));
-        DEBUG("x.GetFormat()" << x.GetFormat());
+        OPENFHE_DEBUG("x.GetFormat()" << x.GetFormat());
         // TP: xDigit is all zeros for BACKEND=6, but not for BACKEND-2
         // *********************************************************
-        DEBUG("<xDigit." << i << ">" << std::endl << xDigit << "</xDigit." << i << ">");
+        OPENFHE_DEBUG("<xDigit." << i << ">" << std::endl << xDigit << "</xDigit." << i << ">");
         if (evalModeAnswer)
             xDigit.SwitchFormat();
         result.push_back(xDigit);
-        DEBUG("<xDigit.SwitchFormat." << i << ">" << std::endl << xDigit << "</xDigit.SwitchFormat." << i << ">");
+        OPENFHE_DEBUG("<xDigit.SwitchFormat." << i << ">" << std::endl << xDigit << "</xDigit.SwitchFormat." << i << ">");
     }
 
 #if !defined(NDEBUG)
-    DEBUG("<result>");
+    OPENFHE_DEBUG("<result>");
     for (auto i : result) {
-        DEBUG(i);
+        OPENFHE_DEBUG(i);
     }
 #endif
-    DEBUG("</result>");
+    OPENFHE_DEBUG("</result>");
 
     return result;
 }

--- a/src/core/lib/lattice/trapdoor-dcrtpoly-impl.cpp
+++ b/src/core/lib/lattice/trapdoor-dcrtpoly-impl.cpp
@@ -144,7 +144,7 @@ template <>
 Matrix<DCRTPoly> RLWETrapdoorUtility<DCRTPoly>::GaussSamp(size_t n, size_t k, const Matrix<DCRTPoly>& A,
                                                           const RLWETrapdoorPair<DCRTPoly>& T, const DCRTPoly& u,
                                                           DggType& dgg, DggType& dggLargeSigma, int64_t base) {
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
     TimeVar t1, t1_tot, t2, t2_tot;
     TIC(t1);
     TIC(t1_tot);
@@ -156,28 +156,28 @@ Matrix<DCRTPoly> RLWETrapdoorUtility<DCRTPoly>::GaussSamp(size_t n, size_t k, co
     // spectral bound s
     double s = SPECTRAL_BOUND(n, k, base);
 
-    DEBUG("c " << c << " s " << s);
+    OPENFHE_DEBUG("c " << c << " s " << s);
 
     // perturbation vector in evaluation representation
     auto pHat = std::make_shared<Matrix<DCRTPoly>>(zero_alloc, k + 2, 1);
-    DEBUG("t1a: " << TOC(t1));
+    OPENFHE_DEBUG("t1a: " << TOC(t1));
     TIC(t1);
     ZSampleSigmaP(n, s, c, T, dgg, dggLargeSigma, pHat);
-    DEBUG("t1b: " << TOC(t1));  // this takes the most time 61
+    OPENFHE_DEBUG("t1b: " << TOC(t1));  // this takes the most time 61
     TIC(t1);
     // It is assumed that A has dimension 1 x (k + 2) and pHat has the dimension
     // of (k + 2) x 1 perturbedSyndrome is in the evaluation representation
     DCRTPoly perturbedSyndrome = u - (A.Mult(*pHat))(0, 0);
 
-    DEBUG("t1c: " << TOC(t1));  // takes 2
+    OPENFHE_DEBUG("t1c: " << TOC(t1));  // takes 2
     TIC(t1);
-    DEBUG("t1d: " << TOC(t1));  // takes 0
+    OPENFHE_DEBUG("t1d: " << TOC(t1));  // takes 0
     Matrix<int64_t> zHatBBI([]() { return 0; }, k, n);
-    DEBUG("t1: " << TOC(t1_tot));  // takes 64
+    OPENFHE_DEBUG("t1: " << TOC(t1_tot));  // takes 64
     TIC(t2);
     TIC(t2_tot);
     perturbedSyndrome.SetFormat(Format::COEFFICIENT);
-    DEBUG("t2a: " << TOC(t2));  // takes 1
+    OPENFHE_DEBUG("t2a: " << TOC(t2));  // takes 1
     TIC(t2);
 
     size_t size = perturbedSyndrome.GetNumOfElements();
@@ -197,17 +197,17 @@ Matrix<DCRTPoly> RLWETrapdoorUtility<DCRTPoly>::GaussSamp(size_t n, size_t k, co
         }
     }
 
-    DEBUG("t2b: " << TOC(t2));  // takes 36
+    OPENFHE_DEBUG("t2b: " << TOC(t2));  // takes 36
     TIC(t2);
     // Convert zHat from a matrix of BBI to a vector of Element ring elements
     // zHat is in the coefficient representation
     Matrix<DCRTPoly> zHat = SplitInt64AltIntoElements<DCRTPoly>(zHatBBI, n, params);
 
-    DEBUG("t2c: " << TOC(t2));  // takes 0
+    OPENFHE_DEBUG("t2c: " << TOC(t2));  // takes 0
     // Now converting it to the evaluation representation before multiplication
     zHat.SetFormat(Format::EVALUATION);
-    DEBUG("t2d: " << TOC(t2));  // takes 17
-    DEBUG("t2: " << TOC(t2_tot));
+    OPENFHE_DEBUG("t2d: " << TOC(t2));  // takes 17
+    OPENFHE_DEBUG("t2: " << TOC(t2_tot));
 
     Matrix<DCRTPoly> zHatPrime(zero_alloc, k + 2, 1);
 

--- a/src/core/lib/lattice/trapdoor-poly-impl.cpp
+++ b/src/core/lib/lattice/trapdoor-poly-impl.cpp
@@ -233,7 +233,7 @@ Matrix<Poly> RLWETrapdoorUtility<Poly>::GaussSamp(size_t n, size_t k, const Matr
                                                   const RLWETrapdoorPair<Poly>& T, const Poly& u,
                                                   typename Poly::DggType& dgg, typename Poly::DggType& dggLargeSigma,
                                                   int64_t base) {
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
     TimeVar t1, t1_tot, t2, t2_tot;
     TIC(t1);
     TIC(t1_tot);
@@ -247,41 +247,41 @@ Matrix<Poly> RLWETrapdoorUtility<Poly>::GaussSamp(size_t n, size_t k, const Matr
     // spectral bound s
     double s = SPECTRAL_BOUND(n, k, base);
 
-    DEBUG("c " << c << " s " << s);
+    OPENFHE_DEBUG("c " << c << " s " << s);
 
     // perturbation vector in evaluation representation
     auto pHat = std::make_shared<Matrix<Poly>>(zero_alloc, k + 2, 1);
-    DEBUG("t1a: " << TOC(t1));
+    OPENFHE_DEBUG("t1a: " << TOC(t1));
     TIC(t1);
     ZSampleSigmaP(n, s, c, T, dgg, dggLargeSigma, pHat);
-    DEBUG("t1b: " << TOC(t1));  // this takes the most time 61
+    OPENFHE_DEBUG("t1b: " << TOC(t1));  // this takes the most time 61
     TIC(t1);
     // It is assumed that A has dimension 1 x (k + 2) and pHat has the dimension
     // of (k + 2) x 1 perturbedSyndrome is in the evaluation representation
     Poly perturbedSyndrome = u - (A.Mult(*pHat))(0, 0);
 
-    DEBUG("t1c: " << TOC(t1));  // takes 2
+    OPENFHE_DEBUG("t1c: " << TOC(t1));  // takes 2
     TIC(t1);
     Matrix<int64_t> zHatBBI([]() { return 0; }, k, n);
-    DEBUG("t1d: " << TOC(t1));     // takes 0
-    DEBUG("t1: " << TOC(t1_tot));  // takes 64
+    OPENFHE_DEBUG("t1d: " << TOC(t1));     // takes 0
+    OPENFHE_DEBUG("t1: " << TOC(t1_tot));  // takes 64
     TIC(t2);
     TIC(t2_tot);
     perturbedSyndrome.SetFormat(Format::COEFFICIENT);
-    DEBUG("t2a: " << TOC(t2));  // takes 1
+    OPENFHE_DEBUG("t2a: " << TOC(t2));  // takes 1
     TIC(t2);
     LatticeGaussSampUtility<Poly>::GaussSampGqArbBase(perturbedSyndrome, c, k, modulus, base, dgg, &zHatBBI);
-    DEBUG("t2b: " << TOC(t2));  // takes 36
+    OPENFHE_DEBUG("t2b: " << TOC(t2));  // takes 36
     TIC(t2);
     // Convert zHat from a matrix of BBI to a vector of Element ring elements
     // zHat is in the coefficient representation
     Matrix<Poly> zHat = SplitInt64AltIntoElements<Poly>(zHatBBI, n, params);
 
-    DEBUG("t2c: " << TOC(t2));  // takes 0
+    OPENFHE_DEBUG("t2c: " << TOC(t2));  // takes 0
     // Now converting it to the evaluation representation before multiplication
     zHat.SetFormat(Format::EVALUATION);
-    DEBUG("t2d: " << TOC(t2));  // takes 17
-    DEBUG("t2: " << TOC(t2_tot));
+    OPENFHE_DEBUG("t2d: " << TOC(t2));  // takes 17
+    OPENFHE_DEBUG("t2: " << TOC(t2_tot));
     // TIC(t3); seems trivial
     Matrix<Poly> zHatPrime(zero_alloc, k + 2, 1);
 
@@ -303,7 +303,7 @@ Matrix<NativePoly> RLWETrapdoorUtility<NativePoly>::GaussSamp(size_t n, size_t k
                                                               const NativePoly& u, typename NativePoly::DggType& dgg,
                                                               typename NativePoly::DggType& dggLargeSigma,
                                                               int64_t base) {
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
     TimeVar t1, t1_tot, t2, t2_tot;
     TIC(t1);
     TIC(t1_tot);
@@ -317,41 +317,41 @@ Matrix<NativePoly> RLWETrapdoorUtility<NativePoly>::GaussSamp(size_t n, size_t k
     // spectral bound s
     double s = SPECTRAL_BOUND(n, k, base);
 
-    DEBUG("c " << c << " s " << s);
+    OPENFHE_DEBUG("c " << c << " s " << s);
 
     // perturbation vector in evaluation representation
     auto pHat = std::make_shared<Matrix<NativePoly>>(zero_alloc, k + 2, 1);
-    DEBUG("t1a: " << TOC(t1));
+    OPENFHE_DEBUG("t1a: " << TOC(t1));
     TIC(t1);
     ZSampleSigmaP(n, s, c, T, dgg, dggLargeSigma, pHat);
-    DEBUG("t1b: " << TOC(t1));  // this takes the most time 61
+    OPENFHE_DEBUG("t1b: " << TOC(t1));  // this takes the most time 61
     TIC(t1);
     // It is assumed that A has dimension 1 x (k + 2) and pHat has the dimension
     // of (k + 2) x 1 perturbedSyndrome is in the evaluation representation
     NativePoly perturbedSyndrome = u - (A.Mult(*pHat))(0, 0);
 
-    DEBUG("t1c: " << TOC(t1));  // takes 2
+    OPENFHE_DEBUG("t1c: " << TOC(t1));  // takes 2
     TIC(t1);
     Matrix<int64_t> zHatBBI([]() { return 0; }, k, n);
-    DEBUG("t1d: " << TOC(t1));     // takes 0
-    DEBUG("t1: " << TOC(t1_tot));  // takes 64
+    OPENFHE_DEBUG("t1d: " << TOC(t1));     // takes 0
+    OPENFHE_DEBUG("t1: " << TOC(t1_tot));  // takes 64
     TIC(t2);
     TIC(t2_tot);
     perturbedSyndrome.SetFormat(Format::COEFFICIENT);
-    DEBUG("t2a: " << TOC(t2));  // takes 1
+    OPENFHE_DEBUG("t2a: " << TOC(t2));  // takes 1
     TIC(t2);
     LatticeGaussSampUtility<NativePoly>::GaussSampGqArbBase(perturbedSyndrome, c, k, modulus, base, dgg, &zHatBBI);
-    DEBUG("t2b: " << TOC(t2));  // takes 36
+    OPENFHE_DEBUG("t2b: " << TOC(t2));  // takes 36
     TIC(t2);
     // Convert zHat from a matrix of BBI to a vector of Element ring elements
     // zHat is in the coefficient representation
     Matrix<NativePoly> zHat = SplitInt64AltIntoElements<NativePoly>(zHatBBI, n, params);
 
-    DEBUG("t2c: " << TOC(t2));  // takes 0
+    OPENFHE_DEBUG("t2c: " << TOC(t2));  // takes 0
     // Now converting it to the evaluation representation before multiplication
     zHat.SetFormat(Format::EVALUATION);
-    DEBUG("t2d: " << TOC(t2));  // takes 17
-    DEBUG("t2: " << TOC(t2_tot));
+    OPENFHE_DEBUG("t2d: " << TOC(t2));  // takes 17
+    OPENFHE_DEBUG("t2: " << TOC(t2_tot));
     // TIC(t3); seems trivial
     Matrix<NativePoly> zHatPrime(zero_alloc, k + 2, 1);
 

--- a/src/core/lib/lattice/trapdoor.cpp
+++ b/src/core/lib/lattice/trapdoor.cpp
@@ -113,7 +113,7 @@ inline void RLWETrapdoorUtility<DCRTPoly>::ZSampleSigmaP(size_t n, double s, dou
                                                          const DCRTPoly::DggType& dgg,
                                                          const DCRTPoly::DggType& dggLargeSigma,
                                                          std::shared_ptr<Matrix<DCRTPoly>> perturbationVector) {
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
     TimeVar t1, t1_tot;
 
     TIC(t1);
@@ -125,7 +125,7 @@ inline void RLWETrapdoorUtility<DCRTPoly>::ZSampleSigmaP(size_t n, double s, dou
 
     const std::shared_ptr<DCRTPoly::Params> params = Tprime0(0, 0).GetParams();
 
-    DEBUG("z1a: " << TOC(t1));  // 0
+    OPENFHE_DEBUG("z1a: " << TOC(t1));  // 0
     TIC(t1);
     // all three Polynomials are initialized with "0" coefficients
     NativePoly va((*params)[0], Format::EVALUATION, 1);
@@ -137,7 +137,7 @@ inline void RLWETrapdoorUtility<DCRTPoly>::ZSampleSigmaP(size_t n, double s, dou
         vb += (NativePoly)Tprime1(0, i).GetElementAtIndex(0) * Tprime0(0, i).Transpose().GetElementAtIndex(0);
         vd += (NativePoly)Tprime1(0, i).GetElementAtIndex(0) * Tprime1(0, i).Transpose().GetElementAtIndex(0);
     }
-    DEBUG("z1b: " << TOC(t1));  // 9
+    OPENFHE_DEBUG("z1b: " << TOC(t1));  // 9
     TIC(t1);
 
     // Switch the ring elements (Polynomials) to coefficient representation
@@ -145,7 +145,7 @@ inline void RLWETrapdoorUtility<DCRTPoly>::ZSampleSigmaP(size_t n, double s, dou
     vb.SetFormat(Format::COEFFICIENT);
     vd.SetFormat(Format::COEFFICIENT);
 
-    DEBUG("z1c: " << TOC(t1));  // 5
+    OPENFHE_DEBUG("z1c: " << TOC(t1));  // 5
     TIC(t1);
 
     // Create field elements from ring elements
@@ -159,14 +159,14 @@ inline void RLWETrapdoorUtility<DCRTPoly>::ZSampleSigmaP(size_t n, double s, dou
 
     a = a + s * s;
     d = d + s * s;
-    DEBUG("z1d: " << TOC(t1));  // 0
+    OPENFHE_DEBUG("z1d: " << TOC(t1));  // 0
     TIC(t1);
 
     // converts the field elements to DFT representation
     a.SetFormat(Format::EVALUATION);
     b.SetFormat(Format::EVALUATION);
     d.SetFormat(Format::EVALUATION);
-    DEBUG("z1e: " << TOC(t1));  // 0
+    OPENFHE_DEBUG("z1e: " << TOC(t1));  // 0
     TIC(t1);
 
     Matrix<int64_t> p2ZVector([]() { return 0; }, n * k, 1);
@@ -190,18 +190,18 @@ inline void RLWETrapdoorUtility<DCRTPoly>::ZSampleSigmaP(size_t n, double s, dou
             p2ZVector(i, 0) = (dggVector.get())[i];
         }
     }
-    DEBUG("z1f1: " << TOC(t1));
+    OPENFHE_DEBUG("z1f1: " << TOC(t1));
     TIC(t1);
 
     // create k ring elements in coefficient representation
     Matrix<DCRTPoly> p2 = SplitInt64IntoElements<DCRTPoly>(p2ZVector, n, params);
-    DEBUG("z1f2: " << TOC(t1));
+    OPENFHE_DEBUG("z1f2: " << TOC(t1));
     TIC(t1);
 
     // now converting to Format::EVALUATION representation before multiplication
     p2.SetFormat(Format::EVALUATION);
 
-    DEBUG("z1g: " << TOC(t1));  // 17
+    OPENFHE_DEBUG("z1g: " << TOC(t1));  // 17
 
     TIC(t1);
 
@@ -212,11 +212,11 @@ inline void RLWETrapdoorUtility<DCRTPoly>::ZSampleSigmaP(size_t n, double s, dou
         Tp2(1, 0) += Tprime1(0, i).GetElementAtIndex(0) * (NativePoly)p2(i, 0).GetElementAtIndex(0);
     }
 
-    DEBUG("z1h2: " << TOC(t1));
+    OPENFHE_DEBUG("z1h2: " << TOC(t1));
     TIC(t1);
     // change to coefficient representation before converting to field elements
     Tp2.SetFormat(Format::COEFFICIENT);
-    DEBUG("z1h3: " << TOC(t1));
+    OPENFHE_DEBUG("z1h3: " << TOC(t1));
     TIC(t1);
 
     Matrix<Field2n> c([]() { return Field2n(); }, 2, 1);
@@ -225,26 +225,26 @@ inline void RLWETrapdoorUtility<DCRTPoly>::ZSampleSigmaP(size_t n, double s, dou
     c(1, 0) = Field2n(Tp2(1, 0)).ScalarMult(-sigma * sigma / (s * s - sigma * sigma));
 
     auto p1ZVector = std::make_shared<Matrix<int64_t>>([]() { return 0; }, n * 2, 1);
-    DEBUG("z1i: " << TOC(t1));
+    OPENFHE_DEBUG("z1i: " << TOC(t1));
     TIC(t1);
 
     LatticeGaussSampUtility<DCRTPoly>::ZSampleSigma2x2(a, b, d, c, dgg, p1ZVector);
-    DEBUG("z1j1: " << TOC(t1));  // 14
+    OPENFHE_DEBUG("z1j1: " << TOC(t1));  // 14
     TIC(t1);
 
     // create 2 ring elements in coefficient representation
     Matrix<DCRTPoly> p1 = SplitInt64IntoElements<DCRTPoly>(*p1ZVector, n, params);
-    DEBUG("z1j2: " << TOC(t1));
+    OPENFHE_DEBUG("z1j2: " << TOC(t1));
     TIC(t1);
 
     p1.SetFormat(Format::EVALUATION);
-    DEBUG("z1j3: " << TOC(t1));
+    OPENFHE_DEBUG("z1j3: " << TOC(t1));
     TIC(t1);
 
     *perturbationVector = p1.VStack(p2);
-    DEBUG("z1j4: " << TOC(t1));
+    OPENFHE_DEBUG("z1j4: " << TOC(t1));
     TIC(t1);
-    DEBUG("z1tot: " << TOC(t1_tot));
+    OPENFHE_DEBUG("z1tot: " << TOC(t1_tot));
 }
 
 }  // namespace lbcrypto

--- a/src/core/lib/math/discretegaussiangenerator.cpp
+++ b/src/core/lib/math/discretegaussiangenerator.cpp
@@ -262,16 +262,16 @@ typename VecType::Integer DiscreteGaussianGeneratorImpl<VecType>::GenerateIntege
 
 template <typename VecType>
 int32_t DiscreteGaussianGeneratorImpl<VecType>::GenerateInteger(double mean, double stddev, size_t n) const {
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
     int32_t x;
 
     // this representation of log_2 is used for Visual Studio
     double t = log2(n) * stddev;
-    DEBUG("DiscreteGaussianGeneratorImpl =========");
-    DEBUG("mean " << mean);
-    DEBUG("stddev " << stddev);
-    DEBUG("n " << n);
-    DEBUG("t " << t);
+    OPENFHE_DEBUG("DiscreteGaussianGeneratorImpl =========");
+    OPENFHE_DEBUG("mean " << mean);
+    OPENFHE_DEBUG("stddev " << stddev);
+    OPENFHE_DEBUG("n " << n);
+    OPENFHE_DEBUG("t " << t);
 
     if (std::isinf(mean)) {
         OPENFHE_THROW(not_available_error, "DiscreteGaussianGeneratorImpl called with mean == +-inf");
@@ -283,11 +283,11 @@ int32_t DiscreteGaussianGeneratorImpl<VecType>::GenerateInteger(double mean, dou
     typename VecType::Integer result;
 
     std::uniform_int_distribution<int32_t> uniform_int(floor(mean - t), ceil(mean + t));
-    DEBUG("uniform( " << floor(mean - t) << ", " << ceil(mean + t) << ")");
+    OPENFHE_DEBUG("uniform( " << floor(mean - t) << ", " << ceil(mean + t) << ")");
     std::uniform_real_distribution<double> uniform_real(0.0, 1.0);
 
     double sigmaFactor = -1 / (2. * stddev * stddev);
-    DEBUG("sigmaFactor " << sigmaFactor);
+    OPENFHE_DEBUG("sigmaFactor " << sigmaFactor);
 
     bool flagSuccess = false;
 
@@ -305,10 +305,10 @@ int32_t DiscreteGaussianGeneratorImpl<VecType>::GenerateInteger(double mean, dou
         if (dice <= UnnormalizedGaussianPDFOptimized(mean, sigmaFactor, x)) {
             flagSuccess = true;
         }
-        // DEBUG("x "<<x<<" dice "<<dice);
+        // OPENFHE_DEBUG("x "<<x<<" dice "<<dice);
         count++;
         if (count > limit) {
-            DEBUG("x " << x << " dice " << dice);
+            OPENFHE_DEBUG("x " << x << " dice " << dice);
             OPENFHE_THROW(not_available_error, "GenerateInteger could not find success after repeated attempts");
         }
     }

--- a/src/core/lib/math/nbtheory.cpp
+++ b/src/core/lib/math/nbtheory.cpp
@@ -130,13 +130,13 @@ static IntType RNG(const IntType& modulus) {
  */
 template <typename IntType>
 static bool WitnessFunction(const IntType& a, const IntType& d, usint s, const IntType& p) {
-    DEBUG_FLAG(false);
-    DEBUG("calling modexp a " << a << " d " << d << " p " << p);
+    OPENFHE_DEBUG_FLAG(false);
+    OPENFHE_DEBUG("calling modexp a " << a << " d " << d << " p " << p);
     IntType mod = a.ModExp(d, p);
-    DEBUG("mod " << mod);
+    OPENFHE_DEBUG("mod " << mod);
     bool prevMod = false;
     for (usint i = 1; i < s + 1; i++) {
-        DEBUG("wf " << i);
+        OPENFHE_DEBUG("wf " << i);
         if (mod != IntType(1) && mod != p - IntType(1)) {
             prevMod = true;
         }
@@ -157,17 +157,17 @@ static bool WitnessFunction(const IntType& a, const IntType& d, usint s, const I
  */
 template <typename IntType>
 static IntType FindGenerator(const IntType& q) {
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
     std::set<IntType> primeFactors;
-    DEBUG("FindGenerator(" << q << "),calling PrimeFactorize");
+    OPENFHE_DEBUG("FindGenerator(" << q << "),calling PrimeFactorize");
 
     IntType qm1 = q - IntType(1);
     IntType qm2 = q - IntType(2);
     PrimeFactorize<IntType>(qm1, primeFactors);
-    DEBUG("prime factors of " << qm1);
+    OPENFHE_DEBUG("prime factors of " << qm1);
 #if !defined(NDEBUG)
     for (auto& v : primeFactors)
-        DEBUG(v << " ");
+        OPENFHE_DEBUG(v << " ");
 #endif
     bool generatorFound = false;
     IntType gen;
@@ -176,11 +176,11 @@ static IntType FindGenerator(const IntType& q) {
 
         // gen = RNG(qm2).ModAdd(IntType::ONE, q); //modadd note needed
         gen = RNG(qm2) + IntType(1);
-        DEBUG("generator " << gen);
-        DEBUG("cycling thru prime factors");
+        OPENFHE_DEBUG("generator " << gen);
+        OPENFHE_DEBUG("cycling thru prime factors");
 
         for (auto it = primeFactors.begin(); it != primeFactors.end(); ++it) {
-            DEBUG(qm1 << " / " << *it << " " << gen.ModExp(qm1 / (*it), q));
+            OPENFHE_DEBUG(qm1 << " / " << *it << " " << gen.ModExp(qm1 / (*it), q));
 
             if (gen.ModExp(qm1 / (*it), q) == IntType(1))
                 break;
@@ -200,20 +200,20 @@ static IntType FindGenerator(const IntType& q) {
  */
 template <typename IntType>
 IntType FindGeneratorCyclic(const IntType& q) {
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
     std::set<IntType> primeFactors;
-    DEBUG("calling PrimeFactorize");
+    OPENFHE_DEBUG("calling PrimeFactorize");
 
     IntType phi_q    = IntType(GetTotient(q.ConvertToInt()));
     IntType phi_q_m1 = IntType(GetTotient(q.ConvertToInt()));
 
     PrimeFactorize<IntType>(phi_q, primeFactors);
-    DEBUG("done");
+    OPENFHE_DEBUG("done");
     bool generatorFound = false;
     IntType gen;
     while (!generatorFound) {
         usint count = 0;
-        DEBUG("count " << count);
+        OPENFHE_DEBUG("count " << count);
 
         gen = RNG(phi_q_m1) + IntType(1);  // gen is random in [1, phi(q)]
         if (GreatestCommonDivisor<IntType>(gen, q) != IntType(1)) {
@@ -223,8 +223,8 @@ IntType FindGeneratorCyclic(const IntType& q) {
 
         // Order of a generator cannot divide any co-factor
         for (auto it = primeFactors.begin(); it != primeFactors.end(); ++it) {
-            DEBUG("in set");
-            DEBUG("divide " << phi_q << " by " << *it);
+            OPENFHE_DEBUG("in set");
+            OPENFHE_DEBUG("divide " << phi_q << " by " << *it);
 
             if (gen.ModExp(phi_q / (*it), q) == IntType(1))
                 break;
@@ -245,20 +245,20 @@ IntType FindGeneratorCyclic(const IntType& q) {
  */
 template <typename IntType>
 bool IsGenerator(const IntType& g, const IntType& q) {
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
     std::set<IntType> primeFactors;
-    DEBUG("calling PrimeFactorize");
+    OPENFHE_DEBUG("calling PrimeFactorize");
 
     IntType qm1 = IntType(GetTotient(q.ConvertToInt()));
 
     PrimeFactorize<IntType>(qm1, primeFactors);
-    DEBUG("done");
+    OPENFHE_DEBUG("done");
 
     usint count = 0;
 
     for (auto it = primeFactors.begin(); it != primeFactors.end(); ++it) {
-        DEBUG("in set");
-        DEBUG("divide " << qm1 << " by " << *it);
+        OPENFHE_DEBUG("in set");
+        OPENFHE_DEBUG("divide " << qm1 << " by " << *it);
 
         if (g.ModExp(qm1 / (*it), q) == IntType(1))
             break;
@@ -282,8 +282,8 @@ bool IsGenerator(const IntType& g, const IntType& q) {
  */
 template <typename IntType>
 IntType RootOfUnity(usint m, const IntType& modulo) {
-    DEBUG_FLAG(false);
-    DEBUG("in Root of unity m :" << m << " modulo " << modulo.ToString());
+    OPENFHE_DEBUG_FLAG(false);
+    OPENFHE_DEBUG("in Root of unity m :" << m << " modulo " << modulo.ToString());
     IntType M(m);
     if ((modulo - IntType(1)).Mod(M) != IntType(0)) {
         std::string errMsg =
@@ -294,16 +294,16 @@ IntType RootOfUnity(usint m, const IntType& modulo) {
         OPENFHE_THROW(math_error, errMsg);
     }
     IntType result;
-    DEBUG("calling FindGenerator");
+    OPENFHE_DEBUG("calling FindGenerator");
     IntType gen = FindGenerator(modulo);
-    DEBUG("gen = " << gen.ToString());
+    OPENFHE_DEBUG("gen = " << gen.ToString());
 
-    DEBUG("calling gen.ModExp( " << ((modulo - IntType(1)).DividedBy(M)).ToString() << ", modulus "
+    OPENFHE_DEBUG("calling gen.ModExp( " << ((modulo - IntType(1)).DividedBy(M)).ToString() << ", modulus "
                                  << modulo.ToString());
     result = gen.ModExp((modulo - IntType(1)).DividedBy(M), modulo);
-    DEBUG("result = " << result.ToString());
+    OPENFHE_DEBUG("result = " << result.ToString());
     if (result == IntType(1)) {
-        DEBUG("LOOP?");
+        OPENFHE_DEBUG("LOOP?");
         result = RootOfUnity(m, modulo);
     }
 
@@ -353,20 +353,20 @@ std::vector<IntType> RootsOfUnity(usint m, const std::vector<IntType> moduli) {
 
 template <typename IntType>
 IntType GreatestCommonDivisor(const IntType& a, const IntType& b) {
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
     IntType m_a, m_b, m_t;
     m_a = a;
     m_b = b;
-    DEBUG("GCD a " << a << " b " << b);
+    OPENFHE_DEBUG("GCD a " << a << " b " << b);
     while (m_b != IntType(0)) {
         m_t = m_b;
-        DEBUG("GCD m_a.Mod(b) " << m_a << "( " << m_b << ")");
+        OPENFHE_DEBUG("GCD m_a.Mod(b) " << m_a << "( " << m_b << ")");
         m_b = m_a % m_b;
 
         m_a = m_t;
-        DEBUG("GCD m_a " << m_b << " m_b " << m_b);
+        OPENFHE_DEBUG("GCD m_a " << m_b << " m_b " << m_b);
     }
-    DEBUG("GCD ret " << m_a);
+    OPENFHE_DEBUG("GCD ret " << m_a);
     return m_a;
 }
 
@@ -378,7 +378,7 @@ IntType GreatestCommonDivisor(const IntType& a, const IntType& b) {
  */
 template <typename IntType>
 bool MillerRabinPrimalityTest(const IntType& p, const usint niter) {
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
     if (p < IntType(2) || ((p != IntType(2)) && (p.Mod(2) == IntType(0))))
         return false;
     if (p == IntType(2) || p == IntType(3) || p == IntType(5))
@@ -386,22 +386,22 @@ bool MillerRabinPrimalityTest(const IntType& p, const usint niter) {
 
     IntType d = p - IntType(1);
     usint s   = 0;
-    DEBUG("start while d " << d);
+    OPENFHE_DEBUG("start while d " << d);
     while (d.Mod(2) == IntType(0)) {
         d.DividedByEq(2);
         s++;
     }
-    DEBUG("end while s " << s);
+    OPENFHE_DEBUG("end while s " << s);
     bool composite = true;
     for (usint i = 0; i < niter; i++) {
-        DEBUG(".1");
+        OPENFHE_DEBUG(".1");
         IntType a = RNG(p - IntType(3)).ModAdd(2, p);
-        DEBUG(".2");
+        OPENFHE_DEBUG(".2");
         composite = (WitnessFunction(a, d, s, p));
         if (composite)
             break;
     }
-    DEBUG("done composite " << composite);
+    OPENFHE_DEBUG("done composite " << composite);
     return (!composite);
 }
 
@@ -412,7 +412,7 @@ bool MillerRabinPrimalityTest(const IntType& p, const usint niter) {
  */
 template <typename IntType>
 const IntType PollardRhoFactorization(const IntType& n) {
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
     IntType divisor(1);
 
     IntType c(RNG(n));
@@ -433,7 +433,7 @@ const IntType PollardRhoFactorization(const IntType& n) {
 
         divisor = GreatestCommonDivisor((x > xx) ? x - xx : xx - x, n);
 
-        DEBUG("PRF divisor " << divisor.ToString());
+        OPENFHE_DEBUG("PRF divisor " << divisor.ToString());
     } while (divisor == IntType(1));
 
     return divisor;
@@ -446,33 +446,33 @@ const IntType PollardRhoFactorization(const IntType& n) {
  */
 template <typename IntType>
 void PrimeFactorize(IntType n, std::set<IntType>& primeFactors) {
-    DEBUG_FLAG(false);
-    DEBUG("PrimeFactorize " << n);
+    OPENFHE_DEBUG_FLAG(false);
+    OPENFHE_DEBUG("PrimeFactorize " << n);
 
     // primeFactors.clear();
-    DEBUG("In PrimeFactorize n " << n);
-    DEBUG("set size " << primeFactors.size());
+    OPENFHE_DEBUG("In PrimeFactorize n " << n);
+    OPENFHE_DEBUG("set size " << primeFactors.size());
 
     if (n == IntType(0) || n == IntType(1))
         return;
-    DEBUG("calling MillerRabinPrimalityTest(" << n << ")");
+    OPENFHE_DEBUG("calling MillerRabinPrimalityTest(" << n << ")");
     if (MillerRabinPrimalityTest(n)) {
-        DEBUG("Miller true");
+        OPENFHE_DEBUG("Miller true");
         primeFactors.insert(n);
         return;
     }
 
-    DEBUG("calling PrFact n " << n);
+    OPENFHE_DEBUG("calling PrFact n " << n);
     IntType divisor(PollardRhoFactorization(n));
 
-    DEBUG("calling PF " << divisor);
+    OPENFHE_DEBUG("calling PF " << divisor);
     PrimeFactorize(divisor, primeFactors);
 
-    DEBUG("calling div " << divisor);
+    OPENFHE_DEBUG("calling div " << divisor);
     // IntType reducedN = n.DividedBy(divisor);
     n /= divisor;
 
-    DEBUG("calling PF reduced n " << n);
+    OPENFHE_DEBUG("calling PF reduced n " << n);
     PrimeFactorize(n, primeFactors);
 }
 
@@ -486,9 +486,9 @@ IntType FirstPrime(uint64_t nBits, uint64_t m) {
     }
 #endif
     try {
-        DEBUG_FLAG(false);
+        OPENFHE_DEBUG_FLAG(false);
         IntType r = IntType(2).ModExp(nBits, m);
-        DEBUG("r " << r);
+        OPENFHE_DEBUG("r " << r);
         IntType qNew = (IntType(1) << nBits);
         double d1    = qNew.ConvertToDouble();
         double d2    = std::pow(2, static_cast<double>(nBits));
@@ -518,9 +518,9 @@ IntType FirstPrime(uint64_t nBits, uint64_t m) {
         OPENFHE_THROW(math_error, "FirstPrime math exception");
     }
     //  try {
-    //    DEBUG_FLAG(false);
+    //    OPENFHE_DEBUG_FLAG(false);
     //    IntType r = IntType(2).ModExp(nBits, m);
-    //    DEBUG("r "<<r);
+    //    OPENFHE_DEBUG("r "<<r);
     //    IntType qNew = (IntType(1) << nBits);
     //    double d1 = qNew.ConvertToDouble();
     //    double d2 = std::pow(2, double(nBits));

--- a/src/core/lib/math/nbtheory2.cpp
+++ b/src/core/lib/math/nbtheory2.cpp
@@ -51,22 +51,22 @@ namespace lbcrypto {
 #ifdef WITH_NTL
 // native NTL version
 NTL::myZZ RNG(const NTL::myZZ& modulus) {
-    DEBUG_FLAG(false);
-    DEBUG("in NTL RNG");
+    OPENFHE_DEBUG_FLAG(false);
+    OPENFHE_DEBUG("in NTL RNG");
     return RandomBnd(modulus);
 }
 
 // define an NTL native implementation
 NTL::myZZ GreatestCommonDivisor(const NTL::myZZ& a, const NTL::myZZ& b) {
-    DEBUG_FLAG(false);
-    DEBUG("NTL::GCD a " << a << " b " << b);
+    OPENFHE_DEBUG_FLAG(false);
+    OPENFHE_DEBUG("NTL::GCD a " << a << " b " << b);
     return GCD(a, b);
 }
 
 // NTL native version
 bool MillerRabinPrimalityTest(const NTL::myZZ& p, const usint niter) {
-    DEBUG_FLAG(false);
-    DEBUG("in NTL MRPT");
+    OPENFHE_DEBUG_FLAG(false);
+    OPENFHE_DEBUG("in NTL MRPT");
     if (p < NTL::myZZ(2) || ((p != NTL::myZZ(2)) && (p.Mod(NTL::myZZ(2)) == NTL::myZZ(0))))
         return false;
     if (p == NTL::myZZ(2) || p == NTL::myZZ(3) || p == NTL::myZZ(5))

--- a/src/core/lib/utils/blockAllocator/xallocator.cpp
+++ b/src/core/lib/utils/blockAllocator/xallocator.cpp
@@ -215,9 +215,9 @@ static inline void* get_block_ptr(void* block) {
 /// @return Allocator instance handling requested block size or nullptr
 /// if no allocator exists.
 static inline Allocator* find_allocator(size_t size) {
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
     for (usint i = 0; i < MAX_ALLOCATORS; i++) {
-        DEBUG("allocator " << i << " " << _allocators[i]);
+        OPENFHE_DEBUG("allocator " << i << " " << _allocators[i]);
 
         if (_allocators[i] == 0)
             break;
@@ -324,7 +324,7 @@ extern "C" Allocator* xallocator_get_allocator(size_t size) {
     // within the block memory region. Most blocks are powers of two,
     // however some common allocator block sizes can be explicitly defined
     // to minimize wasted storage. This offers application specific tuning.
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
     size_t blockSize = size + sizeof(Allocator*);
     if (blockSize > 256 && blockSize <= 396)
         blockSize = 396;
@@ -332,7 +332,7 @@ extern "C" Allocator* xallocator_get_allocator(size_t size) {
         blockSize = 768;
     else
         blockSize = nexthigher<size_t>(blockSize);
-    DEBUG("finding allocator for blockSize " << blockSize);
+    OPENFHE_DEBUG("finding allocator for blockSize " << blockSize);
     Allocator* allocator = find_allocator(blockSize);
 
 #ifdef STATIC_POOLS
@@ -360,7 +360,7 @@ extern "C" Allocator* xallocator_get_allocator(size_t size) {
 ///  @param[in] size - the client requested size of the block.
 /// @return  A pointer to the client's memory block.
 extern "C" void* xmalloc(size_t size) {
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
 
     Allocator* allocator;
     void* blockMemoryPtr;
@@ -370,7 +370,7 @@ extern "C" void* xmalloc(size_t size) {
         // Allocate a raw memory block
         allocator      = xallocator_get_allocator(size);
         blockMemoryPtr = allocator->Allocate(sizeof(Allocator*) + size);
-        DEBUG("xmalloc " << size);
+        OPENFHE_DEBUG("xmalloc " << size);
     }
     lock_release();
 
@@ -384,8 +384,8 @@ extern "C" void* xmalloc(size_t size) {
 ///  to the fixed block allocator that originally created it.
 ///  @param[in] ptr - a pointer to a block created with xalloc.
 extern "C" void xfree(void* ptr) {
-    DEBUG_FLAG(false);
-    DEBUG("xfree ");
+    OPENFHE_DEBUG_FLAG(false);
+    OPENFHE_DEBUG("xfree ");
     if (ptr == 0)
         return;
 

--- a/src/core/unittest/UnitTestBinInt.cpp
+++ b/src/core/unittest/UnitTestBinInt.cpp
@@ -951,7 +951,7 @@ TEST_F(UTBinInt, mod_arithmetic) {
 
 template <typename T>
 void big_modexp(const std::string& msg) {
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
     TimeVar t;
 
     TIC(t);
@@ -964,7 +964,7 @@ void big_modexp(const std::string& msg) {
 
     EXPECT_EQ(expectedResult, calculatedResult) << msg << " Failure testing very big mod_exp_test";
 
-    DEBUG("big_modexp time ns " << TOC_NS(t));
+    OPENFHE_DEBUG("big_modexp time ns " << TOC_NS(t));
 }
 
 TEST_F(UTBinInt, big_modexp) {
@@ -1229,7 +1229,7 @@ TEST_F(UTBinInt, GetBitAtIndex) {
 
 template <typename T>
 void GetInternalRepresentation(const std::string& msg) {
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
     T x(1);
 
     x <<= 100;  // x has one bit at 128
@@ -1239,9 +1239,9 @@ void GetInternalRepresentation(const std::string& msg) {
 
 #if !defined(NDEBUG)
     if (dbg_flag) {
-        DEBUG(x_limbs);
-        DEBUG("x_limbs " << x_limbs);
-        DEBUG("x " << x);
+        OPENFHE_DEBUG(x_limbs);
+        OPENFHE_DEBUG("x_limbs " << x_limbs);
+        OPENFHE_DEBUG("x " << x);
     }
 #endif
 

--- a/src/core/unittest/UnitTestBinVect.cpp
+++ b/src/core/unittest/UnitTestBinVect.cpp
@@ -66,7 +66,7 @@ using namespace lbcrypto;
 */
 template <typename V>
 void AtAndSetModulusTest(const std::string& msg) {
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
     usint len = 10;
     V m(len);
 
@@ -86,9 +86,9 @@ void AtAndSetModulusTest(const std::string& msg) {
 
     m.SetModulus(q);
 
-    DEBUG("m" << m);
+    OPENFHE_DEBUG("m" << m);
     V calculatedResult = m.Mod(q);
-    DEBUG("calculated result" << m);
+    OPENFHE_DEBUG("calculated result" << m);
     uint64_t expectedResult[] = {48, 53, 7, 178, 190, 120, 79, 108, 60, 12};
     for (usint i = 0; i < len; i++) {
         EXPECT_EQ(expectedResult[i], calculatedResult[i].ConvertToInt()) << msg << " Mod failed";
@@ -107,7 +107,7 @@ void AtAndSetModulusTest(const std::string& msg) {
     n.at(8) = typename V::Integer("325328");
     n.at(9) = typename V::Integer("7698798");
 
-    DEBUG("n" << n);
+    OPENFHE_DEBUG("n" << n);
     for (usint i = 0; i < len; i++) {
         if (i != 6) {  // value at 6 is < q
             EXPECT_NE(expectedResult[i], n[i].ConvertToInt()) << msg << " at no mod failed";
@@ -120,7 +120,7 @@ void AtAndSetModulusTest(const std::string& msg) {
     V l(len, q);
     // note list assignment does take modulus
     l = {"987968", "587679", "456454", "234343", "769789", "465654", "79", "346346", "325328", "7698798"};
-    DEBUG("l" << l);
+    OPENFHE_DEBUG("l" << l);
     for (usint i = 0; i < len; i++) {
         EXPECT_EQ(expectedResult[i], l[i].ConvertToInt()) << msg << " Mod on list assignment failed";
     }
@@ -199,15 +199,15 @@ TEST(UTBinVect, ModAddBigModulus) {
 
 template <typename V>
 void ModAddSmallerModulus(const std::string& msg) {
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
 
     typename V::Integer q("3534");  // constructor calling to set mod value
     // calling constructor to create a vector of length 5 and passing value of q
     V m(5, q);
     typename V::Integer n("34365");
 
-    DEBUG("m " << m);
-    DEBUG("m's modulus " << m.GetModulus());
+    OPENFHE_DEBUG("m " << m);
+    OPENFHE_DEBUG("m's modulus " << m.GetModulus());
     // at() does not apply mod.
     m.at(0) = typename V::Integer("9868");
     m.at(1) = typename V::Integer("5879");
@@ -217,8 +217,8 @@ void ModAddSmallerModulus(const std::string& msg) {
 
     V calculatedResult = m.ModAdd(n);
 
-    DEBUG("m " << m);
-    DEBUG("calculated result  " << calculatedResult);
+    OPENFHE_DEBUG("m " << m);
+    OPENFHE_DEBUG("calculated result  " << calculatedResult);
     uint64_t expectedResult[5] = {1825, 1370, 45, 1368, 1746};
 
     for (usint i = 0; i < 5; i++) {
@@ -334,7 +334,7 @@ TEST(UTBinVect, ModMulTest) {
 */
 template <typename V>
 void ModExpTest(const std::string& msg) {
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
     typename V::Integer q("3534");  // constructor calling to set mod value
 
     // calling constructor to create a vector of length 5 and passing value of q
@@ -346,7 +346,7 @@ void ModExpTest(const std::string& msg) {
     m.at(2) = typename V::Integer("4");
     m.at(3) = typename V::Integer("2343");
     m.at(4) = typename V::Integer("97");
-    DEBUG("m's modulus " << m.GetModulus());
+    OPENFHE_DEBUG("m's modulus " << m.GetModulus());
 
     V calculatedResult = m.ModExp(n);
 
@@ -439,7 +439,7 @@ TEST(UTBinVect, modadd_vector_result_smaller_modulus) {
 
 template <typename V>
 void modadd_vector_result_greater_modulus(const std::string& msg) {
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
     typename V::Integer q("657");  // constructor calling to set mod value
     // calling constructor to create a vector of length 5 and passing value of q
     V m(5, q);
@@ -449,14 +449,14 @@ void modadd_vector_result_greater_modulus(const std::string& msg) {
 
     n = {"4533", "4549", "6756", "1233", "7897"};
 
-    DEBUG("m " << m);
-    DEBUG("m mod" << m.GetModulus());
-    DEBUG("n " << n);
-    DEBUG("n mod " << n.GetModulus());
+    OPENFHE_DEBUG("m " << m);
+    OPENFHE_DEBUG("m mod" << m.GetModulus());
+    OPENFHE_DEBUG("n " << n);
+    OPENFHE_DEBUG("n mod " << n.GetModulus());
 
     V calculatedResult = m.ModAdd(n);
 
-    DEBUG("result mod " << calculatedResult.GetModulus());
+    OPENFHE_DEBUG("result mod " << calculatedResult.GetModulus());
     uint64_t expectedResult[5] = {604, 573, 141, 291, 604};
 
     for (usint i = 0; i < 5; i++) {
@@ -474,7 +474,7 @@ TEST(UTBinVect, modadd_vector_result_greater_modulus) {
 */
 template <typename V>
 void method_add_equals_vector_operation(const std::string& msg) {
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
     typename V::Integer q("657");
     // calling constructor to create a vector of length 5 and passing value of q
     V m(5, q);
@@ -489,11 +489,11 @@ void method_add_equals_vector_operation(const std::string& msg) {
     n.at(3) = typename V::Integer("33");
     n.at(4) = typename V::Integer("7");
 
-    DEBUG("m " << m);
-    DEBUG("n " << n);
+    OPENFHE_DEBUG("m " << m);
+    OPENFHE_DEBUG("n " << n);
 
     m += n;
-    DEBUG("m" << m);
+    OPENFHE_DEBUG("m" << m);
     uint64_t expectedResult[5] = {17, 632, 21, 405, 598};
 
     for (usint i = 0; i < 5; i++) {

--- a/src/core/unittest/UnitTestCommonElements.cpp
+++ b/src/core/unittest/UnitTestCommonElements.cpp
@@ -54,7 +54,7 @@ using namespace lbcrypto;
 
 template <typename Element>
 static void common_basic_ops(const std::string& msg) {
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
     // using VecType = typename Element::Vector;
     using ParmType = typename Element::Params;
     // using IntType = typename Element::Vector::Integer;
@@ -82,17 +82,17 @@ static void common_basic_ops(const std::string& msg) {
     // ElemParamFactory::GenElemParams<ParmType>(m,60,2);
 
     // GenerateDCRTParams<typename Element::Integer>(8, 3, 20) );
-    DEBUGEXP(*ilparams);
+    OPENFHE_DEBUGEXP(*ilparams);
     Element ilvector2n1(ilparams);
     ilvector2n1 = {"1", "2", "0", "1"};
     // test for bug where length was 0
     EXPECT_EQ(ilvector2n1.GetLength(), m / 2) << msg << " Failure: ={init list string}";
 
-    DEBUGEXP(ilvector2n1);
+    OPENFHE_DEBUGEXP(ilvector2n1);
     Element ilvector2n2(ilparams);
     ilvector2n2 = {1, 2, 0, 1};
     EXPECT_EQ(ilvector2n2.GetLength(), m / 2) << msg << " Failure: ={init list int}";
-    DEBUGEXP(ilvector2n2);
+    OPENFHE_DEBUGEXP(ilvector2n2);
 
     // test ctor(ilparams), ==
     EXPECT_EQ(ilvector2n1, ilvector2n2) << msg << " Failure:  ctor(ilparams) or op ==";
@@ -106,28 +106,28 @@ static void common_basic_ops(const std::string& msg) {
         Element ilv1 = ilvector2n1;
         EXPECT_EQ(ilvector2n1, ilv1) << msg << " Failure: op=";
     }
-    DEBUGEXP(ilvector2n1);
+    OPENFHE_DEBUGEXP(ilvector2n1);
     // TODO move += -= to arithmetic ops
     {  // test operator-=
         Element ilv1 = ilvector2n1;
-        DEBUGEXP(ilvector2n1);
-        DEBUGEXP(ilv1);
+        OPENFHE_DEBUGEXP(ilvector2n1);
+        OPENFHE_DEBUGEXP(ilv1);
         Element zero(ilparams);
         zero = {0, 0, 0, 0};
-        DEBUGEXP(zero);
+        OPENFHE_DEBUGEXP(zero);
         ilv1 -= ilvector2n1;
-        DEBUGEXP(ilv1);
+        OPENFHE_DEBUGEXP(ilv1);
         EXPECT_EQ(zero, ilv1) << msg << "Failure: Operator-=";
 
         // test !=
         EXPECT_NE(ilvector2n1, zero) << msg << " Failure: Operator!= value comparison";
-        DEBUGEXP(ilvector2n1);
-        DEBUGEXP(ilv1);
+        OPENFHE_DEBUGEXP(ilvector2n1);
+        OPENFHE_DEBUGEXP(ilv1);
     }
 
     {  // test operator+=
         Element ilv1 = ilvector2n1;
-        DEBUGEXP(ilv1);
+        OPENFHE_DEBUGEXP(ilv1);
         Element two(ilparams);
         two = {2, 2, 2, 2};
         ilv1 += ilvector2n1;
@@ -146,7 +146,7 @@ TEST(UTDCRTPoly, common_basic_ops) {
 // template for common_set_format()
 template <typename Element>
 void common_set_format(const std::string& msg) {
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
     using VecType  = typename Element::Vector;
     using ParmType = typename Element::Params;
 
@@ -165,12 +165,12 @@ void common_set_format(const std::string& msg) {
 
     Element ilvector2n(ilparams, Format::COEFFICIENT);
     ilvector2n = {"3", "0", "0", "0"};
-    DEBUGEXP(ilvector2n);
+    OPENFHE_DEBUGEXP(ilvector2n);
     // test for bug where length was 0
     EXPECT_EQ(ilvector2n.GetLength(), m / 2) << msg << " Failure: ={init list string}";
     Element ilvector2nInEval(ilparams, Format::EVALUATION);
     ilvector2nInEval = {"3", "3", "3", "3"};
-    DEBUGEXP(ilvector2nInEval);
+    OPENFHE_DEBUGEXP(ilvector2nInEval);
     {  // test SetFormat()
         Element ilv(ilvector2n);
 
@@ -195,7 +195,7 @@ TEST(UTDCRTPoly, common_set_format) {
 // template for common_setters_getters()
 template <typename Element>
 void common_setters_getters(const std::string& msg) {
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
     using VecType  = typename Element::Vector;
     using ParmType = typename Element::Params;
 
@@ -211,8 +211,8 @@ void common_setters_getters(const std::string& msg) {
         ilvector2n = {"1", "2", "0", "1"};
         Element bbv(ilparams);
         bbv = {"1", "2", "0", "1"};
-        DEBUGEXP(ilvector2n);
-        DEBUGEXP(bbv);
+        OPENFHE_DEBUGEXP(ilvector2n);
+        OPENFHE_DEBUGEXP(bbv);
 
         // test for bug where length was 0
         EXPECT_EQ(ilvector2n.GetLength(), m / 2) << msg << " Failure: ={init list string}";
@@ -237,7 +237,7 @@ TEST(UTDCRTPoly, common_setters_getters) {
 // template for common_binary_ops()
 template <typename Element>
 void common_binary_ops(const std::string& msg) {
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
     using VecType  = typename Element::Vector;
     using ParmType = typename Element::Params;
     using IntType  = typename Element::Vector::Integer;
@@ -254,35 +254,35 @@ void common_binary_ops(const std::string& msg) {
 
     Element ilvector2n1(ilparams);
     ilvector2n1 = {"2", "1", "1", "1"};
-    DEBUGEXP(ilvector2n1);
+    OPENFHE_DEBUGEXP(ilvector2n1);
 
     // test for bug where length was 0
     EXPECT_EQ(ilvector2n1.GetLength(), m / 2) << msg << " Failure: ={init list string}";
 
     Element ilvector2n2(ilparams);
     ilvector2n2 = {"1", "0", "1", "1"};
-    DEBUGEXP(ilvector2n2);
+    OPENFHE_DEBUGEXP(ilvector2n2);
 
     Element ilvector2n3(ilparams, Format::COEFFICIENT);
     ilvector2n3 = {"2", "1", "1", "1"};
-    DEBUGEXP(ilvector2n3);
+    OPENFHE_DEBUGEXP(ilvector2n3);
 
     Element ilvector2n4(ilparams, Format::COEFFICIENT);
     ilvector2n4 = {"1", "0", "1", "1"};
-    DEBUGEXP(ilvector2n4);
+    OPENFHE_DEBUGEXP(ilvector2n4);
 
     {  // test Plus
         Element ilv1(ilvector2n1);
-        DEBUGEXP(ilv1);
+        OPENFHE_DEBUGEXP(ilv1);
         Element ilv2 = ilv1.Plus(ilvector2n2);
-        DEBUGEXP(ilv2);
+        OPENFHE_DEBUGEXP(ilv2);
         Element expected(ilparams, Format::EVALUATION);
         expected = {"3", "1", "2", "2"};
         EXPECT_EQ(expected, ilv2) << msg << " Failure: Plus()";
     }
     {  // test Minus
         Element ilv1(ilvector2n1);
-        DEBUGEXP(ilv1);
+        OPENFHE_DEBUGEXP(ilv1);
         Element ilv2 = ilv1.Minus(ilvector2n2);
         Element expected(ilparams, Format::EVALUATION);
         expected = {"1", "1", "0", "0"};
@@ -291,7 +291,7 @@ void common_binary_ops(const std::string& msg) {
 
     {  // test times
         Element ilv1(ilvector2n1);
-        DEBUGEXP(ilv1);
+        OPENFHE_DEBUGEXP(ilv1);
         Element ilv2 = ilv1.Times(ilvector2n2);
         Element expected(ilparams, Format::EVALUATION);
         expected = {"2", "0", "1", "1"};
@@ -300,17 +300,17 @@ void common_binary_ops(const std::string& msg) {
 
     {  // test SwitchFormat()
         ilvector2n3.SwitchFormat();
-        DEBUGEXP(ilvector2n3);
+        OPENFHE_DEBUGEXP(ilvector2n3);
         ilvector2n4.SwitchFormat();
-        DEBUGEXP(ilvector2n4);
+        OPENFHE_DEBUGEXP(ilvector2n4);
 
         Element ilv3(ilvector2n3);
         Element ilv4 = ilv3.Times(ilvector2n4);
-        DEBUGEXP(ilv3);
-        DEBUGEXP(ilv4);
+        OPENFHE_DEBUGEXP(ilv3);
+        OPENFHE_DEBUGEXP(ilv4);
 
         ilv4.SwitchFormat();
-        DEBUGEXP(ilv4);
+        OPENFHE_DEBUGEXP(ilv4);
         Element expected(ilparams, Format::COEFFICIENT);
         std::stringstream tmpstr;
         tmpstr << (ilv4.GetModulus() - IntType(1));
@@ -460,7 +460,7 @@ void common_other_methods(const std::string& msg) {
     using VecType  = typename Element::Vector;
     using ParmType = typename Element::Params;
 
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
     usint m = 8;
     typename VecType::Integer primeModulus("73");
     typename VecType::Integer primitiveRootOfUnity("22");
@@ -472,7 +472,7 @@ void common_other_methods(const std::string& msg) {
     // test for bug where length was 0
     EXPECT_EQ(ilvector2n.GetLength(), m / 2) << msg << " Failure: ={init list string}";
 
-    DEBUG("AddILElementOne");
+    OPENFHE_DEBUG("AddILElementOne");
     {
         Element ilv(ilvector2n);
 
@@ -482,7 +482,7 @@ void common_other_methods(const std::string& msg) {
         EXPECT_EQ(expected, ilv) << msg << " Failure: AddILElementOne()";
     }
 
-    DEBUG("ModByTwo");
+    OPENFHE_DEBUG("ModByTwo");
     {
         Element ilv(ilvector2n);
         ilv = ilv.ModByTwo();
@@ -491,7 +491,7 @@ void common_other_methods(const std::string& msg) {
         EXPECT_EQ(expected, ilv) << msg << " Failure: ModByTwo()";
     }
 
-    DEBUG("MakeSparse(2)");
+    OPENFHE_DEBUG("MakeSparse(2)");
     {
         Element ilv(ilvector2n);
         ilv.MakeSparse(2);
@@ -506,7 +506,7 @@ void common_other_methods(const std::string& msg) {
         EXPECT_EQ(expected, ilv1) << msg << " Failure: MakeSparse(3)";
     }
 
-    DEBUG("InverseExists");
+    OPENFHE_DEBUG("InverseExists");
     {
         Element ilv(ilparams, Format::COEFFICIENT);
         ilv = {"2", "4", "3", "2"};

--- a/src/core/unittest/UnitTestDCRTElements.cpp
+++ b/src/core/unittest/UnitTestDCRTElements.cpp
@@ -52,7 +52,7 @@ void testDCRTPolyConstructorNegative(std::vector<NativePoly>& towers);
 
 template <typename Element>
 void DCRT_constructors(const std::string& msg) {
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
     usint m         = 8;
     usint towersize = 3;
 
@@ -88,7 +88,7 @@ void DCRT_constructors(const std::string& msg) {
     ilvector2nVector.push_back(ilv1);
     ilvector2nVector.push_back(ilv2);
 
-    DEBUG("1");
+    OPENFHE_DEBUG("1");
     float stdDev = 4.0;
     typename Element::DggType dgg(stdDev);
 
@@ -101,17 +101,17 @@ void DCRT_constructors(const std::string& msg) {
         EXPECT_EQ(towersize, ilva.GetNumOfElements()) << msg << " Failure: ildcrtparams ctor ilva.GetNumOfElements()";
     }
 
-    DEBUG("2");
+    OPENFHE_DEBUG("2");
     {
         Element ilva(ilvector2nVector);
 
-        DEBUG("2.0");
+        OPENFHE_DEBUG("2.0");
         EXPECT_EQ(Format::EVALUATION, ilva.GetFormat()) << msg << " Failure: ctor ilva.GetFormat()";
         EXPECT_EQ(modulus, ilva.GetModulus()) << msg << " Failure: ctor ilva.GetModulus()";
         EXPECT_EQ(m, ilva.GetCyclotomicOrder()) << msg << " Failure: ctor ilva.GetCyclotomicOrder()";
         EXPECT_EQ(towersize, ilva.GetNumOfElements()) << msg << " Failure: ctor ilva.GetNumOfElements()";
 
-        DEBUG("2.1");
+        OPENFHE_DEBUG("2.1");
         std::vector<NativePoly> ilvector2nVectorInconsistent(towersize);
         auto ilparamsNegativeTestCase =
             std::make_shared<ILNativeParams>(128, NativeInteger("1231"), NativeInteger("213"));
@@ -120,15 +120,15 @@ void DCRT_constructors(const std::string& msg) {
         ilvector2nVectorInconsistent[1] = ilv1;
         ilvector2nVectorInconsistent[2] = ilv2;
 
-        DEBUG("2.2");
+        OPENFHE_DEBUG("2.2");
         for (size_t ii = 0; ii < ilvector2nVectorInconsistent.size(); ii++) {
-            DEBUG(ii << " item " << ilvector2nVectorInconsistent.at(ii).GetParams().use_count());
+            OPENFHE_DEBUG(ii << " item " << ilvector2nVectorInconsistent.at(ii).GetParams().use_count());
         }
         EXPECT_THROW(testDCRTPolyConstructorNegative(ilvector2nVectorInconsistent), math_error)
             << msg << " Failure: ilvector2nVectorInconsistent";
     }
 
-    DEBUG("4");
+    OPENFHE_DEBUG("4");
     {
         Element ilva0;
         Element ilva1(ildcrtparams);
@@ -163,9 +163,9 @@ void DCRT_constructors(const std::string& msg) {
         }
     }
 
-    DEBUG("5");
+    OPENFHE_DEBUG("5");
     {
-        DEBUG("ild mod " << ildcrtparams->GetModulus());
+        OPENFHE_DEBUG("ild mod " << ildcrtparams->GetModulus());
         Element ilva(dgg, ildcrtparams);
 
         EXPECT_EQ(Format::EVALUATION, ilva.GetFormat()) << msg << " Failure: ctor(dgg, ldcrtparams) ilva.GetFormat()";
@@ -175,7 +175,7 @@ void DCRT_constructors(const std::string& msg) {
             << msg << " Failure: ctor(dgg, ildcrtparams) ilva.GetNumOfElements()";
     }
 
-    DEBUG("6");
+    OPENFHE_DEBUG("6");
     {
         Element ilva(dgg, ildcrtparams);
         Element ilvaClone(ilva.CloneParametersOnly());

--- a/src/core/unittest/UnitTestDistrGen.cpp
+++ b/src/core/unittest/UnitTestDistrGen.cpp
@@ -251,7 +251,7 @@ void testParallelDiscreteUniformGenerator(typename V::Integer& modulus, std::str
     usint size                  = 50000;
     // usint size = omp_get_max_threads() * 4;
 
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
     std::vector<typename V::Integer> randBigVector;
     #pragma omp parallel  // this is executed in parallel
     {
@@ -272,10 +272,10 @@ void testParallelDiscreteUniformGenerator(typename V::Integer& modulus, std::str
         for (int i = 0; i < omp_get_num_threads(); i++) {
     #pragma omp ordered
             {
-                DEBUG("thread #" << omp_get_thread_num() << " moving " << (int)randBigVectorPvt.size()
+                OPENFHE_DEBUG("thread #" << omp_get_thread_num() << " moving " << (int)randBigVectorPvt.size()
                                  << " to starting point " << (int)randBigVector.size());
                 randBigVector.insert(randBigVector.end(), randBigVectorPvt.begin(), randBigVectorPvt.end());
-                DEBUG("thread #" << omp_get_thread_num() << " moved");
+                OPENFHE_DEBUG("thread #" << omp_get_thread_num() << " moved");
             }
         }
     }
@@ -484,7 +484,7 @@ TEST(UTDistrGen, DiscreteGaussianGenerator) {
 template <typename V>
 void ParallelDiscreteGaussianGenerator_VERY_LONG(const std::string& msg) {
     // mean test
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
 
     {
         int stdev  = 5;
@@ -511,7 +511,7 @@ void ParallelDiscreteGaussianGenerator_VERY_LONG(const std::string& msg) {
             for (int i = 0; i < omp_get_num_threads(); i++) {
     #pragma omp ordered
                 {
-                    DEBUG("thread #" << omp_get_thread_num() << " "
+                    OPENFHE_DEBUG("thread #" << omp_get_thread_num() << " "
                                      << "moving " << (int)dggCharVectorPvt.size() << " to starting point"
                                      << (int)dggCharVector.size());
                     dggCharVector.insert(dggCharVector.end(), dggCharVectorPvt.begin(), dggCharVectorPvt.end());
@@ -555,7 +555,7 @@ void ParallelDiscreteGaussianGenerator_VERY_LONG(const std::string& msg) {
             for (int i = 0; i < omp_get_num_threads(); i++) {
     #pragma omp ordered
                 {
-                    DEBUG("thread #" << omp_get_thread_num() << " "
+                    OPENFHE_DEBUG("thread #" << omp_get_thread_num() << " "
                                      << "moving " << (int)dggBigVectorPvt.size() << " to starting point"
                                      << (int)dggBigVector.size());
                     dggBigVector.insert(dggBigVector.end(), dggBigVectorPvt.begin(), dggBigVectorPvt.end());

--- a/src/core/unittest/UnitTestField2n.cpp
+++ b/src/core/unittest/UnitTestField2n.cpp
@@ -42,41 +42,41 @@ using namespace lbcrypto;
 
 // TEST FOR GETTER FOR FORMAT
 TEST(UTField2n, get_format) {
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
 
-    DEBUG("Step 1");
+    OPENFHE_DEBUG("Step 1");
     Field2n test(2, Format::COEFFICIENT, true);
-    DEBUG("Step 2");
+    OPENFHE_DEBUG("Step 2");
     EXPECT_EQ(Format::COEFFICIENT, test.GetFormat()) << "Failed getter" << std::endl;
 }
 
 // TEST FOR INVERSE OF FIELD ELEMENT
 TEST(UTField2n, inverse) {
-    DEBUG_FLAG(false);
-    DEBUG("Step 1");
+    OPENFHE_DEBUG_FLAG(false);
+    OPENFHE_DEBUG("Step 1");
     Field2n test(2, Format::EVALUATION, true);
     test.at(0) = std::complex<double>(2, 1);
     test.at(1) = std::complex<double>(-4, -2);
-    DEBUG("Step 2");
+    OPENFHE_DEBUG("Step 2");
     Field2n inverse(2, Format::EVALUATION, true);
     inverse.at(0) = std::complex<double>(0.4, -0.2);
     inverse.at(1) = std::complex<double>(-0.2, 0.1);
-    DEBUG("Step 3");
+    OPENFHE_DEBUG("Step 3");
     EXPECT_EQ(inverse, test.Inverse());
 }
 
 // TEST FOR ADDITION OPERATION
 TEST(UTField2n, plus) {
-    DEBUG_FLAG(false);
-    DEBUG("Step 1");
+    OPENFHE_DEBUG_FLAG(false);
+    OPENFHE_DEBUG("Step 1");
     Field2n a(2, Format::EVALUATION, true);
     a.at(0) = std::complex<double>(2, 1);
     a.at(1) = std::complex<double>(-4, 2);
-    DEBUG("Step 2");
+    OPENFHE_DEBUG("Step 2");
     Field2n b(2, Format::EVALUATION, true);
     b.at(0) = std::complex<double>(3, -0.1);
     b.at(1) = std::complex<double>(-4, 3.2);
-    DEBUG("Step 3");
+    OPENFHE_DEBUG("Step 3");
     Field2n c(2, Format::EVALUATION, true);
     c.at(0) = std::complex<double>(5, 0.9);
     c.at(1) = std::complex<double>(-8, 5.2);
@@ -85,14 +85,14 @@ TEST(UTField2n, plus) {
 
 // TEST FOR SCALAR ADDITION
 TEST(UTField2n, scalar_plus) {
-    DEBUG_FLAG(false);
-    DEBUG("Step 1");
+    OPENFHE_DEBUG_FLAG(false);
+    OPENFHE_DEBUG("Step 1");
     Field2n a(2, Format::COEFFICIENT, true);
     a.at(0) = std::complex<double>(2, 0);
     a.at(1) = std::complex<double>(-4, 0);
-    DEBUG("Step 2");
+    OPENFHE_DEBUG("Step 2");
     double b = 3.2;
-    DEBUG("Step 3");
+    OPENFHE_DEBUG("Step 3");
     Field2n c(2, Format::COEFFICIENT, true);
     c.at(0) = std::complex<double>(5.2, 0);
     c.at(1) = std::complex<double>(-4, 0);
@@ -101,16 +101,16 @@ TEST(UTField2n, scalar_plus) {
 
 // TEST FOR SUBSTRACTION OPERATION
 TEST(UTField2n, minus) {
-    DEBUG_FLAG(false);
-    DEBUG("Step 1");
+    OPENFHE_DEBUG_FLAG(false);
+    OPENFHE_DEBUG("Step 1");
     Field2n a(2, Format::EVALUATION, true);
     a.at(0) = std::complex<double>(2, 1);
     a.at(1) = std::complex<double>(-4, 2);
-    DEBUG("Step 2");
+    OPENFHE_DEBUG("Step 2");
     Field2n b(2, Format::EVALUATION, true);
     b.at(0) = std::complex<double>(3, -0.1);
     b.at(1) = std::complex<double>(-4, 3.2);
-    DEBUG("Step 3");
+    OPENFHE_DEBUG("Step 3");
     Field2n c(2, Format::EVALUATION, true);
     c.at(0) = std::complex<double>(-1, 1.1);
     c.at(1) = std::complex<double>(0, -1.2);
@@ -124,20 +124,20 @@ TEST(UTField2n, minus) {
 
 // TEST FOR MULTIPLICATION OPERATION
 TEST(UTField2n, times) {
-    DEBUG_FLAG(false);
-    DEBUG("Step 1");
+    OPENFHE_DEBUG_FLAG(false);
+    OPENFHE_DEBUG("Step 1");
     Field2n a(2, Format::EVALUATION, true);
     a.at(0) = std::complex<double>(4, 3);
     a.at(1) = std::complex<double>(6, -3);
-    DEBUG("Step 2");
+    OPENFHE_DEBUG("Step 2");
     Field2n b(2, Format::EVALUATION, true);
     b.at(0) = std::complex<double>(4, -3);
     b.at(1) = std::complex<double>(4, -2.8);
-    DEBUG("Step 3");
+    OPENFHE_DEBUG("Step 3");
     Field2n c(2, Format::EVALUATION, true);
     c.at(0) = std::complex<double>(25, 0);
     c.at(1) = std::complex<double>(15.6, -28.8);
-    DEBUG("Step 4");
+    OPENFHE_DEBUG("Step 4");
     Field2n d = a.Times(b);
     for (int i = 0; i < 2; i++) {
         EXPECT_LE(fabs(d.at(i).real() - c.at(i).real()), fabs(c.at(i).real()) * 0.00001);
@@ -148,26 +148,26 @@ TEST(UTField2n, times) {
 // TEST FOR MULTIPLICATION OPERATION WITH SWITCH FORMAT
 TEST(UTField2n, times_with_switch) {
     DiscreteFourierTransform::PreComputeTable(8);
-    DEBUG_FLAG(false);
-    DEBUG("Step 1");
+    OPENFHE_DEBUG_FLAG(false);
+    OPENFHE_DEBUG("Step 1");
     Field2n a(4, Format::COEFFICIENT, true);
     a.at(0) = std::complex<double>(1, 0);
     a.at(1) = std::complex<double>(1, 0);
     a.at(2) = std::complex<double>(1, 0);
     a.at(3) = std::complex<double>(1, 0);
-    DEBUG("Step 2");
+    OPENFHE_DEBUG("Step 2");
     Field2n b(4, Format::COEFFICIENT, true);
     b.at(0) = std::complex<double>(1, 0);
     b.at(1) = std::complex<double>(0, 0);
     b.at(2) = std::complex<double>(1, 0);
     b.at(3) = std::complex<double>(0, 0);
-    DEBUG("Step 3");
+    OPENFHE_DEBUG("Step 3");
     Field2n c(4, Format::COEFFICIENT, true);
     c.at(0) = std::complex<double>(0, 0);
     c.at(1) = std::complex<double>(0, 0);
     c.at(2) = std::complex<double>(2, 0);
     c.at(3) = std::complex<double>(2, 0);
-    DEBUG("Step 4");
+    OPENFHE_DEBUG("Step 4");
     a.SwitchFormat();
     b.SwitchFormat();
     Field2n d = a.Times(b);
@@ -180,47 +180,47 @@ TEST(UTField2n, times_with_switch) {
 
 // TEST FOR SHIFT RIGHT OPERATION
 TEST(UTField2n, shift_right) {
-    DEBUG_FLAG(false);
-    DEBUG("Step 1");
+    OPENFHE_DEBUG_FLAG(false);
+    OPENFHE_DEBUG("Step 1");
     Field2n a(4, Format::COEFFICIENT, true);
     a.at(0) = std::complex<double>(4, 0);
     a.at(1) = std::complex<double>(3, 0);
     a.at(2) = std::complex<double>(2, 0);
     a.at(3) = std::complex<double>(1, 0);
-    DEBUG("Step 2");
+    OPENFHE_DEBUG("Step 2");
     Field2n b(4, Format::COEFFICIENT, true);
     b.at(0) = std::complex<double>(-1, 0);
     b.at(1) = std::complex<double>(4, 0);
     b.at(2) = std::complex<double>(3, 0);
     b.at(3) = std::complex<double>(2, 0);
-    DEBUG("Step 3");
+    OPENFHE_DEBUG("Step 3");
     EXPECT_EQ(b, a.ShiftRight());
 }
 
 // TEST FOR TRANSPOSE OPERATION
 TEST(UTField2n, transpose) {
-    DEBUG_FLAG(false);
-    DEBUG("Step 1");
+    OPENFHE_DEBUG_FLAG(false);
+    OPENFHE_DEBUG("Step 1");
     Field2n a(4, Format::COEFFICIENT, true);
     a.at(0) = std::complex<double>(4, 0);
     a.at(1) = std::complex<double>(3, 0);
     a.at(2) = std::complex<double>(2, 0);
     a.at(3) = std::complex<double>(1, 0);
-    DEBUG("Step 2");
+    OPENFHE_DEBUG("Step 2");
     Field2n b(4, Format::COEFFICIENT, true);
     b.at(0) = std::complex<double>(4, 0);
     b.at(1) = std::complex<double>(-1, 0);
     b.at(2) = std::complex<double>(-2, 0);
     b.at(3) = std::complex<double>(-3, 0);
-    DEBUG("Step 3");
+    OPENFHE_DEBUG("Step 3");
     EXPECT_EQ(b, a.Transpose());
 }
 
 // TEST FOR TRANSPOSE OPERATION
 TEST(UTField2n, transpose_eval) {
     DiscreteFourierTransform::PreComputeTable(8);
-    DEBUG_FLAG(false);
-    DEBUG("Step 1");
+    OPENFHE_DEBUG_FLAG(false);
+    OPENFHE_DEBUG("Step 1");
     Field2n a(4, Format::COEFFICIENT, true);
     a.at(0) = std::complex<double>(4, 0);
     a.at(1) = std::complex<double>(3, 0);
@@ -231,13 +231,13 @@ TEST(UTField2n, transpose_eval) {
     a = a.Transpose();
     // back to Format::COEFFICIENT representation
     a.SwitchFormat();
-    DEBUG("Step 2");
+    OPENFHE_DEBUG("Step 2");
     Field2n b(4, Format::COEFFICIENT, true);
     b.at(0) = std::complex<double>(4, 0);
     b.at(1) = std::complex<double>(-1, 0);
     b.at(2) = std::complex<double>(-2, 0);
     b.at(3) = std::complex<double>(-3, 0);
-    DEBUG("Step 3");
+    OPENFHE_DEBUG("Step 3");
     for (int i = 0; i < 4; i++) {
         EXPECT_LE(fabs(b.at(i).real() - a.at(i).real()), fabs(b.at(i).real()) * 0.0001);
     }
@@ -247,8 +247,8 @@ TEST(UTField2n, transpose_eval) {
 // TEST FOR AUTOMORPHISM OPERATION
 TEST(UTField2n, automorphism) {
     DiscreteFourierTransform::PreComputeTable(8);
-    DEBUG_FLAG(false);
-    DEBUG("Step 1");
+    OPENFHE_DEBUG_FLAG(false);
+    OPENFHE_DEBUG("Step 1");
     Field2n a(4, Format::COEFFICIENT, true);
     a.at(0) = std::complex<double>(1, 0);
     a.at(1) = std::complex<double>(2, 0);
@@ -257,13 +257,13 @@ TEST(UTField2n, automorphism) {
     a.SwitchFormat();
     a = a.AutomorphismTransform(3);
     a.SwitchFormat();
-    DEBUG("Step 2");
+    OPENFHE_DEBUG("Step 2");
     Field2n b(4, Format::COEFFICIENT, true);
     b.at(0) = std::complex<double>(1, 0);
     b.at(1) = std::complex<double>(4, 0);
     b.at(2) = std::complex<double>(-3, 0);
     b.at(3) = std::complex<double>(2, 0);
-    DEBUG("Step 3");
+    OPENFHE_DEBUG("Step 3");
     for (int i = 0; i < 4; i++) {
         EXPECT_LE(fabs(b.at(i).real() - a.at(i).real()), fabs(b.at(i).real()) * 0.0001);
     }
@@ -272,100 +272,100 @@ TEST(UTField2n, automorphism) {
 
 // TEST FOR EXTRACT ODD OPERATION
 TEST(UTField2n, extract_odd) {
-    DEBUG_FLAG(false);
-    DEBUG("Step 1");
+    OPENFHE_DEBUG_FLAG(false);
+    OPENFHE_DEBUG("Step 1");
     Field2n a(4, Format::COEFFICIENT, true);
     a.at(0) = std::complex<double>(4, 0);
     a.at(1) = std::complex<double>(3, 0);
     a.at(2) = std::complex<double>(2, 0);
     a.at(3) = std::complex<double>(1, 0);
-    DEBUG("Step 2");
+    OPENFHE_DEBUG("Step 2");
     Field2n b(2, Format::COEFFICIENT, true);
     b.at(0) = std::complex<double>(3, 0);
     b.at(1) = std::complex<double>(1, 0);
-    DEBUG("Step 3");
+    OPENFHE_DEBUG("Step 3");
     EXPECT_EQ(b, a.ExtractOdd());
 }
 
 // TEST FOR EXTRACT EVEN OPERATION
 TEST(UTField2n, extract_even) {
-    DEBUG_FLAG(false);
-    DEBUG("Step 1");
+    OPENFHE_DEBUG_FLAG(false);
+    OPENFHE_DEBUG("Step 1");
     Field2n a(4, Format::COEFFICIENT, true);
     a.at(0) = std::complex<double>(4, 0);
     a.at(1) = std::complex<double>(3, 0);
     a.at(2) = std::complex<double>(2, 0);
     a.at(3) = std::complex<double>(1, 0);
-    DEBUG("Step 2");
+    OPENFHE_DEBUG("Step 2");
     Field2n b(2, Format::COEFFICIENT, true);
     b.at(0) = std::complex<double>(4, 0);
     b.at(1) = std::complex<double>(2, 0);
-    DEBUG("Step 3");
+    OPENFHE_DEBUG("Step 3");
     EXPECT_EQ(b, a.ExtractEven());
 }
 
 // TEST FOR PERMUTE OPERATION
 TEST(UTField2n, permute) {
-    DEBUG_FLAG(false);
-    DEBUG("Step 1");
+    OPENFHE_DEBUG_FLAG(false);
+    OPENFHE_DEBUG("Step 1");
     Field2n a(4, Format::COEFFICIENT, true);
     a.at(0) = std::complex<double>(1, 0);
     a.at(1) = std::complex<double>(2, 0);
     a.at(2) = std::complex<double>(3, 0);
     a.at(3) = std::complex<double>(4, 0);
-    DEBUG("Step 2");
+    OPENFHE_DEBUG("Step 2");
     Field2n b(4, Format::COEFFICIENT, true);
     b.at(0) = std::complex<double>(1, 0);
     b.at(1) = std::complex<double>(3, 0);
     b.at(2) = std::complex<double>(2, 0);
     b.at(3) = std::complex<double>(4, 0);
-    DEBUG("Step 3");
+    OPENFHE_DEBUG("Step 3");
     EXPECT_EQ(b, a.Permute());
 }
 
 // TEST FOR INVERSE PERMUTE OPERATION
 TEST(UTField2n, inverse_permute) {
-    DEBUG_FLAG(false);
-    DEBUG("Step 1");
+    OPENFHE_DEBUG_FLAG(false);
+    OPENFHE_DEBUG("Step 1");
     Field2n a(4, Format::COEFFICIENT, true);
     a.at(0) = std::complex<double>(1, 0);
     a.at(1) = std::complex<double>(3, 0);
     a.at(2) = std::complex<double>(2, 0);
     a.at(3) = std::complex<double>(4, 0);
-    DEBUG("Step 2");
+    OPENFHE_DEBUG("Step 2");
     Field2n b(4, Format::COEFFICIENT, true);
     b.at(0) = std::complex<double>(1, 0);
     b.at(1) = std::complex<double>(2, 0);
     b.at(2) = std::complex<double>(3, 0);
     b.at(3) = std::complex<double>(4, 0);
-    DEBUG("Step 3");
+    OPENFHE_DEBUG("Step 3");
     EXPECT_EQ(b, a.InversePermute());
 }
 
 // TEST FOR SCALAR MULT OPERATION
 TEST(UTField2n, scalar_mult) {
-    DEBUG_FLAG(false);
-    DEBUG("Step 1");
+    OPENFHE_DEBUG_FLAG(false);
+    OPENFHE_DEBUG("Step 1");
     Field2n a(4, Format::EVALUATION, true);
     a.at(0) = std::complex<double>(1, -1);
     a.at(1) = std::complex<double>(3, -2);
     a.at(2) = std::complex<double>(2, -3);
     a.at(3) = std::complex<double>(4, -4);
-    DEBUG("Step 2");
+    OPENFHE_DEBUG("Step 2");
     Field2n b(4, Format::EVALUATION, true);
     b.at(0) = std::complex<double>(3, -3);
     b.at(1) = std::complex<double>(9, -6);
     b.at(2) = std::complex<double>(6, -9);
     b.at(3) = std::complex<double>(12, -12);
-    DEBUG("Step 3");
+    OPENFHE_DEBUG("Step 3");
     EXPECT_EQ(b, a.ScalarMult(3));
 }
 
 // TEST FOR Format::COEFFICIENT TO Format::EVALUATION FORMAT CHANGE
 TEST(UTField2n, COEFFICIENT_EVALUATION) {
     DiscreteFourierTransform::PreComputeTable(16);
-    DEBUG_FLAG(false);
-    DEBUG("Step 1");
+    OPENFHE_DEBUG_FLAG(false);
+    OPENFHE_DEBUG("Step 1");
     Field2n a(8, Format::COEFFICIENT, true);
     a.at(0) = std::complex<double>(4, 0);
     a.at(1) = std::complex<double>(5, 0);
@@ -375,7 +375,7 @@ TEST(UTField2n, COEFFICIENT_EVALUATION) {
     a.at(5) = std::complex<double>(7.1, 0);
     a.at(6) = std::complex<double>(6, 0);
     a.at(7) = std::complex<double>(3, 0);
-    DEBUG("Step 2");
+    OPENFHE_DEBUG("Step 2");
     Field2n b(8, Format::EVALUATION, true);
     b.at(0) = std::complex<double>(4.03087, 26.2795);
     b.at(1) = std::complex<double>(8.15172, 5.84489);
@@ -385,7 +385,7 @@ TEST(UTField2n, COEFFICIENT_EVALUATION) {
     b.at(5) = std::complex<double>(1.26249, -0.288539);
     b.at(6) = std::complex<double>(8.15172, -5.84489);
     b.at(7) = std::complex<double>(4.03087, -26.2795);
-    DEBUG("Step 3");
+    OPENFHE_DEBUG("Step 3");
     a.SwitchFormat();
     for (int i = 0; i < 8; i++) {
         EXPECT_LE(fabs(a.at(i).real() - b.at(i).real()), fabs(b.at(i).real()) * 0.0001);
@@ -397,8 +397,8 @@ TEST(UTField2n, COEFFICIENT_EVALUATION) {
 // TEST FOR Format::EVALUATION TO Format::COEFFICIENT FORMAT CHANGE
 TEST(UTField2n, EVALUATION_COEFFICIENT) {
     DiscreteFourierTransform::PreComputeTable(16);
-    DEBUG_FLAG(false);
-    DEBUG("Step 1");
+    OPENFHE_DEBUG_FLAG(false);
+    OPENFHE_DEBUG("Step 1");
     Field2n b(8, Format::EVALUATION, true);
     b.at(0) = std::complex<double>(4.03087, 26.2795);
     b.at(1) = std::complex<double>(8.15172, 5.84489);
@@ -408,7 +408,7 @@ TEST(UTField2n, EVALUATION_COEFFICIENT) {
     b.at(5) = std::complex<double>(1.26249, -0.288539);
     b.at(6) = std::complex<double>(8.15172, -5.84489);
     b.at(7) = std::complex<double>(4.03087, -26.2795);
-    DEBUG("Step 2");
+    OPENFHE_DEBUG("Step 2");
     Field2n a(8, Format::COEFFICIENT, true);
     a.at(0) = std::complex<double>(4, 0);
     a.at(1) = std::complex<double>(5, 0);
@@ -419,7 +419,7 @@ TEST(UTField2n, EVALUATION_COEFFICIENT) {
     a.at(6) = std::complex<double>(6, 0);
     a.at(7) = std::complex<double>(3, 0);
 
-    DEBUG("Step 3");
+    OPENFHE_DEBUG("Step 3");
     b.SwitchFormat();
     for (int i = 0; i < 8; i++) {
         EXPECT_LE(fabs(a.at(i).real() - b.at(i).real()), fabs(a.at(i).real()) * 0.0001);

--- a/src/core/unittest/UnitTestMatrix.cpp
+++ b/src/core/unittest/UnitTestMatrix.cpp
@@ -111,32 +111,32 @@ TEST(UTMatrix, basic_int_math) {
 
 template <typename V>
 void basic_intvec_math(const std::string& msg) {
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
 
     typename V::Integer modulus("67108913");
-    DEBUG("1");
+    OPENFHE_DEBUG("1");
     auto singleAlloc = [=]() {
         return V(1, modulus);
     };
-    DEBUG("2");
+    OPENFHE_DEBUG("2");
     Matrix<V> z(singleAlloc, 2, 2);
-    DEBUG("3");
+    OPENFHE_DEBUG("3");
     Matrix<V> n = Matrix<V>(singleAlloc, 2, 2).Ones();
-    DEBUG("4");
+    OPENFHE_DEBUG("4");
     Matrix<V> I = Matrix<V>(singleAlloc, 2, 2).Identity();
-    DEBUG("5");
-    DEBUG("z mod 00 " << z(0, 0).GetModulus().ToString());
-    DEBUG("z mod 01 " << z(0, 1).GetModulus().ToString());
-    DEBUG("z mod 10 " << z(1, 0).GetModulus().ToString());
-    DEBUG("z mod 1 1 " << z(1, 1).GetModulus().ToString());
-    DEBUG("n mod " << n(0, 0).GetModulus().ToString());
-    DEBUG("I mod " << I(0, 0).GetModulus().ToString());
+    OPENFHE_DEBUG("5");
+    OPENFHE_DEBUG("z mod 00 " << z(0, 0).GetModulus().ToString());
+    OPENFHE_DEBUG("z mod 01 " << z(0, 1).GetModulus().ToString());
+    OPENFHE_DEBUG("z mod 10 " << z(1, 0).GetModulus().ToString());
+    OPENFHE_DEBUG("z mod 1 1 " << z(1, 1).GetModulus().ToString());
+    OPENFHE_DEBUG("n mod " << n(0, 0).GetModulus().ToString());
+    OPENFHE_DEBUG("I mod " << I(0, 0).GetModulus().ToString());
     EXPECT_EQ(n, I * n) << msg;
-    DEBUG("6");
+    OPENFHE_DEBUG("6");
     n = n - n;
-    DEBUG("7");
+    OPENFHE_DEBUG("7");
     EXPECT_EQ(n, z) << msg;
-    DEBUG("8");
+    OPENFHE_DEBUG("8");
 }
 
 TEST(UTMatrix, basic_intvec_math) {
@@ -239,7 +239,7 @@ inline void expect_close(double a, double b) {
 }
 
 TEST(UTMatrix, cholesky) {
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
     Matrix<int32_t> m([]() { return 0; }, 2, 2);
     m(0, 0) = 20;
     m(0, 1) = 4;
@@ -247,7 +247,7 @@ TEST(UTMatrix, cholesky) {
     m(1, 1) = 10;
 
     auto c = Cholesky(m);
-    DEBUGEXP(c);
+    OPENFHE_DEBUGEXP(c);
     EXPECT_LE(fabs(4.47213595 - c(0, 0)), 1e-8);
     EXPECT_LE(fabs(0 - c(0, 1)), 1e-8);
     EXPECT_LE(fabs(.89442719 - c(1, 0)), 1e-8);
@@ -257,7 +257,7 @@ TEST(UTMatrix, cholesky) {
     EXPECT_LE(fabs(m(0, 1) - cc(0, 1)), 1e-8);
     EXPECT_LE(fabs(m(1, 0) - cc(1, 0)), 1e-8);
     EXPECT_LE(fabs(m(1, 1) - cc(1, 1)), 1e-8);
-    DEBUGEXP(cc);
+    OPENFHE_DEBUGEXP(cc);
 }
 
 template <typename Element>

--- a/src/core/unittest/UnitTestMubintvec.cpp
+++ b/src/core/unittest/UnitTestMubintvec.cpp
@@ -77,7 +77,7 @@ using namespace lbcrypto;
  *  TESTING BASIC METHODS OF mubintvec CLASS
  ************************************************/
 TEST(UTmubintvec, ctor_access_eq_neq) {
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
     // a bigger number
     bigintdyn::xubint q("1234567");
 
@@ -102,7 +102,7 @@ TEST(UTmubintvec, ctor_access_eq_neq) {
     m.at(3) = "2343";
     m.at(4) = "4624";
 
-    DEBUG("m " << m);
+    OPENFHE_DEBUG("m " << m);
     EXPECT_EQ(9868U, m.at(0).ConvertToInt<uint32_t>()) << "Failure in at(0)";
 
     // old fashioned way of expect
@@ -235,7 +235,7 @@ TEST(UTmubintvec, ctor_access_eq_neq) {
 }
 
 TEST(UTmubintvec, constructorTest) {
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
     bigintdyn::xmubintvec m(10);
 
     m.at(0) = "48";
@@ -249,14 +249,14 @@ TEST(UTmubintvec, constructorTest) {
     m.at(8) = "60";
     m.at(9) = "12";
 
-    DEBUG("m: " << m);
+    OPENFHE_DEBUG("m: " << m);
 
     uint64_t expectedResult[10] = {48,  53, 7,   178, 190,
                                    120, 79, 108, 60,  12};  // the expected values are stored as one dimensional
                                                             // integer array
 
     for (usint i = 0; i < 10; i++) {
-        DEBUG("val " << i << " is " << m.at(i));
+        OPENFHE_DEBUG("val " << i << " is " << m.at(i));
         EXPECT_EQ(expectedResult[i], (m.at(i)).ConvertToInt());
     }
 
@@ -297,13 +297,13 @@ TEST(UTmubintvec, mod) {
 }
 
 TEST(UTmubintvec, basic_vector_vector_mod_math_1_limb) {
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
 
     // q1 modulus 1:
     bigintdyn::xubint q1("163841");
     // a1:
     bigintdyn::xmubintvec a1(16, q1);
-    DEBUG("a1.modulus " << a1.GetModulus());
+    OPENFHE_DEBUG("a1.modulus " << a1.GetModulus());
     a1 = {
         "127753", "077706", "017133", "022582", "112132", "027625", "126773", "008924",
         "125972", "002551", "113837", "112045", "100953", "077352", "132013", "057029",
@@ -312,7 +312,7 @@ TEST(UTmubintvec, basic_vector_vector_mod_math_1_limb) {
     // b1:
     bigintdyn::xmubintvec b1;
     b1.SetModulus(q1);
-    DEBUG("b1.modulus " << b1.GetModulus());
+    OPENFHE_DEBUG("b1.modulus " << b1.GetModulus());
 
     b1 = {
         "066773", "069572", "142134", "141115", "123182", "155822", "128147", "094818",
@@ -327,7 +327,7 @@ TEST(UTmubintvec, basic_vector_vector_mod_math_1_limb) {
     };
 
     modadd1.SetModulus(a1);  // sets modadd1.modulus to the same as a1
-    DEBUG("modadd1.modulus " << modadd1.GetModulus());
+    OPENFHE_DEBUG("modadd1.modulus " << modadd1.GetModulus());
 
     // modsub1:
     std::vector<std::string> modsub1sv = {
@@ -350,9 +350,9 @@ TEST(UTmubintvec, basic_vector_vector_mod_math_1_limb) {
     c1 = a1.ModAdd(b1);
     EXPECT_EQ(c1, modadd1) << "Failure 1 limb vector vector ModAdd()";
 
-    DEBUG("modadd1 modulus" << modadd1.GetModulus());
-    DEBUG("c1 modulus" << c1.GetModulus());
-    DEBUG("c1 " << c1 << " modadd " << modadd1);
+    OPENFHE_DEBUG("modadd1 modulus" << modadd1.GetModulus());
+    OPENFHE_DEBUG("c1 modulus" << c1.GetModulus());
+    OPENFHE_DEBUG("c1 " << c1 << " modadd " << modadd1);
 
     c1 = a1 + b1;
     EXPECT_EQ(c1, modadd1) << "Failure 1 limb vector vector +";

--- a/src/core/unittest/UnitTestNbTheory.cpp
+++ b/src/core/unittest/UnitTestNbTheory.cpp
@@ -342,7 +342,7 @@ void method_primitive_root_of_unity_VERY_LONG(const std::string& msg) {
 
     // Exception handling
     {
-        DEBUG_FLAG(false);
+        OPENFHE_DEBUG_FLAG(false);
         int m = 32;
         T modulus1("67108913"), modulus2("17729"), modulus3("2097169"), modulus4("8353"), modulus5("8369");
 
@@ -369,8 +369,8 @@ void method_primitive_root_of_unity_VERY_LONG(const std::string& msg) {
             primitiveRootOfUnity2 = lbcrypto::RootOfUnity<T>(m, modulus2);)
             << msg << " RootOfUnity threw an error and should not have";
 
-        DEBUG("RootOfUnity for " << modulus1 << " is " << primitiveRootOfUnity1);
-        DEBUG("RootOfUnity for " << modulus2 << " is " << primitiveRootOfUnity2);
+        OPENFHE_DEBUG("RootOfUnity for " << modulus1 << " is " << primitiveRootOfUnity1);
+        OPENFHE_DEBUG("RootOfUnity for " << modulus2 << " is " << primitiveRootOfUnity2);
     }
 }
 

--- a/src/core/unittest/UnitTestPolyElements.cpp
+++ b/src/core/unittest/UnitTestPolyElements.cpp
@@ -55,7 +55,7 @@ using namespace lbcrypto;
 
 template <typename Element>
 void rounding_ops(const std::string& msg) {
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
     using VecType  = typename Element::Vector;
     using ParmType = typename Element::Params;
 
@@ -76,54 +76,54 @@ void rounding_ops(const std::string& msg) {
 
     Element ilvector2n1(ilparams, Format::COEFFICIENT);
     ilvector2n1 = {"31", "21", "15", "34"};
-    DEBUGEXP(ilvector2n1);
+    OPENFHE_DEBUGEXP(ilvector2n1);
     // test for bug where length was 0
     EXPECT_EQ(ilvector2n1.GetLength(), m / 2) << msg << " Failure: ={init list string}";
 
     Element ilvector2n2(ilparams, Format::COEFFICIENT);
     ilvector2n2 = {"21", "11", "35", "32"};
-    DEBUGEXP(ilvector2n2);
+    OPENFHE_DEBUGEXP(ilvector2n2);
 
-    DEBUG("unit test for MultiplyAndRound");
+    OPENFHE_DEBUG("unit test for MultiplyAndRound");
     Element roundingCorrect1(ilparams, Format::COEFFICIENT);
     roundingCorrect1 = {"3", "2", "2", "4"};
 
-    DEBUGEXP(ilvector2n1);
+    OPENFHE_DEBUGEXP(ilvector2n1);
 
     Element rounding1 = ilvector2n1.MultiplyAndRound(p, q);
 
     EXPECT_EQ(roundingCorrect1, rounding1) << msg << " Failure: Rounding p*polynomial/q";
 
-    DEBUG("unit test for MultiplyAndRound after a polynomial");
-    DEBUG("multiplication using the larger modulus");
+    OPENFHE_DEBUG("unit test for MultiplyAndRound after a polynomial");
+    OPENFHE_DEBUG("multiplication using the larger modulus");
 
     Element roundingCorrect2(ilparams2, Format::COEFFICIENT);
     roundingCorrect2 = {"16316", "16320", "60", "286"};
 
     ilvector2n1.SwitchModulus(q2, primitiveRootOfUnity2);
     ilvector2n2.SwitchModulus(q2, primitiveRootOfUnity2);
-    DEBUGEXP(ilvector2n1);
-    DEBUGEXP(ilvector2n2);
+    OPENFHE_DEBUGEXP(ilvector2n1);
+    OPENFHE_DEBUGEXP(ilvector2n2);
 
     ilvector2n1.SwitchFormat();
     ilvector2n2.SwitchFormat();
-    DEBUGEXP(ilvector2n1);
-    DEBUGEXP(ilvector2n2);
+    OPENFHE_DEBUGEXP(ilvector2n1);
+    OPENFHE_DEBUGEXP(ilvector2n2);
 
     Element rounding2 = ilvector2n1 * ilvector2n2;
 
-    DEBUGEXP(rounding2);
+    OPENFHE_DEBUGEXP(rounding2);
     rounding2.SwitchFormat();
-    DEBUGEXP(rounding2);
+    OPENFHE_DEBUGEXP(rounding2);
     rounding2 = rounding2.MultiplyAndRound(p, q);
-    DEBUGEXP(rounding2);
+    OPENFHE_DEBUGEXP(rounding2);
     EXPECT_EQ(roundingCorrect2, rounding2) << msg << " Failure: Rounding p*polynomial1*polynomial2/q";
 
-    DEBUG("makes sure the result is correct after");
-    DEBUG("going back to the original modulus");
+    OPENFHE_DEBUG("makes sure the result is correct after");
+    OPENFHE_DEBUG("going back to the original modulus");
 
     rounding2.SwitchModulus(q, primitiveRootOfUnity);
-    DEBUGEXP(rounding2);
+    OPENFHE_DEBUGEXP(rounding2);
 
     Element roundingCorrect3(ilparams, Format::COEFFICIENT);
     roundingCorrect3 = {"45", "49", "60", "67"};
@@ -145,7 +145,7 @@ TEST(UTDCRTPoly, rounding_ops) {
 // template for set_get_values()
 template <typename Element>
 void set_get_values(const std::string& msg) {
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
     using VecType  = typename Element::Vector;
     using ParmType = typename Element::Params;
 
@@ -160,7 +160,7 @@ void set_get_values(const std::string& msg) {
         VecType bbv(m / 2, primeModulus);
         bbv = {"3", "0", "0", "0"};
         ilvector2n.SetValues(bbv, Format::COEFFICIENT);
-        DEBUGEXP(ilvector2n);
+        OPENFHE_DEBUGEXP(ilvector2n);
         // test for bug where length was 0
         EXPECT_EQ(ilvector2n.GetLength(), m / 2) << msg << " Failure: ={init list string}";
 
@@ -180,8 +180,8 @@ void set_get_values(const std::string& msg) {
         ilvector2n = {"1", "2", "0", "1"};
         Element bbv(ilparams);
         bbv = {"1", "2", "0", "1"};
-        DEBUGEXP(ilvector2n);
-        DEBUGEXP(bbv);
+        OPENFHE_DEBUGEXP(ilvector2n);
+        OPENFHE_DEBUGEXP(bbv);
 
         EXPECT_EQ(bbv.GetValues(), ilvector2n.GetValues()) << msg << "Failure: GetValues()";
 
@@ -212,7 +212,7 @@ TEST(UTDCRTPoly, set_get_values) {
 // template for at()
 template <typename Element>
 void at(const std::string& msg) {
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
     using VecType  = typename Element::Vector;
     using ParmType = typename Element::Params;
 
@@ -228,8 +228,8 @@ void at(const std::string& msg) {
         ilvector2n = {"1", "2", "0", "1"};
         Element bbv(ilparams);
         bbv = {"1", "2", "0", "1"};
-        DEBUGEXP(ilvector2n);
-        DEBUGEXP(bbv);
+        OPENFHE_DEBUGEXP(ilvector2n);
+        OPENFHE_DEBUGEXP(bbv);
         // test for bug where length was 0
         EXPECT_EQ(ilvector2n.GetLength(), m / 2) << msg << " Failure: ={init list string}";
 
@@ -265,7 +265,7 @@ TEST(UTDCRTPoly, at) {
 
 template <typename Element>
 void switch_modulus(const std::string& msg) {
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
     using VecType  = typename Element::Vector;
     using ParmType = typename Element::Params;
     // using IntType = typename Element::Vector::Integer;
@@ -275,7 +275,7 @@ void switch_modulus(const std::string& msg) {
     typename VecType::Integer primitiveRootOfUnity("22");
 
     auto ilparams = std::make_shared<ParmType>(m, primeModulus, primitiveRootOfUnity);
-    DEBUG("SwitchModulus");
+    OPENFHE_DEBUG("SwitchModulus");
     {
         Element ilv(ilparams, Format::COEFFICIENT);
         ilv = {"56", "1", "37", "2"};
@@ -320,7 +320,7 @@ void rn_generators(const std::string& msg) {
     using VecType  = typename Element::Vector;
     using ParmType = typename Element::Params;
 
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
     usint m = 8;
     typename VecType::Integer primeModulus("73");
     typename VecType::Integer primitiveRootOfUnity("22");
@@ -333,7 +333,7 @@ void rn_generators(const std::string& msg) {
 
     auto ilparams = std::make_shared<ParmType>(m, primeModulus, primitiveRootOfUnity);
 
-    DEBUG("DestroyPreComputedSamples");
+    OPENFHE_DEBUG("DestroyPreComputedSamples");
     {
         Element ilv(ilparams, Format::COEFFICIENT);
         ilv = {"2", "1", "3", "2"};
@@ -372,7 +372,7 @@ void poly_other_methods(const std::string& msg) {
     using VecType  = typename Element::Vector;
     using ParmType = typename Element::Params;
 
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
     usint m = 8;
     typename VecType::Integer primeModulus("73");
     typename VecType::Integer primitiveRootOfUnity("22");
@@ -384,7 +384,7 @@ void poly_other_methods(const std::string& msg) {
     // test for bug where length was 0
     EXPECT_EQ(ilvector2n.GetLength(), m / 2) << msg << " Failure: ={init list string}";
 
-    DEBUG("SwitchFormat");
+    OPENFHE_DEBUG("SwitchFormat");
     {
         Element ilv(ilparams, Format::COEFFICIENT);
         ilv = {"2", "1", "3", "2"};
@@ -411,7 +411,7 @@ void poly_other_methods(const std::string& msg) {
         EXPECT_EQ(expected2, ilv1) << msg << " Failure: ivl1.SwitchFormat() values";
     }
 
-    DEBUG("MultiplicativeInverse");
+    OPENFHE_DEBUG("MultiplicativeInverse");
     {
         Element ilv1(ilparams, Format::EVALUATION);
         ilv1 = {"2", "4", "3", "2"};
@@ -425,7 +425,7 @@ void poly_other_methods(const std::string& msg) {
         }
     }
 
-    DEBUG("Norm");
+    OPENFHE_DEBUG("Norm");
     {
         Element ilv(ilparams, Format::COEFFICIENT);
         ilv = {"56", "1", "37", "1"};
@@ -497,7 +497,7 @@ void automorphismTransform(const std::string& msg) {
     using VecType  = typename Element::Vector;
     using ParmType = typename Element::Params;
 
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
     usint m = 8;
     typename VecType::Integer primeModulus("73");
     typename VecType::Integer primitiveRootOfUnity("22");
@@ -509,7 +509,7 @@ void automorphismTransform(const std::string& msg) {
     // test for bug where length was 0
     EXPECT_EQ(ilvector2n.GetLength(), m / 2) << msg << " Failure: ={init list string}";
 
-    DEBUG("AutomorphismTransform");
+    OPENFHE_DEBUG("AutomorphismTransform");
     {
         Element ilv(ilparams, Format::COEFFICIENT);
         ilv = {"56", "1", "37", "2"};
@@ -537,7 +537,7 @@ void transposition(const std::string& msg) {
     using VecType  = typename Element::Vector;
     using ParmType = typename Element::Params;
 
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
     usint m = 8;
 
     typename VecType::Integer q("73");
@@ -552,20 +552,20 @@ void transposition(const std::string& msg) {
 
     // converts to Format::EVALUATION representation
     ilvector2n1.SwitchFormat();
-    DEBUG("ilvector2n1 a " << ilvector2n1);
+    OPENFHE_DEBUG("ilvector2n1 a " << ilvector2n1);
 
     ilvector2n1 = ilvector2n1.Transpose();
-    DEBUG("ilvector2n1 b " << ilvector2n1);
+    OPENFHE_DEBUG("ilvector2n1 b " << ilvector2n1);
 
     // converts back to Format::COEFFICIENT representation
     ilvector2n1.SwitchFormat();
 
-    DEBUG("ilvector2n1 c " << ilvector2n1);
+    OPENFHE_DEBUG("ilvector2n1 c " << ilvector2n1);
 
     Element ilvector2n2(ilparams, Format::COEFFICIENT);
     ilvector2n2 = {"31", "39", "58", "52"};
 
-    DEBUG("ilvector2n2 a " << ilvector2n2);
+    OPENFHE_DEBUG("ilvector2n2 a " << ilvector2n2);
 
     EXPECT_EQ(ilvector2n2, ilvector2n1) << msg << " Failure: transposition test";
 }

--- a/src/core/unittest/UnitTestSerialize.cpp
+++ b/src/core/unittest/UnitTestSerialize.cpp
@@ -107,17 +107,17 @@ TEST(UTSer, hugeint) {
 
 template <typename V>
 void vector_of_bigint(const std::string& msg) {
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
     const int vecsize = 100;
 
-    DEBUG("step 0");
+    OPENFHE_DEBUG("step 0");
     typename V::Integer mod((uint64_t)1 << 40);
 
-    DEBUG("step 1");
+    OPENFHE_DEBUG("step 1");
     V testvec(vecsize, mod);
-    DEBUG("step 2");
+    OPENFHE_DEBUG("step 2");
     DiscreteUniformGeneratorImpl<V> dug;
-    DEBUG("step 3");
+    OPENFHE_DEBUG("step 3");
     dug.SetModulus(mod);
     typename V::Integer ranval;
 
@@ -250,21 +250,21 @@ TEST(UTSer, ildcrtpoly_test) {
 ////////////////////////////////////////////////////////////
 template <typename V>
 void serialize_matrix_bigint(const std::string& msg) {
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
     // dimensions of matrix.
     const int nrows = 4;
     const int ncols = 8;
 
-    DEBUG("step 0");
+    OPENFHE_DEBUG("step 0");
     const typename V::Integer mod((uint64_t)1 << 40);
 
-    DEBUG("step 1");
+    OPENFHE_DEBUG("step 1");
     Matrix<typename V::Integer> testmat(V::Integer::Allocator, nrows, ncols);
 
-    DEBUG("step 2");
+    OPENFHE_DEBUG("step 2");
     DiscreteUniformGeneratorImpl<V> dug;
 
-    DEBUG("step 3");
+    OPENFHE_DEBUG("step 3");
     dug.SetModulus(mod);
     typename V::Integer ranval;
 
@@ -276,7 +276,7 @@ void serialize_matrix_bigint(const std::string& msg) {
         }
     }
 
-    DEBUG("step 4");
+    OPENFHE_DEBUG("step 4");
     // serialize the Matrix
 
     std::stringstream ss;
@@ -287,17 +287,17 @@ void serialize_matrix_bigint(const std::string& msg) {
         std::cout << Serial::SerializeToString(testmat) << std::endl;
     }
 #endif
-    DEBUG("step 5");
+    OPENFHE_DEBUG("step 5");
 
     // empty matrix
     Matrix<typename V::Integer> newmat(V::Integer::Allocator, 0, 0);
 
     Serial::Deserialize(newmat, ss, SerType::BINARY);
 
-    DEBUG("step 9");
+    OPENFHE_DEBUG("step 9");
     EXPECT_EQ(testmat, newmat) << msg << " Mismatch after ser/deser";
-    DEBUGEXP(testmat);
-    DEBUGEXP(newmat);
+    OPENFHE_DEBUGEXP(testmat);
+    OPENFHE_DEBUGEXP(newmat);
 }
 
 TEST(UTSer, serialize_matrix_bigint) {

--- a/src/core/unittest/UnitTestTransform.cpp
+++ b/src/core/unittest/UnitTestTransform.cpp
@@ -103,7 +103,7 @@ TEST(UTTransform, CRT_polynomial_mult) {
 
 template <typename V>
 void CRT_polynomial_mult_small(const std::string& msg) {
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
 
     usint m = 22;
     typename V::Integer squareRootOfRoot(3750);
@@ -112,32 +112,32 @@ void CRT_polynomial_mult_small(const std::string& msg) {
     typename V::Integer bigRoot("31971887649898");
     usint n = GetTotient(m);
 
-    DEBUG("m is " << m << " and n is " << n);
+    OPENFHE_DEBUG("m is " << m << " and n is " << n);
     auto cycloPoly = GetCyclotomicPolynomial<V>(m, modulus);
-    DEBUG("2 " << cycloPoly);
+    OPENFHE_DEBUG("2 " << cycloPoly);
 
     // ChineseRemainderTransformArb<V>::PreCompute(m, modulus);
     ChineseRemainderTransformArb<V>().SetCylotomicPolynomial(cycloPoly, modulus);
-    DEBUG("3");
+    OPENFHE_DEBUG("3");
 
     V a(n, modulus);
     a      = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
     auto A = ChineseRemainderTransformArb<V>().ForwardTransform(a, squareRootOfRoot, bigModulus, bigRoot, m);
-    DEBUG("4 " << A);
+    OPENFHE_DEBUG("4 " << A);
 
     V b(n, modulus);
     b      = {5, 6, 7, 8, 9, 10, 11, 12, 13, 14};
     auto B = ChineseRemainderTransformArb<V>().ForwardTransform(b, squareRootOfRoot, bigModulus, bigRoot, m);
-    DEBUG("5 " << B);
+    OPENFHE_DEBUG("5 " << B);
     auto C = A * B;
-    DEBUG("6 " << C);
+    OPENFHE_DEBUG("6 " << C);
 
     auto c = ChineseRemainderTransformArb<V>().InverseTransform(C, squareRootOfRoot, bigModulus, bigRoot, m);
 
-    DEBUG("7 " << c);
+    OPENFHE_DEBUG("7 " << c);
     auto cCheck = PolynomialMultiplication(a, b);
 
-    DEBUG("8");
+    OPENFHE_DEBUG("8");
     cCheck = PolyMod(cCheck, cycloPoly, modulus);
 
     for (usint i = 0; i < n; i++) {
@@ -192,7 +192,7 @@ TEST(UTTransform, CRT_polynomial_mult_big_ring) {
 
 template <typename V>
 void CRT_polynomial_mult_big_ring_prime_cyclotomics(const std::string& msg) {
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
 
     usint m = 1733;
 
@@ -222,8 +222,8 @@ void CRT_polynomial_mult_big_ring_prime_cyclotomics(const std::string& msg) {
     auto cCheck = PolynomialMultiplication(a, b);
 
     cCheck = PolyMod(cCheck, cycloPoly, modulus);
-    DEBUG("c " << c);
-    DEBUG("cCheck " << cCheck);
+    OPENFHE_DEBUG("c " << c);
+    OPENFHE_DEBUG("cCheck " << cCheck);
     EXPECT_EQ(cCheck, c) << msg;
 }
 
@@ -339,14 +339,14 @@ TEST(UTTransform, CRT_CHECK_small_ring_precomputed) {
 
 template <typename V>
 void CRT_CHECK_very_big_ring_precomputed(const std::string& msg) {
-    DEBUG_FLAG(false);
+    OPENFHE_DEBUG_FLAG(false);
     usint m = 8422;
-    DEBUG("1");
+    OPENFHE_DEBUG("1");
     // find a modulus that has 2*8422 root of unity and is 120 bit long
     typename V::Integer modulus("619578785044668429129510602549015713");
     typename V::Integer squareRootOfRoot("204851043665385327685783246012876507");
     usint n = GetTotient(m);
-    DEBUG("UT GetTotient(" << m << ")= " << n);
+    OPENFHE_DEBUG("UT GetTotient(" << m << ")= " << n);
 
     auto cycloPoly = GetCyclotomicPolynomial<V>(m, modulus);
     typename V::Integer nttmodulus(
@@ -360,17 +360,17 @@ void CRT_CHECK_very_big_ring_precomputed(const std::string& msg) {
     // ChineseRemainderTransformArb<V>::SetPreComputedNTTModulus(m, modulus,
     // nttmodulus, nttroot);
 
-    DEBUG("2");
+    OPENFHE_DEBUG("2");
     ChineseRemainderTransformArb<V>().SetCylotomicPolynomial(cycloPoly, modulus);
-    DEBUG("3");
+    OPENFHE_DEBUG("3");
     V input(n, modulus);
     input = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-    DEBUG("4");
+    OPENFHE_DEBUG("4");
     auto INPUT = ChineseRemainderTransformArb<V>().ForwardTransform(input, squareRootOfRoot, nttmodulus, nttroot, m);
-    DEBUG("5");
+    OPENFHE_DEBUG("5");
     auto inputCheck =
         ChineseRemainderTransformArb<V>().InverseTransform(INPUT, squareRootOfRoot, nttmodulus, nttroot, m);
-    DEBUG("6");
+    OPENFHE_DEBUG("6");
     for (usint i = 0; i < n; i++) {
         EXPECT_EQ(input.at(i), inputCheck.at(i)) << msg;
     }

--- a/src/core/unittest/UnitTestTrapdoor.cpp
+++ b/src/core/unittest/UnitTestTrapdoor.cpp
@@ -256,8 +256,8 @@ TEST(UTTrapdoor, TrapDoorMultTestSquareMat) {
 }
 
 TEST(UTTrapdoor, TrapDoorGaussGqSampTest) {
-    DEBUG_FLAG(false);
-    DEBUG("start tests");
+    OPENFHE_DEBUG_FLAG(false);
+    OPENFHE_DEBUG("start tests");
     usint m = 16;
     usint n = m / 2;
     BigInteger modulus("67108913");
@@ -276,9 +276,9 @@ TEST(UTTrapdoor, TrapDoorGaussGqSampTest) {
     Poly::DugType dug = Poly::DugType();
     dug.SetModulus(modulus);
 
-    DEBUG("1");
+    OPENFHE_DEBUG("1");
     Poly u(dug, params, Format::COEFFICIENT);
-    DEBUG("2");
+    OPENFHE_DEBUG("2");
     double val = modulus.ConvertToDouble();  // TODO get the next few lines
                                              // working in a single instance.
     // YSP check logTwo computation
@@ -287,17 +287,17 @@ TEST(UTTrapdoor, TrapDoorGaussGqSampTest) {
 
     Matrix<int64_t> zHatBBI([]() { return 0; }, k, m / 2);
 
-    DEBUG("3");
-    DEBUG("u " << u);
-    DEBUG("sigma " << sigma);
-    DEBUG("k " << k);
-    DEBUG("modulus " << modulus);
+    OPENFHE_DEBUG("3");
+    OPENFHE_DEBUG("u " << u);
+    OPENFHE_DEBUG("sigma " << sigma);
+    OPENFHE_DEBUG("k " << k);
+    OPENFHE_DEBUG("modulus " << modulus);
 
     LatticeGaussSampUtility<Poly>::GaussSampGq(u, sigma, k, modulus, base, dgg, &zHatBBI);
 
     EXPECT_EQ(k, zHatBBI.GetRows()) << "Failure testing number of rows";
     EXPECT_EQ(u.GetLength(), zHatBBI.GetCols()) << "Failure testing number of colums";
-    DEBUG("4");
+    OPENFHE_DEBUG("4");
     Matrix<Poly> z = SplitInt64AltIntoElements<Poly>(zHatBBI, n, params);
     z.SwitchFormat();
 
@@ -306,7 +306,7 @@ TEST(UTTrapdoor, TrapDoorGaussGqSampTest) {
     uEst.SwitchFormat();
 
     EXPECT_EQ(u, uEst);
-    DEBUG("end tests");
+    OPENFHE_DEBUG("end tests");
 }
 
 // this test does not work correctly in the web assembly configuration
@@ -378,8 +378,8 @@ TEST(UTTrapdoor, TrapDoorGaussSampTestDCRT) {
 #endif
 
 TEST(UTTrapdoor, TrapDoorGaussGqSampTestBase1024) {
-    DEBUG_FLAG(false);
-    DEBUG("start tests");
+    OPENFHE_DEBUG_FLAG(false);
+    OPENFHE_DEBUG("start tests");
 
     usint m = 1024;
     usint n = m / 2;
@@ -399,9 +399,9 @@ TEST(UTTrapdoor, TrapDoorGaussGqSampTestBase1024) {
     Poly::DugType dug = Poly::DugType();
     dug.SetModulus(modulus);
 
-    DEBUG("1");
+    OPENFHE_DEBUG("1");
     Poly u(dug, params, Format::COEFFICIENT);
-    DEBUG("2");
+    OPENFHE_DEBUG("2");
     // double val = modulus.ConvertToDouble(); //TODO get the next few lines
     // working in a single instance. YSP check logTwo computation
 
@@ -413,18 +413,18 @@ TEST(UTTrapdoor, TrapDoorGaussGqSampTestBase1024) {
 
     Matrix<int64_t> zHatBBI([]() { return 0; }, k, m / 2);
 
-    DEBUG("3");
-    DEBUG("u " << u);
-    DEBUG("sigma " << sigma);
-    DEBUG("k " << k);
-    DEBUG("modulus " << modulus);
-    DEBUG("base = " << base);
+    OPENFHE_DEBUG("3");
+    OPENFHE_DEBUG("u " << u);
+    OPENFHE_DEBUG("sigma " << sigma);
+    OPENFHE_DEBUG("k " << k);
+    OPENFHE_DEBUG("modulus " << modulus);
+    OPENFHE_DEBUG("base = " << base);
 
     LatticeGaussSampUtility<Poly>::GaussSampGq(u, sigma, k, modulus, base, dgg, &zHatBBI);
 
     EXPECT_EQ(k, zHatBBI.GetRows()) << "Failure testing number of rows";
     EXPECT_EQ(u.GetLength(), zHatBBI.GetCols()) << "Failure testing number of colums";
-    DEBUG("4");
+    OPENFHE_DEBUG("4");
 
     // int32_t maxValue = 0;
 
@@ -436,7 +436,7 @@ TEST(UTTrapdoor, TrapDoorGaussGqSampTestBase1024) {
     // std::cout << maxValue << std::endl;
 
     Matrix<Poly> z = SplitInt64AltIntoElements<Poly>(zHatBBI, n, params);
-    DEBUG("4.5");
+    OPENFHE_DEBUG("4.5");
     // TODO for some reason I must do this before calling switchformat (which
     // uses omp for parallel execution)
     // TODO my guess is there is a race in the calculation/caching of factors
@@ -447,7 +447,7 @@ TEST(UTTrapdoor, TrapDoorGaussGqSampTestBase1024) {
 
     z.SwitchFormat();
 
-    DEBUG("5");
+    OPENFHE_DEBUG("5");
     Poly uEst;
     uEst = (Matrix<Poly>(zero_alloc, 1, k).GadgetVector(base) * z)(0, 0);
     uEst.SwitchFormat();
@@ -455,14 +455,14 @@ TEST(UTTrapdoor, TrapDoorGaussGqSampTestBase1024) {
     // std::cout << u - uEst << std::endl;
 
     EXPECT_EQ(u, uEst);
-    DEBUG("end tests");
+    OPENFHE_DEBUG("end tests");
 }
 
 // Test of Gaussian Sampling using the UCSD integer perturbation sampling
 // algorithm
 TEST(UTTrapdoor, TrapDoorGaussSampTest) {
-    DEBUG_FLAG(false);
-    DEBUG("in test");
+    OPENFHE_DEBUG_FLAG(false);
+    OPENFHE_DEBUG("in test");
     usint m = 16;
     usint n = m / 2;
 
@@ -475,11 +475,11 @@ TEST(UTTrapdoor, TrapDoorGaussSampTest) {
     double logTwo = log(val - 1.0) / log(2) + 1.0;
     usint k       = (usint)floor(logTwo);  // = this->m_cryptoParameters.GetModulus();
 
-    DEBUG("k = " << k);
-    DEBUG("sigma = " << sigma);
-    DEBUG("m = " << m);
-    DEBUG("modulus = " << modulus);
-    DEBUG("root = " << rootOfUnity);
+    OPENFHE_DEBUG("k = " << k);
+    OPENFHE_DEBUG("sigma = " << sigma);
+    OPENFHE_DEBUG("m = " << m);
+    OPENFHE_DEBUG("modulus = " << modulus);
+    OPENFHE_DEBUG("root = " << rootOfUnity);
 
     auto params = std::make_shared<ILParams>(m, modulus, rootOfUnity);
 
@@ -501,9 +501,9 @@ TEST(UTTrapdoor, TrapDoorGaussSampTest) {
 
     Poly u(dug, params, Format::COEFFICIENT);
 
-    DEBUG("u " << u);
+    OPENFHE_DEBUG("u " << u);
     u.SwitchFormat();
-    DEBUG("u " << u);
+    OPENFHE_DEBUG("u " << u);
 
     Matrix<Poly> z =
         RLWETrapdoorUtility<Poly>::GaussSamp(m / 2, k, trapPair.first, trapPair.second, u, dgg, dggLargeSigma);
@@ -515,11 +515,11 @@ TEST(UTTrapdoor, TrapDoorGaussSampTest) {
 
     Poly uEst = (trapPair.first * z)(0, 0);
 
-    DEBUG("uEst " << uEst);
-    DEBUG("u " << u);
+    OPENFHE_DEBUG("uEst " << uEst);
+    OPENFHE_DEBUG("u " << u);
 
-    DEBUG("uEst.GetModulus() " << uEst.GetModulus());
-    DEBUG("u.GetModulus() " << u.GetModulus());
+    OPENFHE_DEBUG("uEst.GetModulus() " << uEst.GetModulus());
+    OPENFHE_DEBUG("u.GetModulus() " << u.GetModulus());
 
     uEst.SwitchFormat();
     u.SwitchFormat();
@@ -531,8 +531,8 @@ TEST(UTTrapdoor, TrapDoorGaussSampTest) {
 
 // Test of Gaussian Sampling for matrices from 2x2 to 5x5
 TEST(UTTrapdoor, TrapDoorGaussSampTestSquareMatrices) {
-    DEBUG_FLAG(false);
-    DEBUG("in test");
+    OPENFHE_DEBUG_FLAG(false);
+    OPENFHE_DEBUG("in test");
     usint m = 16;
     usint n = m / 2;
 

--- a/src/pke/lib/encoding/packedencoding.cpp
+++ b/src/pke/lib/encoding/packedencoding.cpp
@@ -312,7 +312,7 @@ void PackedEncoding::SetParams(usint m, EncodingParams params) {
 
 template <typename P>
 void PackedEncoding::Pack(P *ring, const PlaintextModulus &modulus) const {
-  DEBUG_FLAG(false);
+  OPENFHE_DEBUG_FLAG(false);
 
   usint m = ring->GetCyclotomicOrder();  // cyclotomic order
   NativeInteger modulusNI(modulus);      // native int modulus
@@ -326,7 +326,7 @@ void PackedEncoding::Pack(P *ring, const PlaintextModulus &modulus) const {
 
   usint phim = ring->GetRingDimension();
 
-  DEBUG("Pack for order " << m << " phim " << phim << " modulus " << modulusNI);
+  OPENFHE_DEBUG("Pack for order " << m << " phim " << phim << " modulus " << modulusNI);
 
   // copy values from ring to the vector
   NativeVector slotValues(phim, modulusNI);
@@ -334,8 +334,8 @@ void PackedEncoding::Pack(P *ring, const PlaintextModulus &modulus) const {
     slotValues[i] = (*ring)[i].ConvertToInt();
   }
 
-  DEBUG(*ring);
-  DEBUG(slotValues);
+  OPENFHE_DEBUG(*ring);
+  OPENFHE_DEBUG(slotValues);
 
   // Transform Eval to Coeff
   if (IsPowerOfTwo(m)) {
@@ -361,17 +361,17 @@ void PackedEncoding::Pack(P *ring, const PlaintextModulus &modulus) const {
       permutedSlots[i] = slotValues[m_toCRTPerm[m][i]];
     }
 
-    DEBUG("permutedSlots " << permutedSlots);
-    DEBUG("m_initRoot[modulusM] " << m_initRoot[modulusM]);
-    DEBUG("m_bigModulus[modulusM] " << m_bigModulus[modulusM]);
-    DEBUG("m_bigRoot[modulusM] " << m_bigRoot[modulusM]);
+    OPENFHE_DEBUG("permutedSlots " << permutedSlots);
+    OPENFHE_DEBUG("m_initRoot[modulusM] " << m_initRoot[modulusM]);
+    OPENFHE_DEBUG("m_bigModulus[modulusM] " << m_bigModulus[modulusM]);
+    OPENFHE_DEBUG("m_bigRoot[modulusM] " << m_bigRoot[modulusM]);
 
     slotValues = ChineseRemainderTransformArb<NativeVector>().InverseTransform(
         permutedSlots, m_initRoot[modulusM], m_bigModulus[modulusM],
         m_bigRoot[modulusM], m);
   }
 
-  DEBUG("slotvalues now " << slotValues);
+  OPENFHE_DEBUG("slotvalues now " << slotValues);
   // copy values into the slotValuesRing
   typename P::Vector slotValuesRing(phim, ring->GetModulus());
   for (usint i = 0; i < phim; i++) {
@@ -379,12 +379,12 @@ void PackedEncoding::Pack(P *ring, const PlaintextModulus &modulus) const {
   }
 
   ring->SetValues(std::move(slotValuesRing), Format::COEFFICIENT);
-  DEBUG(*ring);
+  OPENFHE_DEBUG(*ring);
 }
 
 template <typename P>
 void PackedEncoding::Unpack(P *ring, const PlaintextModulus &modulus) const {
-  DEBUG_FLAG(false);
+  OPENFHE_DEBUG_FLAG(false);
 
   usint m = ring->GetCyclotomicOrder();  // cyclotomic order
   NativeInteger modulusNI(modulus);      // native int modulus
@@ -398,7 +398,7 @@ void PackedEncoding::Unpack(P *ring, const PlaintextModulus &modulus) const {
 
   usint phim = ring->GetRingDimension();  // ring dimension
 
-  DEBUG("Unpack for order " << m << " phim " << phim << " modulus "
+  OPENFHE_DEBUG("Unpack for order " << m << " phim " << phim << " modulus "
                             << modulusNI);
 
   // copy aggregate plaintext values
@@ -407,7 +407,7 @@ void PackedEncoding::Unpack(P *ring, const PlaintextModulus &modulus) const {
     packedVector[i] = NativeInteger((*ring)[i].ConvertToInt());
   }
 
-  DEBUG(packedVector);
+  OPENFHE_DEBUG(packedVector);
 
   // Transform Coeff to Eval
   NativeVector permutedSlots(phim, modulusNI);
@@ -430,7 +430,7 @@ void PackedEncoding::Unpack(P *ring, const PlaintextModulus &modulus) const {
     packedVector = permutedSlots;
   }
 
-  DEBUG(packedVector);
+  OPENFHE_DEBUG(packedVector);
 
   // copy values into the slotValuesRing
   typename P::Vector packedVectorRing(phim, ring->GetModulus());

--- a/src/pke/unittest/UnitTestEvalMultMany.cpp
+++ b/src/pke/unittest/UnitTestEvalMultMany.cpp
@@ -83,15 +83,15 @@ TEST(UTBFVrnsEVALMM, Poly_BFVrns_Eval_Mult_Many_Operations) {
 template <typename Element>
 static void RunEvalMultManyTest(CryptoContext<Element> cryptoContext,
                                 std::string msg) {
-  DEBUG_FLAG(false);
+  OPENFHE_DEBUG_FLAG(false);
   ////////////////////////////////////////////////////////////
   // Perform the key generation operation.
   ////////////////////////////////////////////////////////////
-  DEBUG("In RunEvalMultManyTest " << msg);
+  OPENFHE_DEBUG("In RunEvalMultManyTest " << msg);
   auto keyPair = cryptoContext->KeyGen();
-  DEBUG("keygen");
+  OPENFHE_DEBUG("keygen");
   ASSERT_TRUE(keyPair.good()) << "Key generation failed!";
-  DEBUG("EvalMultKeysGen");
+  OPENFHE_DEBUG("EvalMultKeysGen");
   // Create evaluation key vector to be used in keyswitching
   cryptoContext->EvalMultKeysGen(keyPair.secretKey);
 
@@ -109,7 +109,7 @@ static void RunEvalMultManyTest(CryptoContext<Element> cryptoContext,
                                         30, 24, 18, 12, 6, 0};
   std::vector<int64_t> vectorOfInts7 = {120, 96, 72, 48, 24, 0,
                                         120, 96, 72, 48, 24, 0};
-  DEBUG("MakeCoefPackedPlaintext");
+  OPENFHE_DEBUG("MakeCoefPackedPlaintext");
   Plaintext plaintext1 = cryptoContext->MakeCoefPackedPlaintext(vectorOfInts1);
   Plaintext plaintext2 = cryptoContext->MakeCoefPackedPlaintext(vectorOfInts2);
   Plaintext plaintext3 = cryptoContext->MakeCoefPackedPlaintext(vectorOfInts3);
@@ -125,7 +125,7 @@ static void RunEvalMultManyTest(CryptoContext<Element> cryptoContext,
   ////////////////////////////////////////////////////////////
   // Encryption
   ////////////////////////////////////////////////////////////
-  DEBUG("Encryption");
+  OPENFHE_DEBUG("Encryption");
   auto ciphertext1 = cryptoContext->Encrypt(keyPair.publicKey, plaintext1);
   auto ciphertext2 = cryptoContext->Encrypt(keyPair.publicKey, plaintext2);
   auto ciphertext3 = cryptoContext->Encrypt(keyPair.publicKey, plaintext3);
@@ -134,7 +134,7 @@ static void RunEvalMultManyTest(CryptoContext<Element> cryptoContext,
   ////////////////////////////////////////////////////////////
   // EvalMult Operation
   ////////////////////////////////////////////////////////////
-  DEBUG("EvalMults");
+  OPENFHE_DEBUG("EvalMults");
   // Perform consecutive multiplications and do a keyswtiching at the end.
   auto ciphertextMul12 =
       cryptoContext->EvalMultNoRelin(ciphertext1, ciphertext2);
@@ -151,7 +151,7 @@ static void RunEvalMultManyTest(CryptoContext<Element> cryptoContext,
   Plaintext plaintextMul1;
   Plaintext plaintextMul2;
   Plaintext plaintextMul3;
-  DEBUG("DECRYPTIO");
+  OPENFHE_DEBUG("DECRYPTIO");
   cryptoContext->Decrypt(keyPair.secretKey, ciphertextMul12, &plaintextMul1);
   cryptoContext->Decrypt(keyPair.secretKey, ciphertextMul123, &plaintextMul2);
   cryptoContext->Decrypt(keyPair.secretKey, ciphertextMul1234, &plaintextMul3);

--- a/src/pke/unittest/utbgvrns/UnitTestBGVrnsAdvancedSHE.cpp
+++ b/src/pke/unittest/utbgvrns/UnitTestBGVrnsAdvancedSHE.cpp
@@ -112,7 +112,7 @@ TEST_F(UTSHEAdvanced, test_eval_mult_single_crt) {
 }
 
 TEST_F(UTSHEAdvanced, test_eval_add_single_crt) {
-  DEBUG_FLAG(false);
+  OPENFHE_DEBUG_FLAG(false);
   CCParams<CryptoContextBGVRNS> parameters;
   parameters.SetCyclotomicOrder(16);
   parameters.SetPlaintextModulus(20);
@@ -128,30 +128,30 @@ TEST_F(UTSHEAdvanced, test_eval_add_single_crt) {
   // Initialize the public key containers.
   KeyPair<TYPE> kp;
 
-  DEBUG("Filling 1");
+  OPENFHE_DEBUG("Filling 1");
   std::vector<int64_t> vectorOfInts1 = {2, 3, 1, 4};
   Plaintext intArray1 = cc->MakeCoefPackedPlaintext(vectorOfInts1);
 
-  DEBUG("Filling 2");
+  OPENFHE_DEBUG("Filling 2");
   std::vector<int64_t> vectorOfInts2 = {3, 6, 3, 1};
   Plaintext intArray2 = cc->MakeCoefPackedPlaintext(vectorOfInts2);
 
-  DEBUG("getting pairs");
+  OPENFHE_DEBUG("getting pairs");
   kp = cc->KeyGen();
 
-  DEBUG("got pairs");
+  OPENFHE_DEBUG("got pairs");
   Ciphertext<TYPE> ciphertext1;
   Ciphertext<TYPE> ciphertext2;
 
   ciphertext1 = cc->Encrypt(kp.publicKey, intArray1);
-  DEBUG("after crypt 1");
+  OPENFHE_DEBUG("after crypt 1");
   ciphertext2 = cc->Encrypt(kp.publicKey, intArray2);
-  DEBUG("after crypt 2");
+  OPENFHE_DEBUG("after crypt 2");
 
   Ciphertext<TYPE> cResult;
-  DEBUG("before EA");
+  OPENFHE_DEBUG("before EA");
   cResult = cc->EvalAdd(ciphertext1, ciphertext2);
-  DEBUG("after");
+  OPENFHE_DEBUG("after");
 
   Ciphertext<TYPE> ciphertextResults({cResult});
   Plaintext results;

--- a/src/pke/unittest/utbgvrns/UnitTestBGVrnsSerialize.cpp
+++ b/src/pke/unittest/utbgvrns/UnitTestBGVrnsSerialize.cpp
@@ -168,7 +168,7 @@ protected:
         try {
             CryptoContext<Element> cc(UnitTestGenerateContext(testData.params));
 
-            DEBUG_FLAG(false);
+            OPENFHE_DEBUG_FLAG(false);
 
             CryptoContextImpl<DCRTPoly>::ClearEvalMultKeys();
             CryptoContextImpl<DCRTPoly>::ClearEvalSumKeys();
@@ -177,7 +177,7 @@ protected:
             // // The batch size for our tests.
             int vecSize = 10;
 
-            DEBUG("step 0");
+            OPENFHE_DEBUG("step 0");
             {
                 std::stringstream s;
                 Serial::Serialize(cc, s, sertype);
@@ -201,26 +201,26 @@ protected:
                 std::make_shared<EncodingParamsImpl>(cc->GetEncodingParams()->GetPlaintextModulus(), vecSize));
             cryptoParamsBGVrns->SetEncodingParams(encodingParamsNew);
 
-            DEBUG("step 1");
+            OPENFHE_DEBUG("step 1");
             {
                 std::stringstream s;
                 Serial::Serialize(kp.publicKey, s, sertype);
                 Serial::Deserialize(kpnew.publicKey, s, sertype);
                 EXPECT_EQ(*kp.publicKey, *kpnew.publicKey) << "Public key mismatch after ser/deser";
             }
-            DEBUG("step 2");
+            OPENFHE_DEBUG("step 2");
             {
                 std::stringstream s;
                 Serial::Serialize(kp.secretKey, s, sertype);
                 Serial::Deserialize(kpnew.secretKey, s, sertype);
                 EXPECT_EQ(*kp.secretKey, *kpnew.secretKey) << "Secret key mismatch after ser/deser";
             }
-            DEBUG("step 3");
+            OPENFHE_DEBUG("step 3");
             std::vector<int64_t> vals = { 1, 3, 5, 7, 9, 2, 4, 6, 8, 11 };
             Plaintext plaintextShort = cc->MakePackedPlaintext(vals);
             Ciphertext<DCRTPoly> ciphertext = cc->Encrypt(kp.publicKey, plaintextShort);
 
-            DEBUG("step 4");
+            OPENFHE_DEBUG("step 4");
             Ciphertext<DCRTPoly> newC;
             {
                 std::stringstream s;
@@ -229,7 +229,7 @@ protected:
                 EXPECT_EQ(*ciphertext, *newC) << "Ciphertext mismatch";
             }
 
-            DEBUG("step 5");
+            OPENFHE_DEBUG("step 5");
             Plaintext plaintextShortNew;
             cc->Decrypt(kp.secretKey, newC, &plaintextShortNew);
             plaintextShortNew->SetLength(plaintextShort->GetLength());
@@ -240,7 +240,7 @@ protected:
             checkEquality(plaintextShortNew->GetPackedValue(), plaintextShort->GetPackedValue(), eps,
                 failmsg + " Decrypted serialization test fails" + bufferShort.str());
 
-            DEBUG("step 6");
+            OPENFHE_DEBUG("step 6");
             KeyPair<DCRTPoly> kp2 = cc->KeyGen();
 
             cc->EvalMultKeyGen(kp.secretKey);
@@ -248,7 +248,7 @@ protected:
             cc->EvalSumKeyGen(kp.secretKey);
             cc->EvalSumKeyGen(kp2.secretKey);
 
-            DEBUG("step 7");
+            OPENFHE_DEBUG("step 7");
             // serialize a bunch of mult keys
             std::stringstream ser0;
             EXPECT_EQ(CryptoContextImpl<DCRTPoly>::SerializeEvalMultKey(ser0, sertype, kp.secretKey->GetKeyTag()), true)
@@ -260,7 +260,7 @@ protected:
             EXPECT_EQ(CryptoContextImpl<DCRTPoly>::SerializeEvalMultKey(ser3, sertype), true)
                 << "all context eval mult key ser fails";
 
-            DEBUG("step 8");
+            OPENFHE_DEBUG("step 8");
             // serialize a bunch of sum keys
             std::stringstream aser0;
             EXPECT_EQ(CryptoContextImpl<DCRTPoly>::SerializeEvalSumKey(aser0, sertype, kp.secretKey->GetKeyTag()), true)
@@ -272,7 +272,7 @@ protected:
             EXPECT_EQ(CryptoContextImpl<DCRTPoly>::SerializeEvalSumKey(aser3, sertype), true)
                 << "all eval sum key ser fails";
 
-            DEBUG("step 9");
+            OPENFHE_DEBUG("step 9");
             cc.reset();
 
             // test mult deserialize
@@ -302,7 +302,7 @@ protected:
             EXPECT_EQ(CryptoContextFactory<DCRTPoly>::GetContextCount(), 1) << "all-key deser, context";
             EXPECT_EQ(CryptoContextImpl<DCRTPoly>::GetAllEvalMultKeys().size(), 2U) << "all-key deser, keys";
 
-            DEBUG("step 10");
+            OPENFHE_DEBUG("step 10");
             // test sum deserialize
 
             CryptoContextImpl<DCRTPoly>::ClearEvalMultKeys();

--- a/src/pke/unittest/utckksrns/UnitTestCKKSrnsSerialize.cpp
+++ b/src/pke/unittest/utckksrns/UnitTestCKKSrnsSerialize.cpp
@@ -190,13 +190,13 @@ protected:
         try {
             CryptoContext<Element> cc(UnitTestGenerateContext(testData.params));
 
-            DEBUG_FLAG(false);
+            OPENFHE_DEBUG_FLAG(false);
 
             CryptoContextImpl<DCRTPoly>::ClearEvalMultKeys();
             CryptoContextImpl<DCRTPoly>::ClearEvalSumKeys();
             CryptoContextImpl<DCRTPoly>::ClearEvalAutomorphismKeys();
 
-            DEBUG("step 0");
+            OPENFHE_DEBUG("step 0");
             {
                 std::stringstream s;
                 Serial::Serialize(cc, s, sertype);
@@ -212,21 +212,21 @@ protected:
             KeyPair<DCRTPoly> kp = cc->KeyGen();
             KeyPair<DCRTPoly> kpnew;
 
-            DEBUG("step 1");
+            OPENFHE_DEBUG("step 1");
             {
                 std::stringstream s;
                 Serial::Serialize(kp.publicKey, s, sertype);
                 Serial::Deserialize(kpnew.publicKey, s, sertype);
                 EXPECT_EQ(*kp.publicKey, *kpnew.publicKey) << "Public key mismatch after ser/deser";
             }
-            DEBUG("step 2");
+            OPENFHE_DEBUG("step 2");
             {
                 std::stringstream s;
                 Serial::Serialize(kp.secretKey, s, sertype);
                 Serial::Deserialize(kpnew.secretKey, s, sertype);
                 EXPECT_EQ(*kp.secretKey, *kpnew.secretKey) << "Secret key mismatch after ser/deser";
             }
-            DEBUG("step 3");
+            OPENFHE_DEBUG("step 3");
             std::vector<std::complex<double>> vals = { 1.0, 3.0, 5.0, 7.0, 9.0,
                                                  2.0, 4.0, 6.0, 8.0, 11.0 };
             Plaintext plaintextShort = cc->MakeCKKSPackedPlaintext(vals);
@@ -234,7 +234,7 @@ protected:
             Ciphertext<DCRTPoly> ciphertext = cc->Encrypt(kp.publicKey, plaintextShort);
             Ciphertext<DCRTPoly> ciphertextL2D2 = cc->Encrypt(kp.publicKey, plaintextShortL2D2);
 
-            DEBUG("step 4");
+            OPENFHE_DEBUG("step 4");
             Ciphertext<DCRTPoly> newC;
             Ciphertext<DCRTPoly> newCL2D2;
             {
@@ -248,7 +248,7 @@ protected:
                 EXPECT_EQ(*ciphertextL2D2, *newCL2D2) << "Ciphertext mismatch";
             }
 
-            DEBUG("step 5");
+            OPENFHE_DEBUG("step 5");
             Plaintext plaintextShortNew;
             Plaintext plaintextShortNewL2D2;
             cc->Decrypt(kp.secretKey, newC, &plaintextShortNew);
@@ -260,7 +260,7 @@ protected:
             checkEquality(plaintextShortNewL2D2->GetCKKSPackedValue(), plaintextShortL2D2->GetCKKSPackedValue(), eps,
                 failmsg + " Decrypted serialization test fails (level 2, depth 2)");
 
-            DEBUG("step 6");
+            OPENFHE_DEBUG("step 6");
             KeyPair<DCRTPoly> kp2 = cc->KeyGen();
 
             cc->EvalMultKeyGen(kp.secretKey);
@@ -268,7 +268,7 @@ protected:
             cc->EvalSumKeyGen(kp.secretKey);
             cc->EvalSumKeyGen(kp2.secretKey);
 
-            DEBUG("step 7");
+            OPENFHE_DEBUG("step 7");
             // serialize a bunch of mult keys
             std::stringstream ser0;
             EXPECT_EQ(CryptoContextImpl<DCRTPoly>::SerializeEvalMultKey(ser0, sertype, kp.secretKey->GetKeyTag()), true)
@@ -280,7 +280,7 @@ protected:
             EXPECT_EQ(CryptoContextImpl<DCRTPoly>::SerializeEvalMultKey(ser3, sertype), true)
                 << "all context eval mult key ser fails";
 
-            DEBUG("step 8");
+            OPENFHE_DEBUG("step 8");
             // serialize a bunch of sum keys
             std::stringstream aser0;
             EXPECT_EQ(CryptoContextImpl<DCRTPoly>::SerializeEvalSumKey(aser0, sertype, kp.secretKey->GetKeyTag()), true)
@@ -292,7 +292,7 @@ protected:
             EXPECT_EQ(CryptoContextImpl<DCRTPoly>::SerializeEvalSumKey(aser3, sertype), true)
                 << "all eval sum key ser fails";
 
-            DEBUG("step 9");
+            OPENFHE_DEBUG("step 9");
             cc.reset();
 
             // test mult deserialize
@@ -322,7 +322,7 @@ protected:
             EXPECT_EQ(CryptoContextFactory<DCRTPoly>::GetContextCount(), 1) << "all-key deser, context";
             EXPECT_EQ(CryptoContextImpl<DCRTPoly>::GetAllEvalMultKeys().size(), 2U) << "all-key deser, keys";
 
-            DEBUG("step 10");
+            OPENFHE_DEBUG("step 10");
             // test sum deserialize
 
             CryptoContextImpl<DCRTPoly>::ClearEvalMultKeys();


### PR DESCRIPTION
This is a straightforward patch to rename our DEBUG*() macros to OPENFHE_DEBUG*().  Thank you for your support.