### PR TITLE
Sparse

### DIFF
--- a/benchmark/src/Encoding.cpp
+++ b/benchmark/src/Encoding.cpp
@@ -193,7 +193,7 @@ void BM_encoding_PackedCKKSPlaintext(benchmark::State& state) {
     auto scalingFactor = cc->GetEncodingParams()->GetPlaintextModulus();
 
     while (state.KeepRunning()) {
-        plaintext.reset(new CKKSPackedEncoding(lp, ep, vectorOfComplex, 1, 0, scalingFactor));
+        plaintext.reset(new CKKSPackedEncoding(lp, ep, vectorOfComplex, 1, 0, scalingFactor, 0));
         plaintext->Encode();
     }
 }

--- a/src/core/lib/math/dftransform.cpp
+++ b/src/core/lib/math/dftransform.cpp
@@ -210,8 +210,9 @@ void DiscreteFourierTransform::FFTSpecialInvLazy(std::vector<std::complex<double
         for (size_t i = 0; i < size; i += len) {
             size_t lenh = len >> 1;
             size_t lenq = len << 2;
+            size_t gap = m_M / lenq;
             for (size_t j = 0; j < lenh; ++j) {
-                size_t idx             = (lenq - (m_rotGroup[j] % lenq)) * m_M / lenq;
+                size_t idx             = (lenq - (m_rotGroup[j] % lenq)) * gap;
                 std::complex<double> u = vals[i + j] + vals[i + j + lenh];
                 std::complex<double> v = vals[i + j] - vals[i + j + lenh];
                 v *= m_ksiPows[idx];
@@ -225,8 +226,8 @@ void DiscreteFourierTransform::FFTSpecialInvLazy(std::vector<std::complex<double
 
 void DiscreteFourierTransform::FFTSpecialInv(std::vector<std::complex<double>>& vals) {
     // if the precomputed tables do not exist
-    if ((vals.size() != m_Nh) || (!m_isInitialized))
-        Initialize(vals.size() * 4, vals.size());
+    if ((!m_isInitialized))
+        Initialize(m_M, m_M / 4);
     FFTSpecialInvLazy(vals);
     uint32_t size = vals.size();
     for (size_t i = 0; i < size; ++i) {
@@ -236,16 +237,17 @@ void DiscreteFourierTransform::FFTSpecialInv(std::vector<std::complex<double>>& 
 
 void DiscreteFourierTransform::FFTSpecial(std::vector<std::complex<double>>& vals) {
     // if the precomputed tables do not exist
-    if ((vals.size() != m_Nh) || (!m_isInitialized))
-        Initialize(vals.size() * 4, vals.size());
+  if ((!m_isInitialized))
+      Initialize(m_M, m_M / 4);
     BitReverse(vals);
     uint32_t size = vals.size();
     for (size_t len = 2; len <= size; len <<= 1) {
         for (size_t i = 0; i < size; i += len) {
             size_t lenh = len >> 1;
             size_t lenq = len << 2;
+            size_t gap = m_M / lenq;
             for (size_t j = 0; j < lenh; ++j) {
-                int64_t idx            = ((m_rotGroup[j] % lenq)) * m_M / lenq;
+                int64_t idx            = ((m_rotGroup[j] % lenq)) * gap;
                 std::complex<double> u = vals[i + j];
                 std::complex<double> v = vals[i + j + lenh];
                 v *= m_ksiPows[idx];

--- a/src/core/lib/math/dftransform.cpp
+++ b/src/core/lib/math/dftransform.cpp
@@ -242,10 +242,10 @@ void DiscreteFourierTransform::FFTSpecial(std::vector<std::complex<double>>& val
     BitReverse(vals);
     uint32_t size = vals.size();
     for (size_t len = 2; len <= size; len <<= 1) {
-        size_t lenh = len >> 1;
-        size_t lenq = len << 2;
-        size_t gap = m_M / lenq;
         for (size_t i = 0; i < size; i += len) {
+            size_t lenh = len >> 1;
+            size_t lenq = len << 2;
+            size_t gap = m_M / lenq;
             for (size_t j = 0; j < lenh; ++j) {
                 int64_t idx            = ((m_rotGroup[j] % lenq)) * gap;
                 std::complex<double> u = vals[i + j];

--- a/src/core/lib/math/dftransform.cpp
+++ b/src/core/lib/math/dftransform.cpp
@@ -242,10 +242,10 @@ void DiscreteFourierTransform::FFTSpecial(std::vector<std::complex<double>>& val
     BitReverse(vals);
     uint32_t size = vals.size();
     for (size_t len = 2; len <= size; len <<= 1) {
+        size_t lenh = len >> 1;
+        size_t lenq = len << 2;
+        size_t gap = m_M / lenq;
         for (size_t i = 0; i < size; i += len) {
-            size_t lenh = len >> 1;
-            size_t lenq = len << 2;
-            size_t gap = m_M / lenq;
             for (size_t j = 0; j < lenh; ++j) {
                 int64_t idx            = ((m_rotGroup[j] % lenq)) * gap;
                 std::complex<double> u = vals[i + j];

--- a/src/pke/include/ciphertext.h
+++ b/src/pke/include/ciphertext.h
@@ -77,7 +77,8 @@ class CiphertextImpl : public CryptoObject<Element> {
         m_scalingFactor(1),
         m_scalingFactorInt(1),
         m_level(0),
-        m_hopslevel(0) {
+        m_hopslevel(0),
+        m_slots(0) {
     m_metadataMap = std::make_shared<std::map<std::string, std::shared_ptr<Metadata>>>();
   }
 
@@ -94,7 +95,8 @@ class CiphertextImpl : public CryptoObject<Element> {
         m_scalingFactor(1),
         m_scalingFactorInt(1),
         m_level(0),
-        m_hopslevel(0) {
+        m_hopslevel(0),
+        m_slots(0) {
     m_metadataMap = std::make_shared<std::map<std::string, std::shared_ptr<Metadata>>>();
   }
 
@@ -110,7 +112,8 @@ class CiphertextImpl : public CryptoObject<Element> {
         m_scalingFactor(1),
         m_scalingFactorInt(1),
         m_level(0),
-        m_hopslevel(0) {
+        m_hopslevel(0),
+        m_slots(0) {
     m_metadataMap = std::make_shared<std::map<std::string, std::shared_ptr<Metadata>>>();
   }
 
@@ -126,6 +129,7 @@ class CiphertextImpl : public CryptoObject<Element> {
     m_scalingFactor = ciphertext.m_scalingFactor;
     m_scalingFactorInt = ciphertext.m_scalingFactorInt;
     encodingType = ciphertext.encodingType;
+    m_slots = ciphertext.m_slots;
     m_metadataMap = ciphertext.m_metadataMap;
   }
 
@@ -138,6 +142,7 @@ class CiphertextImpl : public CryptoObject<Element> {
     m_scalingFactor = ciphertext->m_scalingFactor;
     m_scalingFactorInt = ciphertext->m_scalingFactorInt;
     encodingType = ciphertext->encodingType;
+    m_slots = ciphertext->m_slots;
     m_metadataMap = ciphertext->m_metadataMap;
   }
 
@@ -153,6 +158,7 @@ class CiphertextImpl : public CryptoObject<Element> {
     m_scalingFactor = std::move(ciphertext.m_scalingFactor);
     m_scalingFactorInt = std::move(ciphertext.m_scalingFactorInt);
     encodingType = std::move(ciphertext.encodingType);
+    m_slots = std::move(ciphertext.m_slots);
     m_metadataMap = std::move(ciphertext.m_metadataMap);
   }
 
@@ -165,6 +171,7 @@ class CiphertextImpl : public CryptoObject<Element> {
     m_scalingFactor = std::move(ciphertext->m_scalingFactor);
     m_scalingFactorInt = std::move(ciphertext->m_scalingFactorInt);
     encodingType = std::move(ciphertext->encodingType);
+    m_slots = std::move(ciphertext->m_slots);
     m_metadataMap = std::move(ciphertext->m_metadataMap);
   }
 
@@ -219,6 +226,7 @@ class CiphertextImpl : public CryptoObject<Element> {
       this->m_scalingFactor = rhs.m_scalingFactor;
       this->m_scalingFactorInt = rhs.m_scalingFactorInt;
       this->encodingType = rhs.encodingType;
+      this->m_slots = rhs.m_slots;
       this->m_metadataMap = rhs.m_metadataMap;
     }
 
@@ -241,6 +249,7 @@ class CiphertextImpl : public CryptoObject<Element> {
       this->m_scalingFactor = std::move(rhs.m_scalingFactor);
       this->m_scalingFactorInt = std::move(rhs.m_scalingFactorInt);
       this->encodingType = std::move(rhs.encodingType);
+      this->m_slots = std::move(rhs.m_slots);
       this->m_metadataMap = std::move(rhs.m_metadataMap);
     }
 
@@ -377,6 +386,16 @@ class CiphertextImpl : public CryptoObject<Element> {
   void SetScalingFactorInt(const NativeInteger sf) { m_scalingFactorInt = sf; }
 
   /**
+   * Get the number of slots of the ciphertext.
+   */
+  size_t GetSlots() const { return m_slots; }
+
+  /**
+   * Set the number of slots of the ciphertext.
+   */
+  void SetSlots(usint slots) { m_slots = slots; }
+
+  /**
    * Get the Metadata map of the ciphertext.
    */
   MetadataMap GetMetadataMap() const { return this->m_metadataMap; }
@@ -447,6 +466,7 @@ class CiphertextImpl : public CryptoObject<Element> {
     cRes->SetHopLevel(this->GetHopLevel());
     cRes->SetScalingFactor(this->GetScalingFactor());
     cRes->SetScalingFactorInt(this->GetScalingFactorInt());
+    cRes->SetSlots(this->GetSlots());
 
     return cRes;
   }
@@ -463,6 +483,8 @@ class CiphertextImpl : public CryptoObject<Element> {
     if (this->m_scalingFactor != rhs.m_scalingFactor) return false;
 
     if (this->m_scalingFactorInt != rhs.m_scalingFactorInt) return false;
+
+    if (this->m_slots != rhs.m_slots) return false;
 
     const std::vector<Element>& lhsE = this->GetElements();
     const std::vector<Element>& rhsE = rhs.GetElements();
@@ -524,6 +546,7 @@ class CiphertextImpl : public CryptoObject<Element> {
     ar(cereal::make_nvp("s", m_scalingFactor));
     ar(cereal::make_nvp("si", m_scalingFactorInt));
     ar(cereal::make_nvp("e", encodingType));
+    ar(cereal::make_nvp("sl", m_slots));
     ar(cereal::make_nvp("m", m_metadataMap));
   }
 
@@ -542,6 +565,7 @@ class CiphertextImpl : public CryptoObject<Element> {
     ar(cereal::make_nvp("s", m_scalingFactor));
     ar(cereal::make_nvp("si", m_scalingFactorInt));
     ar(cereal::make_nvp("e", encodingType));
+    ar(cereal::make_nvp("sl", m_slots));
     ar(cereal::make_nvp("m", m_metadataMap));
   }
 
@@ -564,6 +588,7 @@ class CiphertextImpl : public CryptoObject<Element> {
 
   uint32_t m_hopslevel;  // Parameter for re-encryption to store the number of
                        // times the ciphertext has been re-encrypted.
+  uint32_t m_slots;
   // A map to hold different Metadata objects - used for flexible extensions of
   // Ciphertext
   MetadataMap m_metadataMap;

--- a/src/pke/include/cryptocontext.h
+++ b/src/pke/include/cryptocontext.h
@@ -899,7 +899,7 @@ protected:
    */
   virtual Plaintext MakeCKKSPackedPlaintext(
       const std::vector<std::complex<double>>& value, size_t depth = 1,
-      uint32_t level = 0, const std::shared_ptr<ParmType> params = nullptr) const {
+      uint32_t level = 0, const std::shared_ptr<ParmType> params = nullptr, usint slots = 0) const {
     Plaintext p;
     const auto cryptoParams =
         std::dynamic_pointer_cast<CryptoParametersRNS>(
@@ -932,10 +932,10 @@ protected:
 
       p = Plaintext(std::make_shared<CKKSPackedEncoding>(
           elemParamsPtr, this->GetEncodingParams(), value, depth, level,
-          scFact));
+          scFact, slots));
     } else {
       p = Plaintext(std::make_shared<CKKSPackedEncoding>(
-          params, this->GetEncodingParams(), value, depth, level, scFact));
+          params, this->GetEncodingParams(), value, depth, level, scFact, slots));
     }
 
     p->Encode();
@@ -944,7 +944,6 @@ protected:
     if (cryptoParams->GetRescalingTechnique() == FLEXIBLEAUTOEXT && level == 0) {
       p->SetDepth(2);
     }
-  
     return p;
   }
 
@@ -959,12 +958,12 @@ protected:
    */
   virtual Plaintext MakeCKKSPackedPlaintext(
       const std::vector<double>& value, size_t depth = 1, uint32_t level = 0,
-      const std::shared_ptr<ParmType> params = nullptr) const {
+      const std::shared_ptr<ParmType> params = nullptr, usint slots = 0) const {
     std::vector<std::complex<double>> complexValue(value.size());
     std::transform(value.begin(), value.end(), complexValue.begin(),
                    [](double da) { return std::complex<double>(da); });
 
-    return MakeCKKSPackedPlaintext(complexValue, depth, level, params);
+    return MakeCKKSPackedPlaintext(complexValue, depth, level, params, slots);
   }
 
   /**
@@ -1018,6 +1017,7 @@ protected:
       ciphertext->SetScalingFactorInt(plaintext->GetScalingFactorInt());
       ciphertext->SetDepth(plaintext->GetDepth());
       ciphertext->SetLevel(plaintext->GetLevel());
+      ciphertext->SetSlots(plaintext->GetSlots());
     }
 
     return ciphertext;
@@ -1047,6 +1047,7 @@ protected:
       ciphertext->SetScalingFactorInt(plaintext->GetScalingFactorInt());
       ciphertext->SetDepth(plaintext->GetDepth());
       ciphertext->SetLevel(plaintext->GetLevel());
+      ciphertext->SetSlots(plaintext->GetSlots());
     }
 
     return ciphertext;

--- a/src/pke/include/cryptocontext.h
+++ b/src/pke/include/cryptocontext.h
@@ -811,6 +811,7 @@ protected:
    * @param level is the level to encode the plaintext at
    * @return plaintext
    */
+   // TODO (dsuponit): verify and make MakePlaintext() a private member function
   Plaintext MakePlaintext(const PlaintextEncodings encoding, const std::vector<int64_t>& value,
       size_t depth, uint32_t level) const {
     const auto cryptoParams =

--- a/src/pke/include/encoding/ckkspackedencoding.h
+++ b/src/pke/include/encoding/ckkspackedencoding.h
@@ -77,20 +77,34 @@ class CKKSPackedEncoding : public PlaintextImpl {
 
   CKKSPackedEncoding(std::shared_ptr<Poly::Params> vp, EncodingParams ep,
                      const std::vector<std::complex<double>> &coeffs,
-                     size_t depth, uint32_t level, double scFact)
+                     size_t depth, uint32_t level, double scFact, size_t slots = 0)
       : PlaintextImpl(vp, ep), value(coeffs) {
     this->depth = depth;
     this->level = level;
+    if (slots == 0) {
+      this->slots = GetElementRingDimension() / 2;
+    } else if (slots < coeffs.size()) {
+      this->slots = 1 << (usint)std::ceil(std::log2(coeffs.size()));
+    } else {
+      this->slots = 1 << (usint)std::ceil(std::log2(slots));
+    }
     this->scalingFactor = scFact;
     m_logError = 0.0;
   }
 
   CKKSPackedEncoding(std::shared_ptr<NativePoly::Params> vp, EncodingParams ep,
                      const std::vector<std::complex<double>> &coeffs,
-                     size_t depth, uint32_t level, double scFact)
+                     size_t depth, uint32_t level, double scFact, size_t slots = 0)
       : PlaintextImpl(vp, ep), value(coeffs) {
     this->depth = depth;
     this->level = level;
+    if (slots == 0) {
+      this->slots = GetElementRingDimension() / 2;
+    } else if (slots < coeffs.size()) {
+      this->slots = 1 << (usint)std::ceil(std::log2(coeffs.size()));
+    } else {
+      this->slots = 1 << (usint)std::ceil(std::log2(slots));
+    }
     this->scalingFactor = scFact;
     m_logError = 0.0;
   }
@@ -103,10 +117,17 @@ class CKKSPackedEncoding : public PlaintextImpl {
    */
   CKKSPackedEncoding(std::shared_ptr<DCRTPoly::Params> vp, EncodingParams ep,
                      const std::vector<std::complex<double>> &coeffs,
-                     size_t depth, uint32_t level, double scFact)
+                     size_t depth, uint32_t level, double scFact, size_t slots = 0)
       : PlaintextImpl(vp, ep), value(coeffs) {
     this->depth = depth;
     this->level = level;
+    if (slots == 0) {
+      this->slots = GetElementRingDimension() / 2;
+    } else if (slots < coeffs.size()) {
+      this->slots = 1 << (usint)std::ceil(std::log2(coeffs.size()));
+    } else {
+      this->slots = 1 << (usint)std::ceil(std::log2(slots));
+    }
     this->scalingFactor = scFact;
     m_logError = 0.0;
   }
@@ -116,9 +137,16 @@ class CKKSPackedEncoding : public PlaintextImpl {
    * in the same order.
    * @param rhs - The input object to copy.
    */
-  explicit CKKSPackedEncoding(const std::vector<std::complex<double>> &rhs)
+  explicit CKKSPackedEncoding(const std::vector<std::complex<double>> &rhs, size_t slots = 0)
       : PlaintextImpl(std::shared_ptr<Poly::Params>(0), nullptr), value(rhs) {
     depth = 1;
+    if (slots == 0) {
+      this->slots = GetElementRingDimension() / 2;
+    } else if (slots < rhs.size()) {
+      this->slots = 1 << (usint)std::ceil(std::log2(rhs.size()));
+    } else {
+      this->slots = 1 << (usint)std::ceil(std::log2(slots));
+    }
     m_logError = 0.0;
   }
 

--- a/src/pke/include/encoding/ckkspackedencoding.h
+++ b/src/pke/include/encoding/ckkspackedencoding.h
@@ -77,16 +77,26 @@ class CKKSPackedEncoding : public PlaintextImpl {
 
   CKKSPackedEncoding(std::shared_ptr<Poly::Params> vp, EncodingParams ep,
                      const std::vector<std::complex<double>> &coeffs,
-                     size_t depth, uint32_t level, double scFact, size_t slots = 0)
+                     size_t depth, uint32_t level, double scFact, size_t slots)
       : PlaintextImpl(vp, ep), value(coeffs) {
     this->depth = depth;
     this->level = level;
     if (slots == 0) {
       this->slots = GetElementRingDimension() / 2;
-    } else if (slots < coeffs.size()) {
-      this->slots = 1 << (usint)std::ceil(std::log2(coeffs.size()));
     } else {
-      this->slots = 1 << (usint)std::ceil(std::log2(slots));
+      this->slots = slots;
+    }
+
+    if(this->slots < coeffs.size()) {
+      OPENFHE_THROW(
+          config_error,
+              "The number of slots cannot be smaller than value vector size");
+    }
+
+    if((this->slots & (this->slots - 1)) != 0) {
+      OPENFHE_THROW(
+          config_error,
+              "The number of slots should be a power of two");
     }
     this->scalingFactor = scFact;
     m_logError = 0.0;
@@ -94,16 +104,26 @@ class CKKSPackedEncoding : public PlaintextImpl {
 
   CKKSPackedEncoding(std::shared_ptr<NativePoly::Params> vp, EncodingParams ep,
                      const std::vector<std::complex<double>> &coeffs,
-                     size_t depth, uint32_t level, double scFact, size_t slots = 0)
+                     size_t depth, uint32_t level, double scFact, size_t slots)
       : PlaintextImpl(vp, ep), value(coeffs) {
     this->depth = depth;
     this->level = level;
     if (slots == 0) {
       this->slots = GetElementRingDimension() / 2;
-    } else if (slots < coeffs.size()) {
-      this->slots = 1 << (usint)std::ceil(std::log2(coeffs.size()));
     } else {
-      this->slots = 1 << (usint)std::ceil(std::log2(slots));
+      this->slots = slots;
+    }
+
+    if(this->slots < coeffs.size()) {
+      OPENFHE_THROW(
+          config_error,
+              "The number of slots cannot be smaller than value vector size");
+    }
+
+    if((this->slots & (this->slots - 1)) != 0) {
+      OPENFHE_THROW(
+          config_error,
+              "The number of slots should be a power of two");
     }
     this->scalingFactor = scFact;
     m_logError = 0.0;
@@ -117,16 +137,26 @@ class CKKSPackedEncoding : public PlaintextImpl {
    */
   CKKSPackedEncoding(std::shared_ptr<DCRTPoly::Params> vp, EncodingParams ep,
                      const std::vector<std::complex<double>> &coeffs,
-                     size_t depth, uint32_t level, double scFact, size_t slots = 0)
+                     size_t depth, uint32_t level, double scFact, size_t slots)
       : PlaintextImpl(vp, ep), value(coeffs) {
     this->depth = depth;
     this->level = level;
     if (slots == 0) {
       this->slots = GetElementRingDimension() / 2;
-    } else if (slots < coeffs.size()) {
-      this->slots = 1 << (usint)std::ceil(std::log2(coeffs.size()));
     } else {
-      this->slots = 1 << (usint)std::ceil(std::log2(slots));
+      this->slots = slots;
+    }
+
+    if(this->slots < coeffs.size()) {
+      OPENFHE_THROW(
+          config_error,
+              "The number of slots cannot be smaller than value vector size");
+    }
+
+    if((this->slots & (this->slots - 1)) != 0) {
+      OPENFHE_THROW(
+          config_error,
+              "The number of slots should be a power of two");
     }
     this->scalingFactor = scFact;
     m_logError = 0.0;
@@ -137,15 +167,25 @@ class CKKSPackedEncoding : public PlaintextImpl {
    * in the same order.
    * @param rhs - The input object to copy.
    */
-  explicit CKKSPackedEncoding(const std::vector<std::complex<double>> &rhs, size_t slots = 0)
+  explicit CKKSPackedEncoding(const std::vector<std::complex<double>> &rhs, size_t slots)
       : PlaintextImpl(std::shared_ptr<Poly::Params>(0), nullptr), value(rhs) {
     depth = 1;
     if (slots == 0) {
       this->slots = GetElementRingDimension() / 2;
-    } else if (slots < rhs.size()) {
-      this->slots = 1 << (usint)std::ceil(std::log2(rhs.size()));
     } else {
-      this->slots = 1 << (usint)std::ceil(std::log2(slots));
+      this->slots = slots;
+    }
+
+    if(this->slots < rhs.size()) {
+      OPENFHE_THROW(
+          config_error,
+              "The number of slots cannot be smaller than value vector size");
+    }
+
+    if((this->slots & (this->slots - 1)) != 0) {
+      OPENFHE_THROW(
+          config_error,
+              "The number of slots should be a power of two");
     }
     m_logError = 0.0;
   }

--- a/src/pke/include/encoding/ckkspackedencoding.h
+++ b/src/pke/include/encoding/ckkspackedencoding.h
@@ -41,7 +41,6 @@
 
 #include "encoding/encodingparams.h"
 #include "encoding/plaintext.h"
-//#include "utils/inttypes.h"
 #include "constants.h"
 
 namespace lbcrypto {
@@ -57,88 +56,13 @@ namespace lbcrypto {
 class CKKSPackedEncoding : public PlaintextImpl {
  public:
   // these two constructors are used inside of Decrypt
-  CKKSPackedEncoding(std::shared_ptr<Poly::Params> vp, EncodingParams ep)
-      : PlaintextImpl(vp, ep) {
-    depth = 1;
-    m_logError = 0.0;
-  }
-
-  CKKSPackedEncoding(std::shared_ptr<NativePoly::Params> vp, EncodingParams ep)
-      : PlaintextImpl(vp, ep) {
-    depth = 1;
-    m_logError = 0.0;
-  }
-
-  CKKSPackedEncoding(std::shared_ptr<DCRTPoly::Params> vp, EncodingParams ep)
-      : PlaintextImpl(vp, ep) {
-    depth = 1;
-    m_logError = 0.0;
-  }
-
-  CKKSPackedEncoding(std::shared_ptr<Poly::Params> vp, EncodingParams ep,
-                     const std::vector<std::complex<double>> &coeffs,
-                     size_t depth, uint32_t level, double scFact, size_t slots)
-      : PlaintextImpl(vp, ep), value(coeffs) {
-    this->depth = depth;
-    this->level = level;
-    if (slots == 0) {
-      this->slots = GetElementRingDimension() / 2;
-    } else {
-      this->slots = slots;
-    }
-
-    if(this->slots < coeffs.size()) {
-      OPENFHE_THROW(
-          config_error,
-              "The number of slots cannot be smaller than value vector size");
-    }
-
-    if(this->slots > (GetElementRingDimension() / 2)) {
-      OPENFHE_THROW(
-          config_error,
-              "The number of slots cannot be larger than half of ring dimension");
-    }
-
-    if((this->slots & (this->slots - 1)) != 0) {
-      OPENFHE_THROW(
-          config_error,
-              "The number of slots should be a power of two");
-    }
-    this->scalingFactor = scFact;
-    m_logError = 0.0;
-  }
-
-  CKKSPackedEncoding(std::shared_ptr<NativePoly::Params> vp, EncodingParams ep,
-                     const std::vector<std::complex<double>> &coeffs,
-                     size_t depth, uint32_t level, double scFact, size_t slots)
-      : PlaintextImpl(vp, ep), value(coeffs) {
-    this->depth = depth;
-    this->level = level;
-    if (slots == 0) {
-      this->slots = GetElementRingDimension() / 2;
-    } else {
-      this->slots = slots;
-    }
-
-    if(this->slots < coeffs.size()) {
-      OPENFHE_THROW(
-          config_error,
-              "The number of slots cannot be smaller than value vector size");
-    }
-
-    if(this->slots > (GetElementRingDimension() / 2)) {
-      OPENFHE_THROW(
-          config_error,
-              "The number of slots cannot be larger than half of ring dimension");
-    }
-
-    if((this->slots & (this->slots - 1)) != 0) {
-      OPENFHE_THROW(
-          config_error,
-              "The number of slots should be a power of two");
-    }
-    this->scalingFactor = scFact;
-    m_logError = 0.0;
+  template <typename T, typename std::enable_if<
+      std::is_same<T, Poly::Params>::value ||
+      std::is_same<T, NativePoly::Params>::value ||
+      std::is_same<T, DCRTPoly::Params>::value,
+      bool>::type = true>
+      CKKSPackedEncoding(std::shared_ptr<T> vp, EncodingParams ep) : PlaintextImpl(vp, ep) {
+      depth = 1; // TODO (dsuponit): is depth supposed to be initialized to 1 in all constructors?
   }
 
   /*
@@ -147,37 +71,31 @@ class CKKSPackedEncoding : public PlaintextImpl {
    * @param scFact scaling factor of a plaintext of this level at depth 1.
    *
    */
-  CKKSPackedEncoding(std::shared_ptr<DCRTPoly::Params> vp, EncodingParams ep,
-                     const std::vector<std::complex<double>> &coeffs,
-                     size_t depth, uint32_t level, double scFact, size_t slots)
+  template <typename T, typename std::enable_if<
+      std::is_same<T, Poly::Params>::value ||
+      std::is_same<T, NativePoly::Params>::value ||
+      std::is_same<T, DCRTPoly::Params>::value,
+      bool>::type = true>
+      CKKSPackedEncoding(std::shared_ptr<T> vp, EncodingParams ep,
+          const std::vector<std::complex<double>>& coeffs,
+          size_t depth, uint32_t level, double scFact, size_t slots)
       : PlaintextImpl(vp, ep), value(coeffs) {
-    this->depth = depth;
-    this->level = level;
-    if (slots == 0) {
-      this->slots = GetElementRingDimension() / 2;
-    } else {
-      this->slots = slots;
-    }
+      // validate the number of slots
+      if ((slots & (slots - 1)) != 0) {
+          OPENFHE_THROW(config_error, "The number of slots should be a power of two");
+      }
 
-    if(this->slots < coeffs.size()) {
-      OPENFHE_THROW(
-          config_error,
-              "The number of slots cannot be smaller than value vector size");
-    }
+      this->slots = (slots == 0) ? GetElementRingDimension() / 2 : slots;
+      if (this->slots < coeffs.size()) {
+          OPENFHE_THROW(config_error, "The number of slots cannot be smaller than value vector size");
+      }
+      else if (this->slots > (GetElementRingDimension() / 2)) {
+          OPENFHE_THROW(config_error, "The number of slots cannot be larger than half of ring dimension");
+      }
 
-    if(this->slots > (GetElementRingDimension() / 2)) {
-      OPENFHE_THROW(
-          config_error,
-              "The number of slots cannot be larger than half of ring dimension");
-    }
-
-    if((this->slots & (this->slots - 1)) != 0) {
-      OPENFHE_THROW(
-          config_error,
-              "The number of slots should be a power of two");
-    }
-    this->scalingFactor = scFact;
-    m_logError = 0.0;
+      this->depth = depth;
+      this->level = level;
+      this->scalingFactor = scFact;
   }
 
   /**
@@ -187,31 +105,20 @@ class CKKSPackedEncoding : public PlaintextImpl {
    */
   explicit CKKSPackedEncoding(const std::vector<std::complex<double>> &rhs, size_t slots)
       : PlaintextImpl(std::shared_ptr<Poly::Params>(0), nullptr), value(rhs) {
-    depth = 1;
-    if (slots == 0) {
-      this->slots = GetElementRingDimension() / 2;
-    } else {
-      this->slots = slots;
-    }
+      // validate the number of slots
+      if ((slots & (slots - 1)) != 0) {
+          OPENFHE_THROW(config_error, "The number of slots should be a power of two");
+      }
 
-    if(this->slots < rhs.size()) {
-      OPENFHE_THROW(
-          config_error,
-              "The number of slots cannot be smaller than value vector size");
-    }
+      this->slots = (slots == 0) ? GetElementRingDimension() / 2 : slots;
+      if (this->slots < rhs.size()) {
+          OPENFHE_THROW(config_error, "The number of slots cannot be smaller than value vector size");
+      }
+      else if (this->slots > (GetElementRingDimension() / 2)) {
+          OPENFHE_THROW(config_error, "The number of slots cannot be larger than half of ring dimension");
+      }
 
-    if(this->slots > (GetElementRingDimension() / 2)) {
-      OPENFHE_THROW(
-          config_error,
-              "The number of slots cannot be larger than half of ring dimension");
-    }
-
-    if((this->slots & (this->slots - 1)) != 0) {
-      OPENFHE_THROW(
-          config_error,
-              "The number of slots should be a power of two");
-    }
-    m_logError = 0.0;
+      depth = 1;
   }
 
   /**
@@ -220,24 +127,19 @@ class CKKSPackedEncoding : public PlaintextImpl {
   CKKSPackedEncoding()
       : PlaintextImpl(std::shared_ptr<Poly::Params>(0), nullptr), value() {
     depth = 1;
-    m_logError = 0.0;
   }
 
   CKKSPackedEncoding(const CKKSPackedEncoding &rhs)
       : PlaintextImpl(rhs), value(rhs.value), m_logError(rhs.m_logError) {}
 
   CKKSPackedEncoding(const CKKSPackedEncoding &&rhs)
-      : PlaintextImpl(rhs),
-        value(std::move(rhs.value)),
-        m_logError(rhs.m_logError) {}
+      : PlaintextImpl(rhs), value(std::move(rhs.value)), m_logError(rhs.m_logError) {}
 
   bool Encode();
 
   bool Decode() {
-    OPENFHE_THROW(
-        not_available_error,
-        "CKKSPackedEncoding::Decode() is not implemented. "
-        "Use CKKSPackedEncoding::Decode(depth,scalingFactor,rstech) instead.");
+    OPENFHE_THROW(not_available_error,
+        "CKKSPackedEncoding::Decode() is not implemented. Use CKKSPackedEncoding::Decode(depth,scalingFactor,rstech) instead.");
   }
 
   bool Decode(size_t depth, double scalingFactor, RescalingTechnique rsTech);
@@ -339,7 +241,7 @@ class CKKSPackedEncoding : public PlaintextImpl {
  private:
   std::vector<std::complex<double>> value;
 
-  double m_logError;
+  double m_logError = 0;
 
  protected:
   /**

--- a/src/pke/include/encoding/ckkspackedencoding.h
+++ b/src/pke/include/encoding/ckkspackedencoding.h
@@ -85,7 +85,12 @@ class CKKSPackedEncoding : public PlaintextImpl {
           OPENFHE_THROW(config_error, "The number of slots should be a power of two");
       }
 
-      this->slots = (slots == 0) ? GetElementRingDimension() / 2 : slots;
+      if (0 == slots) {
+          auto batchSize = GetEncodingParams()->GetBatchSize();
+          this->slots = (0 == batchSize) ? GetElementRingDimension() / 2 : batchSize;
+      } else {
+        this->slots = slots;
+      }
       if (this->slots < coeffs.size()) {
           OPENFHE_THROW(config_error, "The number of slots cannot be smaller than value vector size");
       }
@@ -110,7 +115,12 @@ class CKKSPackedEncoding : public PlaintextImpl {
           OPENFHE_THROW(config_error, "The number of slots should be a power of two");
       }
 
-      this->slots = (slots == 0) ? GetElementRingDimension() / 2 : slots;
+      if (0 == slots) {
+          auto batchSize = GetEncodingParams()->GetBatchSize();
+          this->slots = (0 == batchSize) ? GetElementRingDimension() / 2 : batchSize;
+      } else {
+        this->slots = slots;
+      }
       if (this->slots < rhs.size()) {
           OPENFHE_THROW(config_error, "The number of slots cannot be smaller than value vector size");
       }

--- a/src/pke/include/encoding/ckkspackedencoding.h
+++ b/src/pke/include/encoding/ckkspackedencoding.h
@@ -93,6 +93,12 @@ class CKKSPackedEncoding : public PlaintextImpl {
               "The number of slots cannot be smaller than value vector size");
     }
 
+    if(this->slots > (GetElementRingDimension() / 2)) {
+      OPENFHE_THROW(
+          config_error,
+              "The number of slots cannot be larger than half of ring dimension");
+    }
+
     if((this->slots & (this->slots - 1)) != 0) {
       OPENFHE_THROW(
           config_error,
@@ -118,6 +124,12 @@ class CKKSPackedEncoding : public PlaintextImpl {
       OPENFHE_THROW(
           config_error,
               "The number of slots cannot be smaller than value vector size");
+    }
+
+    if(this->slots > (GetElementRingDimension() / 2)) {
+      OPENFHE_THROW(
+          config_error,
+              "The number of slots cannot be larger than half of ring dimension");
     }
 
     if((this->slots & (this->slots - 1)) != 0) {
@@ -153,6 +165,12 @@ class CKKSPackedEncoding : public PlaintextImpl {
               "The number of slots cannot be smaller than value vector size");
     }
 
+    if(this->slots > (GetElementRingDimension() / 2)) {
+      OPENFHE_THROW(
+          config_error,
+              "The number of slots cannot be larger than half of ring dimension");
+    }
+
     if((this->slots & (this->slots - 1)) != 0) {
       OPENFHE_THROW(
           config_error,
@@ -180,6 +198,12 @@ class CKKSPackedEncoding : public PlaintextImpl {
       OPENFHE_THROW(
           config_error,
               "The number of slots cannot be smaller than value vector size");
+    }
+
+    if(this->slots > (GetElementRingDimension() / 2)) {
+      OPENFHE_THROW(
+          config_error,
+              "The number of slots cannot be larger than half of ring dimension");
     }
 
     if((this->slots & (this->slots - 1)) != 0) {

--- a/src/pke/include/encoding/plaintext.h
+++ b/src/pke/include/encoding/plaintext.h
@@ -111,6 +111,7 @@ class PlaintextImpl {
   NativeInteger scalingFactorInt;
   size_t level;
   size_t depth;
+  usint slots;
 
  public:
   PlaintextImpl(std::shared_ptr<Poly::Params> vp, EncodingParams ep,
@@ -122,7 +123,8 @@ class PlaintextImpl {
         scalingFactor(1),
         scalingFactorInt(1),
         level(0),
-        depth(1) {}
+        depth(1),
+        slots(0) {}
 
   PlaintextImpl(std::shared_ptr<NativePoly::Params> vp, EncodingParams ep,
                 bool isEncoded = false)
@@ -133,7 +135,8 @@ class PlaintextImpl {
         scalingFactor(1),
         scalingFactorInt(1),
         level(0),
-        depth(1) {}
+        depth(1),
+        slots(0) {}
 
   PlaintextImpl(std::shared_ptr<DCRTPoly::Params> vp, EncodingParams ep,
                 bool isEncoded = false)
@@ -145,7 +148,8 @@ class PlaintextImpl {
         scalingFactor(1),
         scalingFactorInt(1),
         level(0),
-        depth(1) {}
+        depth(1),
+        slots(0) {}
 
   PlaintextImpl(const PlaintextImpl& rhs)
       : isEncoded(rhs.isEncoded),
@@ -156,7 +160,8 @@ class PlaintextImpl {
         scalingFactor(rhs.scalingFactor),
         scalingFactorInt(rhs.scalingFactorInt),
         level(rhs.level),
-        depth(rhs.depth) {}
+        depth(rhs.depth),
+        slots(rhs.slots) {}
 
   PlaintextImpl(const PlaintextImpl&& rhs)
       : isEncoded(rhs.isEncoded),
@@ -167,7 +172,8 @@ class PlaintextImpl {
         scalingFactor(rhs.scalingFactor),
         scalingFactorInt(rhs.scalingFactorInt),
         level(rhs.level),
-        depth(rhs.depth) {}
+        depth(rhs.depth),
+        slots(rhs.slots) {}
 
   virtual ~PlaintextImpl() {}
 
@@ -333,6 +339,18 @@ class PlaintextImpl {
    * Method to set the level of a plaintext.
    */
   void SetLevel(size_t l) { level = l; }
+
+  /*
+   * Method to get the level of a plaintext.
+   *
+   * @return the level of the plaintext
+   */
+  usint GetSlots() const { return slots; }
+
+  /*
+   * Method to set the level of a plaintext.
+   */
+  void SetSlots(usint l) { slots = l; }
 
   virtual double GetLogError() const {
     OPENFHE_THROW(not_available_error,

--- a/src/pke/lib/cryptocontext.cpp
+++ b/src/pke/lib/cryptocontext.cpp
@@ -535,6 +535,7 @@ DecryptResult CryptoContextImpl<Element>::Decrypt(
     decryptedCKKS->SetDepth(ciphertext->GetDepth());
     decryptedCKKS->SetLevel(ciphertext->GetLevel());
     decryptedCKKS->SetScalingFactor(ciphertext->GetScalingFactor());
+    decryptedCKKS->SetSlots(ciphertext->GetSlots());
 
     const auto cryptoParamsCKKS =
         std::dynamic_pointer_cast<CryptoParametersRNS>(
@@ -672,6 +673,7 @@ namespace lbcrypto {
             decryptedCKKS->SetDepth(ciphertext->GetDepth());
             decryptedCKKS->SetLevel(ciphertext->GetLevel());
             decryptedCKKS->SetScalingFactor(ciphertext->GetScalingFactor());
+            decryptedCKKS->SetSlots(ciphertext->GetSlots());
 
             const auto cryptoParamsCKKS =
                 std::dynamic_pointer_cast<CryptoParametersCKKSRNS>(

--- a/src/pke/lib/cryptocontext.cpp
+++ b/src/pke/lib/cryptocontext.cpp
@@ -595,6 +595,7 @@ DecryptResult CryptoContextImpl<Element>::MultipartyDecryptFusion(
   if (partialCiphertextVec[0]->GetEncodingType() == CKKSPacked) {
     auto decryptedCKKS =
         std::static_pointer_cast<CKKSPackedEncoding>(decrypted);
+    decryptedCKKS->SetSlots(partialCiphertextVec[0]->GetSlots());
     const auto cryptoParamsCKKS =
         std::dynamic_pointer_cast<CryptoParametersRNS>(
             this->GetCryptoParameters());
@@ -740,6 +741,7 @@ namespace lbcrypto {
         if (partialCiphertextVec[0]->GetEncodingType() == CKKSPacked) {
             auto decryptedCKKS =
                 std::static_pointer_cast<CKKSPackedEncoding>(decrypted);
+            decryptedCKKS->SetSlots(partialCiphertextVec[0]->GetSlots());
             const auto cryptoParamsCKKS =
                 std::dynamic_pointer_cast<CryptoParametersCKKSRNS>(
                     this->GetCryptoParameters());

--- a/src/pke/lib/encoding/ckkspackedencoding.cpp
+++ b/src/pke/lib/encoding/ckkspackedencoding.cpp
@@ -54,6 +54,9 @@ std::vector<std::complex<double>> Conjugate(
 double StdDev(const std::vector<std::complex<double>> &vec,
               const std::vector<std::complex<double>> &conjugate) {
   uint32_t slots = vec.size();
+  if (1 == slots) {
+    return vec[0].imag();
+  }
   // ring dimension
   uint32_t dslots = slots * 2;
 

--- a/src/pke/lib/encoding/ckkspackedencoding.cpp
+++ b/src/pke/lib/encoding/ckkspackedencoding.cpp
@@ -184,7 +184,7 @@ bool CKKSPackedEncoding::Encode() {
       temp[i] = (re < 0) ? Max128BitValue() + re : re;
       temp[i + slots] = (im < 0) ? Max128BitValue() + im : im;
 
-      if (is128BitOverflow(temp[i]) || is128BitOverflow(temp[i + Nh])) {
+      if (is128BitOverflow(temp[i]) || is128BitOverflow(temp[i + slots])) {
         OPENFHE_THROW(math_error, "Overflow, try to decrease scaling factor");
       }
     }
@@ -521,7 +521,7 @@ bool CKKSPackedEncoding::Decode(size_t depth, double scalingFactor,
                    "too high. Check the parameters. ");
 
   // real values
-  std::vector<std::complex<double>> realValues(Nh);
+  std::vector<std::complex<double>> realValues(slots);
 
   // CKKS_M_FACTOR is a compile-level parameter
   // set to 1 by default

--- a/src/pke/lib/scheme/ckksrns/ckksrns-leveledshe.cpp
+++ b/src/pke/lib/scheme/ckksrns/ckksrns-leveledshe.cpp
@@ -157,6 +157,7 @@ Ciphertext<DCRTPoly> LeveledSHECKKSRNS::EvalMultFixed(
   result->SetScalingFactor(ciphertext->GetScalingFactor() *
                            plaintext->GetScalingFactor());
   result->SetLevel(ciphertext->GetLevel());
+  result->SetSlots(ciphertext->GetSlots());
 
   return result;
 }
@@ -221,6 +222,7 @@ Ciphertext<DCRTPoly> LeveledSHECKKSRNS::EvalMultMutable(
   result->SetDepth(ciphertext->GetDepth() + ptxDepth);
   result->SetScalingFactor(ciphertext->GetScalingFactor() * ptxSF);
   result->SetLevel(ciphertext->GetLevel());
+  result->SetSlots(ciphertext->GetSlots());
 
   return result;
 }
@@ -594,6 +596,7 @@ Ciphertext<DCRTPoly> LeveledSHECKKSRNS::EvalAddCore(
   result->SetDepth(ciphertext->GetDepth());
   result->SetLevel(ciphertext->GetLevel());
   result->SetScalingFactor(ciphertext->GetScalingFactor());
+  result->SetSlots(ciphertext->GetSlots());
 
   return result;
 }
@@ -653,6 +656,7 @@ Ciphertext<DCRTPoly> LeveledSHECKKSRNS::EvalSubCore(
   result->SetDepth(ciphertext->GetDepth());
   result->SetLevel(ciphertext->GetLevel());
   result->SetScalingFactor(ciphertext->GetScalingFactor());
+  result->SetSlots(ciphertext->GetSlots());
 
   return result;
 }

--- a/src/pke/lib/schemerns/rns-multiparty.cpp
+++ b/src/pke/lib/schemerns/rns-multiparty.cpp
@@ -90,6 +90,7 @@ Ciphertext<DCRTPoly> MultipartyRNS::MultipartyDecryptLead(
   result->SetLevel(ciphertext->GetLevel());
   result->SetScalingFactor(ciphertext->GetScalingFactor());
   result->SetScalingFactorInt(ciphertext->GetScalingFactorInt());
+  result->SetSlots(ciphertext->GetSlots());
 
   return result;
 }
@@ -126,6 +127,7 @@ Ciphertext<DCRTPoly> MultipartyRNS::MultipartyDecryptMain(
   result->SetLevel(ciphertext->GetLevel());
   result->SetScalingFactor(ciphertext->GetScalingFactor());
   result->SetScalingFactorInt(ciphertext->GetScalingFactorInt());
+  result->SetSlots(ciphertext->GetSlots());
 
   return result;
 }

--- a/src/pke/unittest/UnitTestMultiparty.cpp
+++ b/src/pke/unittest/UnitTestMultiparty.cpp
@@ -83,6 +83,7 @@ struct TEST_CASE_UTMultiparty {
 
     // additional test case data
     bool star;
+    uint32_t slots = 0;
 
 
     std::string buildTestName() const {
@@ -110,75 +111,132 @@ static std::ostream& operator<<(std::ostream& os, const TEST_CASE_UTMultiparty& 
 constexpr usint BATCH = 16;
 // clang-format off
 static std::vector<TEST_CASE_UTMultiparty> testCases = {
-    // TestType,   Descr, Scheme,          RDim, MultDepth, SFBits, RWin, BatchSz, Mode, Depth, MDepth, ModSize, SecLvl,       KSTech, RSTech,          LDigits, PtMod, StdDev, EvalAddCt, EvalMultCt, KSCt, MultTech, Star
-    { CKKSRNS_TEST, "01", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    false },
-    { CKKSRNS_TEST, "02", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDAUTO,       DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    false },
-    { CKKSRNS_TEST, "03", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    false },
-    { CKKSRNS_TEST, "04", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDAUTO,       DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    false },
-    { CKKSRNS_TEST, "05", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    true },
-    { CKKSRNS_TEST, "06", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDAUTO,       DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    true },
-    { CKKSRNS_TEST, "07", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    true },
-    { CKKSRNS_TEST, "08", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDAUTO,       DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    true },
+    // TestType,   Descr, Scheme,          RDim, MultDepth, SFBits, RWin, BatchSz, Mode, Depth, MDepth, ModSize, SecLvl,       KSTech, RSTech,          LDigits, PtMod, StdDev, EvalAddCt, EvalMultCt, KSCt, MultTech, Star, Slots
+    { CKKSRNS_TEST, "01", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    false,    0},
+    { CKKSRNS_TEST, "02", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDAUTO,       DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    false,    0},
+    { CKKSRNS_TEST, "03", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    false,    0},
+    { CKKSRNS_TEST, "04", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDAUTO,       DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    false,    0},
+    { CKKSRNS_TEST, "05", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    true,     0},
+    { CKKSRNS_TEST, "06", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDAUTO,       DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    true,     0},
+    { CKKSRNS_TEST, "07", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    true,     0},
+    { CKKSRNS_TEST, "08", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDAUTO,       DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    true,     0},
 #if NATIVEINT != 128
-    { CKKSRNS_TEST, "09", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    false },
-    { CKKSRNS_TEST, "10", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    false },
-    { CKKSRNS_TEST, "11", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    false },
-    { CKKSRNS_TEST, "12", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    false },
-    { CKKSRNS_TEST, "13", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    true },
-    { CKKSRNS_TEST, "14", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    true },
-    { CKKSRNS_TEST, "15", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    true },
-    { CKKSRNS_TEST, "16", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    true },
+    { CKKSRNS_TEST, "09", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    false,    0},
+    { CKKSRNS_TEST, "10", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    false,    0},
+    { CKKSRNS_TEST, "11", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    false,    0},
+    { CKKSRNS_TEST, "12", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    false,    0},
+    { CKKSRNS_TEST, "13", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    true,     0},
+    { CKKSRNS_TEST, "14", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    true,     0},
+    { CKKSRNS_TEST, "15", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    true,     0},
+    { CKKSRNS_TEST, "16", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    true,     0},
+#endif
+    // TestType,   Descr, Scheme,          RDim, MultDepth, SFBits, RWin, BatchSz, Mode, Depth, MDepth, ModSize, SecLvl,       KSTech, RSTech,          LDigits, PtMod, StdDev, EvalAddCt, EvalMultCt, KSCt, MultTech, Star, Slots
+    { CKKSRNS_TEST, "21", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    false,   16},
+    { CKKSRNS_TEST, "22", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDAUTO,       DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    false,   16},
+    { CKKSRNS_TEST, "23", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    false,   16},
+    { CKKSRNS_TEST, "24", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDAUTO,       DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    false,   16},
+    { CKKSRNS_TEST, "25", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    true,    16},
+    { CKKSRNS_TEST, "26", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDAUTO,       DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    true,    16},
+    { CKKSRNS_TEST, "27", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    true,    16},
+    { CKKSRNS_TEST, "28", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDAUTO,       DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    true,    16},
+#if NATIVEINT != 128
+    { CKKSRNS_TEST, "29", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    false,   16},
+    { CKKSRNS_TEST, "30", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    false,   16},
+    { CKKSRNS_TEST, "31", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    false,   16},
+    { CKKSRNS_TEST, "32", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    false,   16},
+    { CKKSRNS_TEST, "33", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    true,    16},
+    { CKKSRNS_TEST, "34", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    true,    16},
+    { CKKSRNS_TEST, "35", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    true,    16},
+    { CKKSRNS_TEST, "36", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    true,    16},
+#endif
+    // TestType,   Descr, Scheme,          RDim, MultDepth, SFBits, RWin, BatchSz, Mode, Depth, MDepth, ModSize, SecLvl,       KSTech, RSTech,          LDigits, PtMod, StdDev, EvalAddCt, EvalMultCt, KSCt, MultTech, Star, Slots
+    { CKKSRNS_TEST, "41", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    false,   32},
+    { CKKSRNS_TEST, "42", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDAUTO,       DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    false,   32},
+    { CKKSRNS_TEST, "43", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    false,   32},
+    { CKKSRNS_TEST, "44", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDAUTO,       DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    false,   32},
+    { CKKSRNS_TEST, "45", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    true,    32},
+    { CKKSRNS_TEST, "46", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDAUTO,       DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    true,    32},
+    { CKKSRNS_TEST, "47", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    true,    32},
+    { CKKSRNS_TEST, "48", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDAUTO,       DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    true,    32},
+#if NATIVEINT != 128
+    { CKKSRNS_TEST, "49", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    false,   32},
+    { CKKSRNS_TEST, "50", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    false,   32},
+    { CKKSRNS_TEST, "51", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    false,   32},
+    { CKKSRNS_TEST, "52", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    false,   32},
+    { CKKSRNS_TEST, "53", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    true,    32},
+    { CKKSRNS_TEST, "54", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    true,    32},
+    { CKKSRNS_TEST, "55", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    true,    32},
+    { CKKSRNS_TEST, "56", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    true,    32},
+#endif
+    // TestType,   Descr, Scheme,          RDim, MultDepth, SFBits, RWin, BatchSz, Mode, Depth, MDepth, ModSize, SecLvl,       KSTech, RSTech,          LDigits, PtMod, StdDev, EvalAddCt, EvalMultCt, KSCt, MultTech, Star, Slots
+    { CKKSRNS_TEST, "61", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    false, 1024},
+    { CKKSRNS_TEST, "62", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDAUTO,       DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    false, 1024},
+    { CKKSRNS_TEST, "63", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    false, 1024},
+    { CKKSRNS_TEST, "64", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDAUTO,       DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    false, 1024},
+    { CKKSRNS_TEST, "65", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    true,  1024},
+    { CKKSRNS_TEST, "66", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDAUTO,       DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    true,  1024},
+    { CKKSRNS_TEST, "67", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    true,  1024},
+    { CKKSRNS_TEST, "68", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDAUTO,       DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    true,  1024},
+#if NATIVEINT != 128
+    { CKKSRNS_TEST, "69", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    false, 1024},
+    { CKKSRNS_TEST, "70", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    false, 1024},
+    { CKKSRNS_TEST, "71", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    false, 1024},
+    { CKKSRNS_TEST, "72", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    false, 1024},
+    { CKKSRNS_TEST, "73", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    true,  1024},
+    { CKKSRNS_TEST, "74", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    true,  1024},
+    { CKKSRNS_TEST, "75", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    true,  1024},
+    { CKKSRNS_TEST, "76", {CKKSRNS_SCHEME, 2048, 2,         50,     3,    BATCH,   DFLT, DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   0,         0,          0,    DFLT},    true,  1024},
 #endif
     // ==========================================
-    // TestType,   Descr, Scheme,          RDim, MultDepth, SFBits, RWin, BatchSz, Mode, Depth, MDepth, ModSize, SecLvl,       KSTech, RSTech,       LDigits, PtMod, StdDev, EvalAddCt, EvalMultCt, KSCt, MultTech, Star
-    { BFVRNS_TEST, "01", {BFVRNS_SCHEME,   DFLT, DFLT,      60,    20,    DFLT,    OPTIMIZED, DFLT, DFLT, DFLT,  DFLT,         DFLT,   DFLT,         DFLT,    65537, DFLT,   DFLT,      2,          DFLT, HPS},     false },
-    { BFVRNS_TEST, "02", {BFVRNS_SCHEME,   DFLT, DFLT,      60,    20,    DFLT,    RLWE,      DFLT, DFLT, DFLT,  DFLT,         DFLT,   DFLT,         DFLT,    65537, DFLT,   DFLT,      2,          DFLT, HPS},     false },
-    { BFVRNS_TEST, "03", {BFVRNS_SCHEME,   DFLT, DFLT,      60,    20,    DFLT,    OPTIMIZED, DFLT, DFLT, DFLT,  DFLT,         DFLT,   DFLT,         DFLT,    65537, DFLT,   DFLT,      2,          DFLT, BEHZ},    false },
-    { BFVRNS_TEST, "04", {BFVRNS_SCHEME,   DFLT, DFLT,      60,    20,    DFLT,    RLWE,      DFLT, DFLT, DFLT,  DFLT,         DFLT,   DFLT,         DFLT,    65537, DFLT,   DFLT,      2,          DFLT, BEHZ},    false },
-    { BFVRNS_TEST, "05", {BFVRNS_SCHEME,   DFLT, DFLT,      60,    20,    DFLT,    OPTIMIZED, DFLT, DFLT, DFLT,  DFLT,         DFLT,   DFLT,         DFLT,    65537, DFLT,   DFLT,      2,          DFLT, HPS},     true },
-    { BFVRNS_TEST, "06", {BFVRNS_SCHEME,   DFLT, DFLT,      60,    20,    DFLT,    RLWE,      DFLT, DFLT, DFLT,  DFLT,         DFLT,   DFLT,         DFLT,    65537, DFLT,   DFLT,      2,          DFLT, HPS},     true },
-    { BFVRNS_TEST, "07", {BFVRNS_SCHEME,   DFLT, DFLT,      60,    20,    DFLT,    OPTIMIZED, DFLT, DFLT, DFLT,  DFLT,         DFLT,   DFLT,         DFLT,    65537, DFLT,   DFLT,      2,          DFLT, BEHZ},    true },
-    { BFVRNS_TEST, "08", {BFVRNS_SCHEME,   DFLT, DFLT,      60,    20,    DFLT,    RLWE,      DFLT, DFLT, DFLT,  DFLT,         DFLT,   DFLT,         DFLT,    65537, DFLT,   DFLT,      2,          DFLT, BEHZ},    true },
+    // TestType,   Descr, Scheme,          RDim, MultDepth, SFBits, RWin, BatchSz, Mode, Depth, MDepth, ModSize, SecLvl,       KSTech, RSTech,       LDigits, PtMod, StdDev, EvalAddCt, EvalMultCt, KSCt, MultTech, Star, Slots
+    { BFVRNS_TEST, "01", {BFVRNS_SCHEME,   DFLT, DFLT,      60,    20,    DFLT,    OPTIMIZED, DFLT, DFLT, DFLT,  DFLT,         DFLT,   DFLT,         DFLT,    65537, DFLT,   DFLT,      2,          DFLT, HPS},     false,    0},
+    { BFVRNS_TEST, "02", {BFVRNS_SCHEME,   DFLT, DFLT,      60,    20,    DFLT,    RLWE,      DFLT, DFLT, DFLT,  DFLT,         DFLT,   DFLT,         DFLT,    65537, DFLT,   DFLT,      2,          DFLT, HPS},     false,    0},
+    { BFVRNS_TEST, "03", {BFVRNS_SCHEME,   DFLT, DFLT,      60,    20,    DFLT,    OPTIMIZED, DFLT, DFLT, DFLT,  DFLT,         DFLT,   DFLT,         DFLT,    65537, DFLT,   DFLT,      2,          DFLT, BEHZ},    false,    0},
+    { BFVRNS_TEST, "04", {BFVRNS_SCHEME,   DFLT, DFLT,      60,    20,    DFLT,    RLWE,      DFLT, DFLT, DFLT,  DFLT,         DFLT,   DFLT,         DFLT,    65537, DFLT,   DFLT,      2,          DFLT, BEHZ},    false,    0},
+    { BFVRNS_TEST, "05", {BFVRNS_SCHEME,   DFLT, DFLT,      60,    20,    DFLT,    OPTIMIZED, DFLT, DFLT, DFLT,  DFLT,         DFLT,   DFLT,         DFLT,    65537, DFLT,   DFLT,      2,          DFLT, HPS},     true,     0},
+    { BFVRNS_TEST, "06", {BFVRNS_SCHEME,   DFLT, DFLT,      60,    20,    DFLT,    RLWE,      DFLT, DFLT, DFLT,  DFLT,         DFLT,   DFLT,         DFLT,    65537, DFLT,   DFLT,      2,          DFLT, HPS},     true,     0},
+    { BFVRNS_TEST, "07", {BFVRNS_SCHEME,   DFLT, DFLT,      60,    20,    DFLT,    OPTIMIZED, DFLT, DFLT, DFLT,  DFLT,         DFLT,   DFLT,         DFLT,    65537, DFLT,   DFLT,      2,          DFLT, BEHZ},    true,     0},
+    { BFVRNS_TEST, "08", {BFVRNS_SCHEME,   DFLT, DFLT,      60,    20,    DFLT,    RLWE,      DFLT, DFLT, DFLT,  DFLT,         DFLT,   DFLT,         DFLT,    65537, DFLT,   DFLT,      2,          DFLT, BEHZ},    true,     0},
     // ==========================================
-    // TestType,   Descr, Scheme,          RDim, MultDepth, SFBits, RWin, BatchSz, Mode, Depth, MDepth, ModSize, SecLvl,       KSTech, RSTech,          LDigits, PtMod, StdDev, EvalAddCt, EvalMultCt, KSCt, MultTech, Star
-    { BGVRNS_TEST, "01", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   OPTIMIZED, DFLT, 1,  60,      HEStd_NotSet, BV,     FIXEDMANUAL,     DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    false },
-    { BGVRNS_TEST, "02", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   OPTIMIZED, DFLT, 1,  60,      HEStd_NotSet, BV,     FIXEDAUTO,       DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    false },
-    { BGVRNS_TEST, "03", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   OPTIMIZED, DFLT, 1,  60,      HEStd_NotSet, BV,     FLEXIBLEAUTO,    DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    false },
-    { BGVRNS_TEST, "04", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   OPTIMIZED, DFLT, 1,  60,      HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    false },
-    { BGVRNS_TEST, "05", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   RLWE,      DFLT, 1,  60,      HEStd_NotSet, BV,     FIXEDMANUAL,     DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    false },
-    { BGVRNS_TEST, "06", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   RLWE,      DFLT, 1,  60,      HEStd_NotSet, BV,     FIXEDAUTO,       DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    false },
-    { BGVRNS_TEST, "07", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   RLWE,      DFLT, 1,  60,      HEStd_NotSet, BV,     FLEXIBLEAUTO,    DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    false },
-    { BGVRNS_TEST, "08", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   RLWE,      DFLT, 1,  60,      HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    false },
-    { BGVRNS_TEST, "09", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   OPTIMIZED, DFLT, 1,  60,      HEStd_NotSet, HYBRID, FIXEDMANUAL,     DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    false },
-    { BGVRNS_TEST, "10", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   OPTIMIZED, DFLT, 1,  60,      HEStd_NotSet, HYBRID, FIXEDAUTO,       DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    false },
-    { BGVRNS_TEST, "11", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   OPTIMIZED, DFLT, 1,  60,      HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    false },
-    { BGVRNS_TEST, "12", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   OPTIMIZED, DFLT, 1,  60,      HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    false },
-    { BGVRNS_TEST, "13", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   RLWE,      DFLT, 1,  60,      HEStd_NotSet, HYBRID, FIXEDMANUAL,     DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    false },
-    { BGVRNS_TEST, "14", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   RLWE,      DFLT, 1,  60,      HEStd_NotSet, HYBRID, FIXEDAUTO,       DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    false },
-    { BGVRNS_TEST, "15", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   RLWE,      DFLT, 1,  60,      HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    false },
-    { BGVRNS_TEST, "16", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   RLWE,      DFLT, 1,  60,      HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    false },
-    { BGVRNS_TEST, "17", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   OPTIMIZED, DFLT, 1,  60,      HEStd_NotSet, BV,     FIXEDMANUAL,     DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    true },
-    { BGVRNS_TEST, "18", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   OPTIMIZED, DFLT, 1,  60,      HEStd_NotSet, BV,     FIXEDAUTO,       DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    true },
-    { BGVRNS_TEST, "19", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   OPTIMIZED, DFLT, 1,  60,      HEStd_NotSet, BV,     FLEXIBLEAUTO,    DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    true },
-    { BGVRNS_TEST, "20", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   OPTIMIZED, DFLT, 1,  60,      HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    true },
-    { BGVRNS_TEST, "21", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   RLWE,      DFLT, 1,  60,      HEStd_NotSet, BV,     FIXEDMANUAL,     DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    true },
-    { BGVRNS_TEST, "22", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   RLWE,      DFLT, 1,  60,      HEStd_NotSet, BV,     FIXEDAUTO,       DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    true },
-    { BGVRNS_TEST, "23", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   RLWE,      DFLT, 1,  60,      HEStd_NotSet, BV,     FLEXIBLEAUTO,    DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    true },
-    { BGVRNS_TEST, "24", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   RLWE,      DFLT, 1,  60,      HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    true },
-    { BGVRNS_TEST, "25", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   OPTIMIZED, DFLT, 1,  60,      HEStd_NotSet, HYBRID, FIXEDMANUAL,     DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    true },
-    { BGVRNS_TEST, "26", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   OPTIMIZED, DFLT, 1,  60,      HEStd_NotSet, HYBRID, FIXEDAUTO,       DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    true },
-    { BGVRNS_TEST, "27", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   OPTIMIZED, DFLT, 1,  60,      HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    true },
-    { BGVRNS_TEST, "28", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   OPTIMIZED, DFLT, 1,  60,      HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    true },
-    { BGVRNS_TEST, "29", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   RLWE,      DFLT, 1,  60,      HEStd_NotSet, HYBRID, FIXEDMANUAL,     DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    true },
-    { BGVRNS_TEST, "30", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   RLWE,      DFLT, 1,  60,      HEStd_NotSet, HYBRID, FIXEDAUTO,       DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    true },
-    { BGVRNS_TEST, "31", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   RLWE,      DFLT, 1,  60,      HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    true },
-    { BGVRNS_TEST, "32", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   RLWE,      DFLT, 1,  60,      HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    true },
+    // TestType,   Descr, Scheme,          RDim, MultDepth, SFBits, RWin, BatchSz, Mode, Depth, MDepth, ModSize, SecLvl,       KSTech, RSTech,          LDigits, PtMod, StdDev, EvalAddCt, EvalMultCt, KSCt, MultTech, Star, Slots
+    { BGVRNS_TEST, "01", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   OPTIMIZED, DFLT, 1,  60,      HEStd_NotSet, BV,     FIXEDMANUAL,     DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    false,    0},
+    { BGVRNS_TEST, "02", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   RLWE,      DFLT, 1,  60,      HEStd_NotSet, BV,     FIXEDMANUAL,     DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    false,    0},
+    { BGVRNS_TEST, "03", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   OPTIMIZED, DFLT, 1,  60,      HEStd_NotSet, HYBRID, FIXEDMANUAL,     DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    false,    0},
+    { BGVRNS_TEST, "04", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   RLWE,      DFLT, 1,  60,      HEStd_NotSet, HYBRID, FIXEDMANUAL,     DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    false,    0},
+    { BGVRNS_TEST, "05", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   OPTIMIZED, DFLT, 1,  60,      HEStd_NotSet, BV,     FIXEDMANUAL,     DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    true,     0},
+    { BGVRNS_TEST, "06", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   RLWE,      DFLT, 1,  60,      HEStd_NotSet, BV,     FIXEDMANUAL,     DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    true,     0},
+    { BGVRNS_TEST, "07", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   OPTIMIZED, DFLT, 1,  60,      HEStd_NotSet, HYBRID, FIXEDMANUAL,     DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    true,     0},
+    { BGVRNS_TEST, "08", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   RLWE,      DFLT, 1,  60,      HEStd_NotSet, HYBRID, FIXEDMANUAL,     DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    true,     0},
+    { BGVRNS_TEST, "09", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   OPTIMIZED, DFLT, 1,  60,      HEStd_NotSet, BV,     FIXEDAUTO,       DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    false,    0},
+    { BGVRNS_TEST, "10", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   RLWE,      DFLT, 1,  60,      HEStd_NotSet, BV,     FIXEDAUTO,       DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    false,    0},
+    { BGVRNS_TEST, "11", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   OPTIMIZED, DFLT, 1,  60,      HEStd_NotSet, HYBRID, FIXEDAUTO,       DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    false,    0},
+    { BGVRNS_TEST, "12", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   RLWE,      DFLT, 1,  60,      HEStd_NotSet, HYBRID, FIXEDAUTO,       DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    false,    0},
+    { BGVRNS_TEST, "13", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   OPTIMIZED, DFLT, 1,  60,      HEStd_NotSet, BV,     FIXEDAUTO,       DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    true,     0},
+    { BGVRNS_TEST, "14", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   RLWE,      DFLT, 1,  60,      HEStd_NotSet, BV,     FIXEDAUTO,       DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    true,     0},
+    { BGVRNS_TEST, "15", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   OPTIMIZED, DFLT, 1,  60,      HEStd_NotSet, HYBRID, FIXEDAUTO,       DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    true,     0},
+    { BGVRNS_TEST, "16", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   RLWE,      DFLT, 1,  60,      HEStd_NotSet, HYBRID, FIXEDAUTO,       DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    true,     0},
+    { BGVRNS_TEST, "17", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   OPTIMIZED, DFLT, 1,  60,      HEStd_NotSet, BV,     FLEXIBLEAUTO,    DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    false,    0},
+    { BGVRNS_TEST, "18", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   RLWE,      DFLT, 1,  60,      HEStd_NotSet, BV,     FLEXIBLEAUTO,    DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    false,    0},
+    { BGVRNS_TEST, "19", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   OPTIMIZED, DFLT, 1,  60,      HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    false,    0},
+    { BGVRNS_TEST, "20", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   RLWE,      DFLT, 1,  60,      HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    false,    0},
+    { BGVRNS_TEST, "21", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   OPTIMIZED, DFLT, 1,  60,      HEStd_NotSet, BV,     FLEXIBLEAUTO,    DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    true,     0},
+    { BGVRNS_TEST, "22", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   RLWE,      DFLT, 1,  60,      HEStd_NotSet, BV,     FLEXIBLEAUTO,    DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    true,     0},
+    { BGVRNS_TEST, "23", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   OPTIMIZED, DFLT, 1,  60,      HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    true,     0},
+    { BGVRNS_TEST, "24", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   RLWE,      DFLT, 1,  60,      HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    true,     0},
+    { BGVRNS_TEST, "25", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   OPTIMIZED, DFLT, 1,  60,      HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    false,    0},
+    { BGVRNS_TEST, "26", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   RLWE,      DFLT, 1,  60,      HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    false,    0},
+    { BGVRNS_TEST, "27", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   OPTIMIZED, DFLT, 1,  60,      HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    false,    0},
+    { BGVRNS_TEST, "28", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   RLWE,      DFLT, 1,  60,      HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    false,    0},
+    { BGVRNS_TEST, "29", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   OPTIMIZED, DFLT, 1,  60,      HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    true,     0},
+    { BGVRNS_TEST, "30", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   RLWE,      DFLT, 1,  60,      HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    true,     0},
+    { BGVRNS_TEST, "31", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   OPTIMIZED, DFLT, 1,  60,      HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    true,     0},
+    { BGVRNS_TEST, "32", {BGVRNS_SCHEME,   256,  2,         50,     3,    BATCH,   RLWE,      DFLT, 1,  60,      HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    65537, DFLT,   DFLT,      DFLT,       DFLT, DFLT},    true,     0},
     // ==========================================
-    // TestType,   Descr, Scheme,          RDim, MultDepth, SFBits, RWin, BatchSz, Mode, Depth, MDepth, ModSize, SecLvl,       KSTech, RSTech,       LDigits, PtMod, StdDev, EvalAddCt, EvalMultCt, KSCt, MultTech, Star
-    { BFVRNS_TEST_EXTRA, "01", {BFVRNS_SCHEME, DFLT, DFLT,  60,     20,   DFLT,    RLWE,      DFLT, DFLT, DFLT,  DFLT,         DFLT,   DFLT,         DFLT,    4,     DFLT,   DFLT,      2,          DFLT, HPS},     false },
-    { BFVRNS_TEST_EXTRA, "02", {BFVRNS_SCHEME, DFLT, DFLT,  60,     20,   DFLT,    OPTIMIZED, DFLT, DFLT, DFLT,  DFLT,         DFLT,   DFLT,         DFLT,    16,    DFLT,   DFLT,      2,          DFLT, HPS},     false },
-    { BFVRNS_TEST_EXTRA, "03", {BFVRNS_SCHEME, DFLT, DFLT,  60,     20,   DFLT,    RLWE,      DFLT, DFLT, DFLT,  DFLT,         DFLT,   DFLT,         DFLT,    4,     DFLT,   DFLT,      2,          DFLT, BEHZ},    false },
-    { BFVRNS_TEST_EXTRA, "04", {BFVRNS_SCHEME, DFLT, DFLT,  60,     20,   DFLT,    OPTIMIZED, DFLT, DFLT, DFLT,  DFLT,         DFLT,   DFLT,         DFLT,    16,    DFLT,   DFLT,      2,          DFLT, BEHZ},    false },
+    // TestType,   Descr, Scheme,          RDim, MultDepth, SFBits, RWin, BatchSz, Mode, Depth, MDepth, ModSize, SecLvl,       KSTech, RSTech,       LDigits, PtMod, StdDev, EvalAddCt, EvalMultCt, KSCt, MultTech, Star, Slots
+    { BFVRNS_TEST_EXTRA, "01", {BFVRNS_SCHEME, DFLT, DFLT,  60,     20,   DFLT,    RLWE,      DFLT, DFLT, DFLT,  DFLT,         DFLT,   DFLT,         DFLT,    4,     DFLT,   DFLT,      2,          DFLT, HPS},     false,    0},
+    { BFVRNS_TEST_EXTRA, "02", {BFVRNS_SCHEME, DFLT, DFLT,  60,     20,   DFLT,    OPTIMIZED, DFLT, DFLT, DFLT,  DFLT,         DFLT,   DFLT,         DFLT,    16,    DFLT,   DFLT,      2,          DFLT, HPS},     false,    0},
+    { BFVRNS_TEST_EXTRA, "03", {BFVRNS_SCHEME, DFLT, DFLT,  60,     20,   DFLT,    RLWE,      DFLT, DFLT, DFLT,  DFLT,         DFLT,   DFLT,         DFLT,    4,     DFLT,   DFLT,      2,          DFLT, BEHZ},    false,    0},
+    { BFVRNS_TEST_EXTRA, "04", {BFVRNS_SCHEME, DFLT, DFLT,  60,     20,   DFLT,    OPTIMIZED, DFLT, DFLT, DFLT,  DFLT,         DFLT,   DFLT,         DFLT,    16,    DFLT,   DFLT,      2,          DFLT, BEHZ},    false,    0},
 };
 // clang-format on
 //===========================================================================================================
@@ -248,13 +306,34 @@ protected:
             size_t encodedLength = vectorOfInts1.size();
             std::vector<int64_t> sumInput(encodedLength, 0);
             std::vector<int64_t> multInput(encodedLength, 0);
-            std::vector<int64_t> evalSumInput(encodedLength, 0);
-            std::vector<int64_t> rotateInput(encodedLength, 0);
-
-            // the following loop operates with forward and reverse index
-            for (usint i = 0, rev = (encodedLength - 1); i < encodedLength; ++i, --rev) {
+            for (usint i = 0; i < encodedLength; ++i) {
                 sumInput[i] = vectorOfInts1[i] + vectorOfInts2[i] + vectorOfInts3[i];
                 multInput[i] = vectorOfInts1[i] * vectorOfInts3[i];
+            }
+
+            std::vector<int64_t> evalSumInput(encodedLength, 0);
+            std::vector<int64_t> rotateInput(encodedLength, 0);
+            if (CKKSRNS_TEST == testData.testCaseType) {
+              // For CKKS there is different logic, depending on slots value
+              uint32_t slots = (testData.slots != 0) ? testData.slots : (BATCH != 0) ? BATCH : cc->GetRingDimension() / 2;
+              for (usint i = 0; i < encodedLength; ++i) {
+                evalSumInput[i] = 0;
+                // we add to evalSumInput[i] value vectorOfInts3[(i + j) % BATCH];
+                for (usint j = 0; j < BATCH; ++j) {
+                  if ((i + j) % slots < encodedLength) {
+                    evalSumInput[i] += vectorOfInts3[(i + j) % slots];
+                  }
+                }
+              }
+
+              for (usint i = 0; i < encodedLength; ++i) {
+                if ((slots + i + indices[0]) % slots < encodedLength) {
+                  rotateInput[i] = vectorOfInts1[(slots + i + indices[0]) % slots];
+                }
+              }
+            } else {
+              // For BGV and BFV no slots is given
+              for (usint i = 0, rev = (encodedLength - 1); i < encodedLength; ++i, --rev) {
                 if (i == 0)
                     evalSumInput[rev] = vectorOfInts3[rev];
                 else
@@ -263,7 +342,9 @@ protected:
                     rotateInput[i] = 0;
                 else
                     rotateInput[i] = vectorOfInts1[i + indices[0]];
+              }
             }
+
 
             Plaintext plaintext1(nullptr);
             Plaintext plaintext2(nullptr);
@@ -275,13 +356,13 @@ protected:
             if (CKKSRNS_TEST == testData.testCaseType) {
                 // TODO (dsuponit): we have to rename MakeCKKSPackedPlaintext() to MakePackedPlaintext(). All of them have different input params
                 // for CKKS we need to convert vectors of integers to vectors of complex numbers
-                plaintext1 = cc->MakeCKKSPackedPlaintext(toComplexDoubleVec(vectorOfInts1));
-                plaintext2 = cc->MakeCKKSPackedPlaintext(toComplexDoubleVec(vectorOfInts2));
-                plaintext3 = cc->MakeCKKSPackedPlaintext(toComplexDoubleVec(vectorOfInts3));
-                plaintextSumInput = cc->MakeCKKSPackedPlaintext(toComplexDoubleVec(sumInput));
-                plaintextMultInput = cc->MakeCKKSPackedPlaintext(toComplexDoubleVec(multInput));
-                plaintextEvalSumInput = cc->MakeCKKSPackedPlaintext(toComplexDoubleVec(evalSumInput));
-                plaintextRotateInput = cc->MakeCKKSPackedPlaintext(toComplexDoubleVec(rotateInput));
+                plaintext1 = cc->MakeCKKSPackedPlaintext(toComplexDoubleVec(vectorOfInts1), 1, 0, nullptr, testData.slots);
+                plaintext2 = cc->MakeCKKSPackedPlaintext(toComplexDoubleVec(vectorOfInts2), 1, 0, nullptr, testData.slots);
+                plaintext3 = cc->MakeCKKSPackedPlaintext(toComplexDoubleVec(vectorOfInts3), 1, 0, nullptr, testData.slots);
+                plaintextSumInput = cc->MakeCKKSPackedPlaintext(toComplexDoubleVec(sumInput), 1, 0, nullptr, testData.slots);
+                plaintextMultInput = cc->MakeCKKSPackedPlaintext(toComplexDoubleVec(multInput), 1, 0, nullptr, testData.slots);
+                plaintextEvalSumInput = cc->MakeCKKSPackedPlaintext(toComplexDoubleVec(evalSumInput), 1, 0, nullptr, testData.slots);
+                plaintextRotateInput = cc->MakeCKKSPackedPlaintext(toComplexDoubleVec(rotateInput), 1, 0, nullptr, testData.slots);
             }
             else {
                 plaintext1 = cc->MakePackedPlaintext(vectorOfInts1);

--- a/src/pke/unittest/utckksrns/UnitTestCKKSrns.cpp
+++ b/src/pke/unittest/utckksrns/UnitTestCKKSrns.cpp
@@ -764,6 +764,7 @@ protected:
             results->SetLength(plaintextMult->GetLength());
             checkEquality(plaintextMult->GetCKKSPackedValue(), results->GetCKKSPackedValue(), eps,
                 failmsg + " EvalMult fails");
+            precisions.emplace_back(results->GetLogPrecision());
 
             // Testing operator*
             cResult = ciphertext1 * ciphertext2;
@@ -771,6 +772,7 @@ protected:
             results->SetLength(plaintextMult->GetLength());
             checkEquality(plaintextMult->GetCKKSPackedValue(), results->GetCKKSPackedValue(), eps,
                 failmsg + " operator* fails");
+            precisions.emplace_back(results->GetLogPrecision());
 
             // Testing operator*=
             Ciphertext<Element> cmultInplace(ciphertext1);
@@ -779,6 +781,7 @@ protected:
             results->SetLength(plaintextMult->GetLength());
             checkEquality(plaintextMult->GetCKKSPackedValue(), results->GetCKKSPackedValue(), eps,
                 failmsg + " operator*= fails");
+            precisions.emplace_back(results->GetLogPrecision());
 
             // Testing EvalMult ciphertext * plaintext
             cResult = cc->EvalMult(ciphertext1, plaintext2);
@@ -786,6 +789,7 @@ protected:
             results->SetLength(plaintextMult->GetLength());
             checkEquality(plaintextMult->GetCKKSPackedValue(), results->GetCKKSPackedValue(), eps,
                 failmsg + " EvalMult Ct and Pt fails");
+            precisions.emplace_back(results->GetLogPrecision());
 
             // Testing EvalMult ciphertext * positive double
             cResult = cc->EvalMult(ciphertext1, 1.0);
@@ -793,6 +797,7 @@ protected:
             results->SetLength(plaintext1->GetLength());
             checkEquality(plaintext1->GetCKKSPackedValue(), results->GetCKKSPackedValue(), eps,
                 failmsg + " EvalMult Ct and positive double fails");
+            precisions.emplace_back(results->GetLogPrecision());
 
             // Testing EvalMult ciphertext * negative double
             cResult = cc->EvalMult(ciphertext1, -1.0);
@@ -802,6 +807,7 @@ protected:
             buffer1 << "should be: " << plaintextNeg->GetCKKSPackedValue() << " - we get: " << results->GetCKKSPackedValue();
             checkEquality(plaintextNeg->GetCKKSPackedValue(), results->GetCKKSPackedValue(), eps,
                 failmsg + " EvalMult Ct and negative double fails; " + buffer1.str());
+            precisions.emplace_back(results->GetLogPrecision());
 
             // Testing EvalMultNoRelin ciphertext * ciphertext
             cResult = cc->EvalMultNoRelin(ciphertext1, ciphertext2);
@@ -809,6 +815,7 @@ protected:
             results->SetLength(plaintextMult->GetLength());
             checkEquality(plaintextMult->GetCKKSPackedValue(), results->GetCKKSPackedValue(), eps,
                 failmsg + " EvalMultNoRelin Ct fails");
+            precisions.emplace_back(results->GetLogPrecision());
 
             return true;
         }

--- a/src/pke/unittest/utckksrns/UnitTestCKKSrns.cpp
+++ b/src/pke/unittest/utckksrns/UnitTestCKKSrns.cpp
@@ -174,51 +174,39 @@ static std::vector<TEST_CASE_UTCKKSRNS> testCases = {
 #endif
     // ==========================================
     // TestType,  Descr, Scheme,         RDim, MultDepth, SFBits, RWin,  BatchSz, Mode,       Depth, MDepth, ModSize, SecLvl,       KSTech, RSTech,          LDigits, PtMod, StdDev, EvalAddCt, EvalMultCt, KSCt, MultTech, Slots
-    { ADD_PACKED, "11", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
-    { ADD_PACKED, "12", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
-    { ADD_PACKED, "13", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
-    { ADD_PACKED, "14", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+    { ADD_PACKED, "11", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    BATCH},
+    { ADD_PACKED, "12", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    BATCH},
+    { ADD_PACKED, "13", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    BATCH},
+    { ADD_PACKED, "14", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    BATCH},
 #if NATIVEINT != 128
-    { ADD_PACKED, "15", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
-    { ADD_PACKED, "16", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
-    { ADD_PACKED, "17", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
-    { ADD_PACKED, "18", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+    { ADD_PACKED, "15", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    BATCH},
+    { ADD_PACKED, "16", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    BATCH},
+    { ADD_PACKED, "17", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    BATCH},
+    { ADD_PACKED, "18", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    BATCH},
 #endif
     // ==========================================
     // TestType,  Descr, Scheme,         RDim, MultDepth, SFBits, RWin,  BatchSz, Mode,       Depth, MDepth, ModSize, SecLvl,       KSTech, RSTech,          LDigits, PtMod, StdDev, EvalAddCt, EvalMultCt, KSCt, MultTech, Slots
-    { ADD_PACKED, "21", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    BATCH},
-    { ADD_PACKED, "22", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    BATCH},
-    { ADD_PACKED, "23", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    BATCH},
-    { ADD_PACKED, "24", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    BATCH},
+    { ADD_PACKED, "21", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    32},
+    { ADD_PACKED, "22", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    32},
+    { ADD_PACKED, "23", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    32},
+    { ADD_PACKED, "24", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    32},
 #if NATIVEINT != 128
-    { ADD_PACKED, "25", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    BATCH},
-    { ADD_PACKED, "26", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    BATCH},
-    { ADD_PACKED, "27", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    BATCH},
-    { ADD_PACKED, "28", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    BATCH},
+    { ADD_PACKED, "25", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    32},
+    { ADD_PACKED, "26", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    32},
+    { ADD_PACKED, "27", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    32},
+    { ADD_PACKED, "28", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    32},
 #endif
     // ==========================================
     // TestType,  Descr, Scheme,         RDim, MultDepth, SFBits, RWin,  BatchSz, Mode,       Depth, MDepth, ModSize, SecLvl,       KSTech, RSTech,          LDigits, PtMod, StdDev, EvalAddCt, EvalMultCt, KSCt, MultTech, Slots
-    { ADD_PACKED, "31", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    32},
-    { ADD_PACKED, "32", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    32},
-    { ADD_PACKED, "33", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    32},
-    { ADD_PACKED, "34", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    32},
+    { ADD_PACKED, "31", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    RING_DIM_HALF},
+    { ADD_PACKED, "32", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    RING_DIM_HALF},
+    { ADD_PACKED, "33", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    RING_DIM_HALF},
+    { ADD_PACKED, "34", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    RING_DIM_HALF},
 #if NATIVEINT != 128
-    { ADD_PACKED, "35", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    32},
-    { ADD_PACKED, "36", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    32},
-    { ADD_PACKED, "37", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    32},
-    { ADD_PACKED, "38", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    32},
-#endif
-    // ==========================================
-    // TestType,  Descr, Scheme,         RDim, MultDepth, SFBits, RWin,  BatchSz, Mode,       Depth, MDepth, ModSize, SecLvl,       KSTech, RSTech,          LDigits, PtMod, StdDev, EvalAddCt, EvalMultCt, KSCt, MultTech, Slots
-    { ADD_PACKED, "41", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    RING_DIM_HALF},
-    { ADD_PACKED, "42", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    RING_DIM_HALF},
-    { ADD_PACKED, "43", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    RING_DIM_HALF},
-    { ADD_PACKED, "44", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    RING_DIM_HALF},
-#if NATIVEINT != 128
-    { ADD_PACKED, "45", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    RING_DIM_HALF},
-    { ADD_PACKED, "46", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    RING_DIM_HALF},
-    { ADD_PACKED, "47", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    RING_DIM_HALF},
-    { ADD_PACKED, "48", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    RING_DIM_HALF},
+    { ADD_PACKED, "35", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    RING_DIM_HALF},
+    { ADD_PACKED, "36", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    RING_DIM_HALF},
+    { ADD_PACKED, "37", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    RING_DIM_HALF},
+    { ADD_PACKED, "38", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    RING_DIM_HALF},
 #endif
     // ==========================================
     // TestType,  Descr, Scheme,          RDim, MultDepth, SFBits, RWin,  BatchSz, Mode,       Depth, MDepth, ModSize, SecLvl,       KSTech, RSTech,          LDigits, PtMod, StdDev, EvalAddCt, EvalMultCt, KSCt, MultTech, Slots
@@ -234,15 +222,15 @@ static std::vector<TEST_CASE_UTCKKSRNS> testCases = {
 #endif
     // ==========================================
     // TestType,  Descr, Scheme,          RDim, MultDepth, SFBits, RWin,  BatchSz, Mode,       Depth, MDepth, ModSize, SecLvl,       KSTech, RSTech,          LDigits, PtMod, StdDev, EvalAddCt, EvalMultCt, KSCt, MultTech, Slots
-    { MULT_PACKED, "11", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
-    { MULT_PACKED, "12", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
-    { MULT_PACKED, "13", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
-    { MULT_PACKED, "14", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+    { MULT_PACKED, "11", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+    { MULT_PACKED, "12", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+    { MULT_PACKED, "13", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+    { MULT_PACKED, "14", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
 #if NATIVEINT != 128
-    { MULT_PACKED, "15", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
-    { MULT_PACKED, "16", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
-    { MULT_PACKED, "17", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
-    { MULT_PACKED, "18", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+    { MULT_PACKED, "15", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+    { MULT_PACKED, "16", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+    { MULT_PACKED, "17", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+    { MULT_PACKED, "18", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
 #endif
     // ==========================================
     // TestType,  Descr, Scheme,          RDim, MultDepth, SFBits, RWin,  BatchSz, Mode,       Depth, MDepth, ModSize, SecLvl,       KSTech, RSTech,          LDigits, PtMod, StdDev, EvalAddCt, EvalMultCt, KSCt, MultTech, Slots

--- a/src/pke/unittest/utckksrns/UnitTestCKKSrns.cpp
+++ b/src/pke/unittest/utckksrns/UnitTestCKKSrns.cpp
@@ -161,28 +161,124 @@ constexpr usint SCALE = 50;
 
 // clang-format off
 static std::vector<TEST_CASE_UTCKKSRNS> testCases = {
-    // TestType,  Descr, Scheme,         RDim, MultDepth, SFBits, RWin,  BatchSz, Mode,       Depth, MDepth, ModSize, SecLvl,       KSTech, RSTech,          LDigits, PtMod, StdDev, EvalAddCt, EvalMultCt, KSCt, MultTech
-    { ADD_PACKED, "01", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT}, },
-    { ADD_PACKED, "02", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT}, },
-    { ADD_PACKED, "03", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT}, },
-    { ADD_PACKED, "04", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT}, },
+    // TestType,  Descr, Scheme,         RDim, MultDepth, SFBits, RWin,  BatchSz, Mode,       Depth, MDepth, ModSize, SecLvl,       KSTech, RSTech,          LDigits, PtMod, StdDev, EvalAddCt, EvalMultCt, KSCt, MultTech, Slots
+    { ADD_PACKED, "01", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+    { ADD_PACKED, "02", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+    { ADD_PACKED, "03", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+    { ADD_PACKED, "04", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
 #if NATIVEINT != 128
-    { ADD_PACKED, "05", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT}, },
-    { ADD_PACKED, "06", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT}, },
-    { ADD_PACKED, "07", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT}, },
-    { ADD_PACKED, "08", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT}, },
+    { ADD_PACKED, "05", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+    { ADD_PACKED, "06", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+    { ADD_PACKED, "07", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+    { ADD_PACKED, "08", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
 #endif
     // ==========================================
-    // TestType,  Descr, Scheme,          RDim, MultDepth, SFBits, RWin,  BatchSz, Mode,       Depth, MDepth, ModSize, SecLvl,       KSTech, RSTech,          LDigits, PtMod, StdDev, EvalAddCt, EvalMultCt, KSCt, MultTech
-    { MULT_PACKED, "01", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT}, },
-    { MULT_PACKED, "02", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT}, },
-    { MULT_PACKED, "03", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT}, },
-    { MULT_PACKED, "04", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT}, },
+    // TestType,  Descr, Scheme,         RDim, MultDepth, SFBits, RWin,  BatchSz, Mode,       Depth, MDepth, ModSize, SecLvl,       KSTech, RSTech,          LDigits, PtMod, StdDev, EvalAddCt, EvalMultCt, KSCt, MultTech, Slots
+    { ADD_PACKED, "11", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+    { ADD_PACKED, "12", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+    { ADD_PACKED, "13", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+    { ADD_PACKED, "14", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
 #if NATIVEINT != 128
-    { MULT_PACKED, "05", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT}, },
-    { MULT_PACKED, "06", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT}, },
-    { MULT_PACKED, "07", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT}, },
-    { MULT_PACKED, "08", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT}, },
+    { ADD_PACKED, "15", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+    { ADD_PACKED, "16", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+    { ADD_PACKED, "17", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+    { ADD_PACKED, "18", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+#endif
+    // ==========================================
+    // TestType,  Descr, Scheme,         RDim, MultDepth, SFBits, RWin,  BatchSz, Mode,       Depth, MDepth, ModSize, SecLvl,       KSTech, RSTech,          LDigits, PtMod, StdDev, EvalAddCt, EvalMultCt, KSCt, MultTech, Slots
+    { ADD_PACKED, "21", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    BATCH},
+    { ADD_PACKED, "22", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    BATCH},
+    { ADD_PACKED, "23", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    BATCH},
+    { ADD_PACKED, "24", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    BATCH},
+#if NATIVEINT != 128
+    { ADD_PACKED, "25", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    BATCH},
+    { ADD_PACKED, "26", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    BATCH},
+    { ADD_PACKED, "27", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    BATCH},
+    { ADD_PACKED, "28", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    BATCH},
+#endif
+    // ==========================================
+    // TestType,  Descr, Scheme,         RDim, MultDepth, SFBits, RWin,  BatchSz, Mode,       Depth, MDepth, ModSize, SecLvl,       KSTech, RSTech,          LDigits, PtMod, StdDev, EvalAddCt, EvalMultCt, KSCt, MultTech, Slots
+    { ADD_PACKED, "31", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    32},
+    { ADD_PACKED, "32", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    32},
+    { ADD_PACKED, "33", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    32},
+    { ADD_PACKED, "34", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    32},
+#if NATIVEINT != 128
+    { ADD_PACKED, "35", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    32},
+    { ADD_PACKED, "36", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    32},
+    { ADD_PACKED, "37", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    32},
+    { ADD_PACKED, "38", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    32},
+#endif
+    // ==========================================
+    // TestType,  Descr, Scheme,         RDim, MultDepth, SFBits, RWin,  BatchSz, Mode,       Depth, MDepth, ModSize, SecLvl,       KSTech, RSTech,          LDigits, PtMod, StdDev, EvalAddCt, EvalMultCt, KSCt, MultTech, Slots
+    { ADD_PACKED, "41", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    RING_DIM_HALF},
+    { ADD_PACKED, "42", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    RING_DIM_HALF},
+    { ADD_PACKED, "43", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    RING_DIM_HALF},
+    { ADD_PACKED, "44", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    RING_DIM_HALF},
+#if NATIVEINT != 128
+    { ADD_PACKED, "45", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    RING_DIM_HALF},
+    { ADD_PACKED, "46", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    RING_DIM_HALF},
+    { ADD_PACKED, "47", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    RING_DIM_HALF},
+    { ADD_PACKED, "48", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    RING_DIM_HALF},
+#endif
+    // ==========================================
+    // TestType,  Descr, Scheme,          RDim, MultDepth, SFBits, RWin,  BatchSz, Mode,       Depth, MDepth, ModSize, SecLvl,       KSTech, RSTech,          LDigits, PtMod, StdDev, EvalAddCt, EvalMultCt, KSCt, MultTech, Slots
+    { MULT_PACKED, "01", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+    { MULT_PACKED, "02", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+    { MULT_PACKED, "03", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+    { MULT_PACKED, "04", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+#if NATIVEINT != 128
+    { MULT_PACKED, "05", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+    { MULT_PACKED, "06", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+    { MULT_PACKED, "07", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+    { MULT_PACKED, "08", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+#endif
+    // ==========================================
+    // TestType,  Descr, Scheme,          RDim, MultDepth, SFBits, RWin,  BatchSz, Mode,       Depth, MDepth, ModSize, SecLvl,       KSTech, RSTech,          LDigits, PtMod, StdDev, EvalAddCt, EvalMultCt, KSCt, MultTech, Slots
+    { MULT_PACKED, "11", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+    { MULT_PACKED, "12", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+    { MULT_PACKED, "13", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+    { MULT_PACKED, "14", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+#if NATIVEINT != 128
+    { MULT_PACKED, "15", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+    { MULT_PACKED, "16", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+    { MULT_PACKED, "17", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+    { MULT_PACKED, "18", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   SPARSE,     DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+#endif
+    // ==========================================
+    // TestType,  Descr, Scheme,          RDim, MultDepth, SFBits, RWin,  BatchSz, Mode,       Depth, MDepth, ModSize, SecLvl,       KSTech, RSTech,          LDigits, PtMod, StdDev, EvalAddCt, EvalMultCt, KSCt, MultTech, Slots
+    { MULT_PACKED, "21", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    BATCH},
+    { MULT_PACKED, "22", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    BATCH},
+    { MULT_PACKED, "23", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    BATCH},
+    { MULT_PACKED, "24", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    BATCH},
+#if NATIVEINT != 128
+    { MULT_PACKED, "25", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    BATCH},
+    { MULT_PACKED, "26", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    BATCH},
+    { MULT_PACKED, "27", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    BATCH},
+    { MULT_PACKED, "28", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    BATCH},
+#endif
+    // ==========================================
+    // TestType,  Descr, Scheme,          RDim, MultDepth, SFBits, RWin,  BatchSz, Mode,       Depth, MDepth, ModSize, SecLvl,       KSTech, RSTech,          LDigits, PtMod, StdDev, EvalAddCt, EvalMultCt, KSCt, MultTech, Slots
+    { MULT_PACKED, "31", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    32},
+    { MULT_PACKED, "32", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    32},
+    { MULT_PACKED, "33", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    32},
+    { MULT_PACKED, "34", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    32},
+#if NATIVEINT != 128
+    { MULT_PACKED, "35", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    32},
+    { MULT_PACKED, "36", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    32},
+    { MULT_PACKED, "37", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    32},
+    { MULT_PACKED, "38", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    32},
+#endif
+    // ==========================================
+    // TestType,  Descr, Scheme,          RDim, MultDepth, SFBits, RWin,  BatchSz, Mode,       Depth, MDepth, ModSize, SecLvl,       KSTech, RSTech,          LDigits, PtMod, StdDev, EvalAddCt, EvalMultCt, KSCt, MultTech, Slots
+    { MULT_PACKED, "41", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    RING_DIM_HALF},
+    { MULT_PACKED, "42", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    RING_DIM_HALF},
+    { MULT_PACKED, "43", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    RING_DIM_HALF},
+    { MULT_PACKED, "44", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    RING_DIM_HALF},
+#if NATIVEINT != 128
+    { MULT_PACKED, "45", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    RING_DIM_HALF},
+    { MULT_PACKED, "46", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    RING_DIM_HALF},
+    { MULT_PACKED, "47", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    RING_DIM_HALF},
+    { MULT_PACKED, "48", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    RING_DIM_HALF},
 #endif
     // ==========================================
     // TestType,               Descr, Scheme,          RDim, MultDepth, SFBits, RWin,  BatchSz, Mode,       Depth, MDepth, ModSize, SecLvl,       KSTech, RSTech,          LDigits, PtMod, StdDev, EvalAddCt, EvalMultCt, KSCt, MultTech
@@ -426,14 +522,14 @@ protected:
         try {
             CryptoContext<Element> cc(UnitTestGenerateContext(testData.params));
 
-            Plaintext plaintext1 = cc->MakeCKKSPackedPlaintext(vectorOfInts0_7);
-            Plaintext plaintext1AddScalar = cc->MakeCKKSPackedPlaintext(vectorOfInts0_7_Add);
-            Plaintext plaintext1SubScalar = cc->MakeCKKSPackedPlaintext(vectorOfInts0_7_Sub);
-            Plaintext negatives1 = cc->MakeCKKSPackedPlaintext(vectorOfInts0_7neg);
-            Plaintext plaintext2 = cc->MakeCKKSPackedPlaintext(vectorOfInts7_0);
+            Plaintext plaintext1 = cc->MakeCKKSPackedPlaintext(vectorOfInts0_7, 1, 0, nullptr, testData.slots);
+            Plaintext plaintext1AddScalar = cc->MakeCKKSPackedPlaintext(vectorOfInts0_7_Add, 1, 0, nullptr, testData.slots);
+            Plaintext plaintext1SubScalar = cc->MakeCKKSPackedPlaintext(vectorOfInts0_7_Sub, 1, 0, nullptr, testData.slots);
+            Plaintext negatives1 = cc->MakeCKKSPackedPlaintext(vectorOfInts0_7neg, 1, 0, nullptr, testData.slots);
+            Plaintext plaintext2 = cc->MakeCKKSPackedPlaintext(vectorOfInts7_0, 1, 0, nullptr, testData.slots);
 
-            Plaintext plaintextAdd = cc->MakeCKKSPackedPlaintext(std::vector<std::complex<double>>(VECTOR_SIZE, 7)); // vector of 7s
-            Plaintext plaintextSub = cc->MakeCKKSPackedPlaintext(std::vector<std::complex<double>>{ -7, -5, -3, -1, 1, 3, 5, 7 });
+            Plaintext plaintextAdd = cc->MakeCKKSPackedPlaintext(std::vector<std::complex<double>>(VECTOR_SIZE, 7), 1, 0, nullptr, testData.slots); // vector of 7s
+            Plaintext plaintextSub = cc->MakeCKKSPackedPlaintext(std::vector<std::complex<double>>{ -7, -5, -3, -1, 1, 3, 5, 7 }, 1, 0, nullptr, testData.slots);
 
             // Generate encryption keys
             KeyPair<Element> kp = cc->KeyGen();
@@ -563,11 +659,11 @@ protected:
         try {
             CryptoContext<Element> cc(UnitTestGenerateContext(testData.params));
 
-            Plaintext plaintext1 = cc->MakeCKKSPackedPlaintext(vectorOfInts0_7);
-            Plaintext plaintext2 = cc->MakeCKKSPackedPlaintext(vectorOfInts7_0);
-            Plaintext plaintextNeg = cc->MakeCKKSPackedPlaintext(vectorOfInts0_7_Neg);
+            Plaintext plaintext1 = cc->MakeCKKSPackedPlaintext(vectorOfInts0_7, 1, 0, nullptr, testData.slots);
+            Plaintext plaintext2 = cc->MakeCKKSPackedPlaintext(vectorOfInts7_0, 1, 0, nullptr, testData.slots);
+            Plaintext plaintextNeg = cc->MakeCKKSPackedPlaintext(vectorOfInts0_7_Neg, 1, 0, nullptr, testData.slots);
             Plaintext plaintextMult =
-                cc->MakeCKKSPackedPlaintext(std::vector<std::complex<double>>({ 0, 6,10,12,12,10, 6, 0 }));
+                cc->MakeCKKSPackedPlaintext(std::vector<std::complex<double>>({ 0, 6,10,12,12,10, 6, 0 }), 1, 0, nullptr, testData.slots);
 
             // Generate encryption keys
             KeyPair<Element> kp = cc->KeyGen();

--- a/src/pke/unittest/utckksrns/UnitTestCKKSrns.cpp
+++ b/src/pke/unittest/utckksrns/UnitTestCKKSrns.cpp
@@ -60,6 +60,8 @@ enum TEST_CASE_TYPE {
     RE_ENCRYPTION,
     EVAL_POLY,
     METADATA,
+    ADD_PACKED_PRECISION,
+    MULT_PACKED_PRECISION,
 };
 
 static std::ostream& operator<<(std::ostream& os, const TEST_CASE_TYPE& type) {
@@ -100,6 +102,12 @@ static std::ostream& operator<<(std::ostream& os, const TEST_CASE_TYPE& type) {
         break;
     case METADATA:
         typeName = "METADATA";
+        break;
+    case ADD_PACKED_PRECISION:
+        typeName = "ADD_PACKED_PRECISION";
+        break;
+    case MULT_PACKED_PRECISION:
+        typeName = "MULT_PACKED_PRECISION";
         break;
     default:
         typeName = "UNKNOWN";
@@ -171,6 +179,8 @@ static std::vector<TEST_CASE_UTCKKSRNS> testCases = {
     { ADD_PACKED, "06", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
     { ADD_PACKED, "07", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
     { ADD_PACKED, "08", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+    // TestType,            Descr, Scheme,         RDim, MultDepth, SFBits, RWin,  BatchSz, Mode,       Depth, MDepth, ModSize, SecLvl,       KSTech, RSTech, LDigits, PtMod, StdDev, EvalAddCt, EvalMultCt, KSCt, MultTech, Slots
+    { ADD_PACKED_PRECISION, "09", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, DFLT,   DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
 #endif
     // ==========================================
     // TestType,  Descr, Scheme,         RDim, MultDepth, SFBits, RWin,  BatchSz, Mode,       Depth, MDepth, ModSize, SecLvl,       KSTech, RSTech,          LDigits, PtMod, StdDev, EvalAddCt, EvalMultCt, KSCt, MultTech, Slots
@@ -183,6 +193,8 @@ static std::vector<TEST_CASE_UTCKKSRNS> testCases = {
     { ADD_PACKED, "16", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    BATCH},
     { ADD_PACKED, "17", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    BATCH},
     { ADD_PACKED, "18", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    BATCH},
+    // TestType,            Descr, Scheme,         RDim, MultDepth, SFBits, RWin,  BatchSz, Mode,       Depth, MDepth, ModSize, SecLvl,       KSTech, RSTech, LDigits, PtMod, StdDev, EvalAddCt, EvalMultCt, KSCt, MultTech, Slots
+    { ADD_PACKED_PRECISION, "19", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, DFLT,   DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    BATCH},
 #endif
     // ==========================================
     // TestType,  Descr, Scheme,         RDim, MultDepth, SFBits, RWin,  BatchSz, Mode,       Depth, MDepth, ModSize, SecLvl,       KSTech, RSTech,          LDigits, PtMod, StdDev, EvalAddCt, EvalMultCt, KSCt, MultTech, Slots
@@ -195,6 +207,8 @@ static std::vector<TEST_CASE_UTCKKSRNS> testCases = {
     { ADD_PACKED, "26", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    32},
     { ADD_PACKED, "27", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    32},
     { ADD_PACKED, "28", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    32},
+    // TestType,            Descr, Scheme,         RDim, MultDepth, SFBits, RWin,  BatchSz, Mode,       Depth, MDepth, ModSize, SecLvl,       KSTech, RSTech, LDigits, PtMod, StdDev, EvalAddCt, EvalMultCt, KSCt, MultTech, Slots
+    { ADD_PACKED_PRECISION, "29", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, DFLT,   DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    32},
 #endif
     // ==========================================
     // TestType,  Descr, Scheme,         RDim, MultDepth, SFBits, RWin,  BatchSz, Mode,       Depth, MDepth, ModSize, SecLvl,       KSTech, RSTech,          LDigits, PtMod, StdDev, EvalAddCt, EvalMultCt, KSCt, MultTech, Slots
@@ -207,6 +221,8 @@ static std::vector<TEST_CASE_UTCKKSRNS> testCases = {
     { ADD_PACKED, "36", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    RING_DIM_HALF},
     { ADD_PACKED, "37", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    RING_DIM_HALF},
     { ADD_PACKED, "38", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    RING_DIM_HALF},
+    // TestType,            Descr, Scheme,         RDim, MultDepth, SFBits, RWin,  BatchSz, Mode,       Depth, MDepth, ModSize, SecLvl,       KSTech, RSTech, LDigits, PtMod, StdDev, EvalAddCt, EvalMultCt, KSCt, MultTech, Slots
+    { ADD_PACKED_PRECISION, "39", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, DFLT,   DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    RING_DIM_HALF},
 #endif
     // ==========================================
     // TestType,  Descr, Scheme,          RDim, MultDepth, SFBits, RWin,  BatchSz, Mode,       Depth, MDepth, ModSize, SecLvl,       KSTech, RSTech,          LDigits, PtMod, StdDev, EvalAddCt, EvalMultCt, KSCt, MultTech, Slots
@@ -219,6 +235,8 @@ static std::vector<TEST_CASE_UTCKKSRNS> testCases = {
     { MULT_PACKED, "06", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
     { MULT_PACKED, "07", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
     { MULT_PACKED, "08", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+    // TestType,             Descr, Scheme,         RDim, MultDepth, SFBits, RWin,  BatchSz, Mode,       Depth, MDepth, ModSize, SecLvl,       KSTech, RSTech, LDigits, PtMod, StdDev, EvalAddCt, EvalMultCt, KSCt, MultTech, Slots
+    { MULT_PACKED_PRECISION, "09", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, DFLT,   DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
 #endif
     // ==========================================
     // TestType,  Descr, Scheme,          RDim, MultDepth, SFBits, RWin,  BatchSz, Mode,       Depth, MDepth, ModSize, SecLvl,       KSTech, RSTech,          LDigits, PtMod, StdDev, EvalAddCt, EvalMultCt, KSCt, MultTech, Slots
@@ -231,6 +249,8 @@ static std::vector<TEST_CASE_UTCKKSRNS> testCases = {
     { MULT_PACKED, "16", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
     { MULT_PACKED, "17", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
     { MULT_PACKED, "18", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+    // TestType,             Descr, Scheme,         RDim, MultDepth, SFBits, RWin,  BatchSz, Mode,       Depth, MDepth, ModSize, SecLvl,       KSTech, RSTech, LDigits, PtMod, StdDev, EvalAddCt, EvalMultCt, KSCt, MultTech, Slots
+    { MULT_PACKED_PRECISION, "19", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, DFLT,   DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
 #endif
     // ==========================================
     // TestType,  Descr, Scheme,          RDim, MultDepth, SFBits, RWin,  BatchSz, Mode,       Depth, MDepth, ModSize, SecLvl,       KSTech, RSTech,          LDigits, PtMod, StdDev, EvalAddCt, EvalMultCt, KSCt, MultTech, Slots
@@ -243,6 +263,8 @@ static std::vector<TEST_CASE_UTCKKSRNS> testCases = {
     { MULT_PACKED, "26", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    BATCH},
     { MULT_PACKED, "27", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    BATCH},
     { MULT_PACKED, "28", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    BATCH},
+    // TestType,             Descr, Scheme,         RDim, MultDepth, SFBits, RWin,  BatchSz, Mode,       Depth, MDepth, ModSize, SecLvl,       KSTech, RSTech, LDigits, PtMod, StdDev, EvalAddCt, EvalMultCt, KSCt, MultTech, Slots
+    { MULT_PACKED_PRECISION, "29", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, DFLT,   DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    BATCH},
 #endif
     // ==========================================
     // TestType,  Descr, Scheme,          RDim, MultDepth, SFBits, RWin,  BatchSz, Mode,       Depth, MDepth, ModSize, SecLvl,       KSTech, RSTech,          LDigits, PtMod, StdDev, EvalAddCt, EvalMultCt, KSCt, MultTech, Slots
@@ -255,6 +277,8 @@ static std::vector<TEST_CASE_UTCKKSRNS> testCases = {
     { MULT_PACKED, "36", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    32},
     { MULT_PACKED, "37", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    32},
     { MULT_PACKED, "38", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    32},
+    // TestType,             Descr, Scheme,         RDim, MultDepth, SFBits, RWin,  BatchSz, Mode,       Depth, MDepth, ModSize, SecLvl,       KSTech, RSTech, LDigits, PtMod, StdDev, EvalAddCt, EvalMultCt, KSCt, MultTech, Slots
+    { MULT_PACKED_PRECISION, "39", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, DFLT,   DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    32 },
 #endif
     // ==========================================
     // TestType,  Descr, Scheme,          RDim, MultDepth, SFBits, RWin,  BatchSz, Mode,       Depth, MDepth, ModSize, SecLvl,       KSTech, RSTech,          LDigits, PtMod, StdDev, EvalAddCt, EvalMultCt, KSCt, MultTech, Slots
@@ -267,6 +291,8 @@ static std::vector<TEST_CASE_UTCKKSRNS> testCases = {
     { MULT_PACKED, "46", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    RING_DIM_HALF},
     { MULT_PACKED, "47", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    RING_DIM_HALF},
     { MULT_PACKED, "48", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    RING_DIM_HALF},
+    // TestType,             Descr, Scheme,         RDim, MultDepth, SFBits, RWin,  BatchSz, Mode,       Depth, MDepth, ModSize, SecLvl,       KSTech, RSTech, LDigits, PtMod, StdDev, EvalAddCt, EvalMultCt, KSCt, MultTech, Slots
+    { MULT_PACKED_PRECISION, "49", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, DFLT,   DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    RING_DIM_HALF },
 #endif
     // ==========================================
     // TestType,               Descr, Scheme,          RDim, MultDepth, SFBits, RWin,  BatchSz, Mode,       Depth, MDepth, ModSize, SecLvl,       KSTech, RSTech,          LDigits, PtMod, StdDev, EvalAddCt, EvalMultCt, KSCt, MultTech
@@ -506,7 +532,7 @@ protected:
         CryptoContextFactory<DCRTPoly>::ReleaseAllContexts();
     }
 
-    void UnitTest_Add_Packed(const TEST_CASE_UTCKKSRNS& testData, const std::string& failmsg = std::string()) {
+    bool UnitTest_Add_Packed(const TEST_CASE_UTCKKSRNS& testData, std::vector<uint32_t>& precisions, const std::string& failmsg = std::string()) {
         try {
             CryptoContext<Element> cc(UnitTestGenerateContext(testData.params));
 
@@ -536,6 +562,7 @@ protected:
             results->SetLength(plaintextAdd->GetLength());
             checkEquality(plaintextAdd->GetCKKSPackedValue(), results->GetCKKSPackedValue(), eps,
                 failmsg + " EvalAdd fails");
+            precisions.emplace_back(results->GetLogPrecision());
 
             // Testing EvalAddInPlace
             cc->EvalAddInPlace(ciphertext1_mutable, ciphertext2);
@@ -543,6 +570,7 @@ protected:
             results->SetLength(plaintextAdd->GetLength());
             checkEquality(plaintextAdd->GetCKKSPackedValue(), results->GetCKKSPackedValue(), eps,
                 failmsg + " EvalAddInPlace fails");
+            precisions.emplace_back(results->GetLogPrecision());
 
             // Testing operator+
             cResult = ciphertext1 + ciphertext2;
@@ -550,6 +578,7 @@ protected:
             results->SetLength(plaintextAdd->GetLength());
             checkEquality(plaintextAdd->GetCKKSPackedValue(), results->GetCKKSPackedValue(), eps,
                 failmsg + " operator+ fails");
+            precisions.emplace_back(results->GetLogPrecision());
 
             // Testing operator+=
             Ciphertext<Element> caddInplace(ciphertext1);
@@ -558,6 +587,7 @@ protected:
             results->SetLength(plaintextAdd->GetLength());
             checkEquality(plaintextAdd->GetCKKSPackedValue(), results->GetCKKSPackedValue(), eps,
                 failmsg + " operator+= fails");
+            precisions.emplace_back(results->GetLogPrecision());
 
             // Testing EvalSub
             cResult = cc->EvalSub(ciphertext1, ciphertext2);
@@ -565,6 +595,7 @@ protected:
             results->SetLength(plaintextSub->GetLength());
             checkEquality(plaintextSub->GetCKKSPackedValue(), results->GetCKKSPackedValue(), eps,
                 failmsg + " EvalSub fails");
+            precisions.emplace_back(results->GetLogPrecision());
 
             // Testing operator-
             cResult = ciphertext1 - ciphertext2;
@@ -572,6 +603,7 @@ protected:
             results->SetLength(plaintextSub->GetLength());
             checkEquality(plaintextSub->GetCKKSPackedValue(), results->GetCKKSPackedValue(), eps,
                 failmsg + " operator- fails");
+            precisions.emplace_back(results->GetLogPrecision());
 
             // Testing operator-=
             Ciphertext<Element> csubInplace(ciphertext1);
@@ -580,6 +612,7 @@ protected:
             results->SetLength(plaintextSub->GetLength());
             checkEquality(plaintextSub->GetCKKSPackedValue(), results->GetCKKSPackedValue(), eps,
                 failmsg + " operator-= fails");
+            precisions.emplace_back(results->GetLogPrecision());
 
             // Testing EvalAdd ciphertext + plaintext
             cResult = cc->EvalAdd(ciphertext1, plaintext2);
@@ -587,6 +620,7 @@ protected:
             results->SetLength(plaintextAdd->GetLength());
             checkEquality(plaintextAdd->GetCKKSPackedValue(), results->GetCKKSPackedValue(), eps,
                 failmsg + " EvalAdd Ct and Pt fails");
+            precisions.emplace_back(results->GetLogPrecision());
 
             // Testing EvalSub ciphertext - plaintext
             cResult = cc->EvalSub(ciphertext1, plaintext2);
@@ -594,6 +628,7 @@ protected:
             results->SetLength(plaintextSub->GetLength());
             checkEquality(plaintextSub->GetCKKSPackedValue(), results->GetCKKSPackedValue(), eps,
                 failmsg + " EvalSub Ct and Pt fails fails");
+            precisions.emplace_back(results->GetLogPrecision());
 
             // Testing EvalAdd ciphertext + double
             cResult = cc->EvalAdd(ciphertext1, 0.5);
@@ -601,6 +636,7 @@ protected:
             results->SetLength(plaintext1AddScalar->GetLength());
             checkEquality(plaintext1AddScalar->GetCKKSPackedValue(), results->GetCKKSPackedValue(), eps,
                 failmsg + " EvalAdd Ct and Double fails");
+            precisions.emplace_back(results->GetLogPrecision());
 
             // Testing EvalAdd ciphertext - double
             cResult = cc->EvalSub(ciphertext1, 0.5);
@@ -608,6 +644,7 @@ protected:
             results->SetLength(plaintext1SubScalar->GetLength());
             checkEquality(plaintext1SubScalar->GetCKKSPackedValue(), results->GetCKKSPackedValue(), eps,
                 failmsg + " EvalSub Ct and Double fails");
+            precisions.emplace_back(results->GetLogPrecision());
 
             // Testing EvalAdd ciphertext + negative double
             cResult = cc->EvalAdd(ciphertext1, -0.5);
@@ -615,6 +652,7 @@ protected:
             results->SetLength(plaintext1SubScalar->GetLength());
             checkEquality(plaintext1SubScalar->GetCKKSPackedValue(), results->GetCKKSPackedValue(), eps,
                 failmsg + " EvalAdd Ct and negative double fails");
+            precisions.emplace_back(results->GetLogPrecision());
 
             // Testing EvalAdd ciphertext - negative double
             cResult = cc->EvalSub(ciphertext1, -0.5);
@@ -622,6 +660,7 @@ protected:
             results->SetLength(plaintext1AddScalar->GetLength());
             checkEquality(plaintext1AddScalar->GetCKKSPackedValue(), results->GetCKKSPackedValue(), eps,
                 failmsg + " EvalSub Ct and negative double fails");
+            precisions.emplace_back(results->GetLogPrecision());
 
             // Testing EvalNegate
             cResult = cc->EvalNegate(ciphertext1);
@@ -629,6 +668,9 @@ protected:
             results->SetLength(negatives1->GetLength());
             checkEquality(negatives1->GetCKKSPackedValue(), results->GetCKKSPackedValue(), eps,
                 failmsg + " EvalNegate fails");
+            precisions.emplace_back(results->GetLogPrecision());
+
+            return true;
         }
         catch (std::exception& e) {
             std::cerr << "Exception thrown from " << __func__ << "(): " << e.what() << std::endl;
@@ -641,9 +683,59 @@ protected:
             // make it fail
             EXPECT_TRUE(0 == 1) << failmsg;
         }
+
+        return false;
     }
 
-    void UnitTest_Mult_Packed(const TEST_CASE_UTCKKSRNS& testData, const std::string& failmsg = std::string()) {
+    void UnitTest_Add_Packed(const TEST_CASE_UTCKKSRNS& testData, const std::string& failmsg = std::string()) {
+        std::vector<uint32_t> precisions;
+        UnitTest_Add_Packed(testData, precisions, failmsg);
+    }
+
+    void UnitTest_Add_Packed_Precision(const TEST_CASE_UTCKKSRNS& testData, const std::string& failmsg = std::string()) {
+        TEST_CASE_UTCKKSRNS testDataLocal(testData);
+        
+        std::vector<uint32_t> lowPrecisions;
+        CryptoContextFactory<DCRTPoly>::ReleaseAllContexts();
+        testDataLocal.params.rsTech = FLEXIBLEAUTO;
+        if (!UnitTest_Add_Packed(testDataLocal, lowPrecisions, failmsg))
+            return;
+
+        std::vector<uint32_t> highPrecisions;
+        CryptoContextFactory<DCRTPoly>::ReleaseAllContexts();
+        testDataLocal.params.rsTech = FLEXIBLEAUTOEXT;
+        if(!UnitTest_Add_Packed(testDataLocal, highPrecisions, failmsg))
+            return;
+
+        std::stringstream ss;
+        if (!lowPrecisions.empty() && !highPrecisions.empty()) {
+            if (lowPrecisions.size() == highPrecisions.size()) {
+                // check if the precision for FLEXIBLEAUTOEXT is higher than for FLEXIBLEAUTO
+                for (size_t i = 0; i < lowPrecisions.size(); ++i) {
+                    if (lowPrecisions[i] >= highPrecisions[i]) {
+                        std::string errMsg("FLEXIBLEAUTOEXT's precision is LESS than the precision for FLEXIBLEAUTO");
+                        EXPECT_TRUE(0 == 1) << errMsg;
+                    }
+                }
+            }
+            else {
+                ss << "Precision vectors are different in size:"
+                    << " low - " << lowPrecisions.size()
+                    << ", high - " << highPrecisions.size();
+                // make it fail
+                EXPECT_TRUE(0 == 1) << ss.str();
+            }
+        }
+        else {
+            ss << "Precision vectors are empty:"
+                << " low - " << lowPrecisions.size()
+                << ", high - " << highPrecisions.size();
+            // make it fail
+            EXPECT_TRUE(0 == 1) << ss.str();
+        }
+    }
+
+    bool UnitTest_Mult_Packed(const TEST_CASE_UTCKKSRNS& testData, std::vector<uint32_t>& precisions, const std::string& failmsg = std::string()) {
         try {
             CryptoContext<Element> cc(UnitTestGenerateContext(testData.params));
 
@@ -717,6 +809,8 @@ protected:
             results->SetLength(plaintextMult->GetLength());
             checkEquality(plaintextMult->GetCKKSPackedValue(), results->GetCKKSPackedValue(), eps,
                 failmsg + " EvalMultNoRelin Ct fails");
+
+            return true;
         }
         catch (std::exception& e) {
             std::cerr << "Exception thrown from " << __func__ << "(): " << e.what() << std::endl;
@@ -728,6 +822,56 @@ protected:
             std::cerr << "Unknown exception of type \"" << name << "\" thrown from " << __func__ << "()" << std::endl;
             // make it fail
             EXPECT_TRUE(0 == 1) << failmsg;
+        }
+
+        return false;
+    }
+
+    void UnitTest_Mult_Packed(const TEST_CASE_UTCKKSRNS& testData, const std::string& failmsg = std::string()) {
+        std::vector<uint32_t> precisions;
+        UnitTest_Mult_Packed(testData, precisions, failmsg);
+    }
+
+    void UnitTest_Mult_Packed_Precision(const TEST_CASE_UTCKKSRNS& testData, const std::string& failmsg = std::string()) {
+        TEST_CASE_UTCKKSRNS testDataLocal(testData);
+
+        std::vector<uint32_t> lowPrecisions;
+        CryptoContextFactory<DCRTPoly>::ReleaseAllContexts();
+        testDataLocal.params.rsTech = FLEXIBLEAUTO;
+        if (!UnitTest_Mult_Packed(testDataLocal, lowPrecisions, failmsg))
+            return;
+
+        std::vector<uint32_t> highPrecisions;
+        CryptoContextFactory<DCRTPoly>::ReleaseAllContexts();
+        testDataLocal.params.rsTech = FLEXIBLEAUTOEXT;
+        if (!UnitTest_Mult_Packed(testDataLocal, highPrecisions, failmsg))
+            return;
+
+        std::stringstream ss;
+        if (!lowPrecisions.empty() && !highPrecisions.empty()) {
+            if (lowPrecisions.size() == highPrecisions.size()) {
+                // check if the precision for FLEXIBLEAUTOEXT is higher than for FLEXIBLEAUTO
+                for (size_t i = 0; i < lowPrecisions.size(); ++i) {
+                    if (lowPrecisions[i] >= highPrecisions[i]) {
+                        std::string errMsg("FLEXIBLEAUTOEXT's precision is LESS than the precision for FLEXIBLEAUTO");
+                        EXPECT_TRUE(0 == 1) << errMsg;
+                    }
+                }
+            }
+            else {
+                ss << "Precision vectors are different in size:"
+                    << " low - " << lowPrecisions.size()
+                    << ", high - " << highPrecisions.size();
+                // make it fail
+                EXPECT_TRUE(0 == 1) << ss.str();
+            }
+        }
+        else {
+            ss << "Precision vectors are empty:"
+                << " low - " << lowPrecisions.size()
+                << ", high - " << highPrecisions.size();
+            // make it fail
+            EXPECT_TRUE(0 == 1) << ss.str();
         }
     }
 
@@ -1840,6 +1984,12 @@ TEST_P(UTCKKSRNS, CKKSRNS) {
         break;
     case METADATA:
         UnitTest_Metadata(test, test.buildTestName());
+        break;
+    case ADD_PACKED_PRECISION:
+        UnitTest_Add_Packed_Precision(test, test.buildTestName());
+        break;
+    case MULT_PACKED_PRECISION:
+        UnitTest_Mult_Packed_Precision(test, test.buildTestName());
         break;
     default:
         break;

--- a/src/pke/unittest/utckksrns/UnitTestCKKSrns.cpp
+++ b/src/pke/unittest/utckksrns/UnitTestCKKSrns.cpp
@@ -117,6 +117,7 @@ struct TEST_CASE_UTCKKSRNS {
 
     // additional test case data
     // ........
+    uint32_t slots;
 
     std::string buildTestName() const {
         std::stringstream ss;
@@ -149,6 +150,7 @@ static std::ostream& operator<<(std::ostream& os, const TEST_CASE_UTCKKSRNS& tes
  * BATCH: The length of the packed vectors to be used with CKKS.
  */
 constexpr usint RING_DIM = 512;
+constexpr usint RING_DIM_HALF = 256;
 constexpr usint RELIN    = 10;
 constexpr usint BATCH    = 8;
 #if NATIVEINT == 128
@@ -220,28 +222,108 @@ static std::vector<TEST_CASE_UTCKKSRNS> testCases = {
     { COMPRESS,   "08", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT}, },
 #endif
     // ==========================================
-    // TestType,         Descr, Scheme,          RDim, MultDepth, SFBits, RWin,  BatchSz, Mode,       Depth, MDepth, ModSize, SecLvl,       KSTech, RSTech,          LDigits, PtMod, StdDev, EvalAddCt, EvalMultCt, KSCt, MultTech
-    { EVAL_FAST_ROTATION, "01", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT}, },
-    { EVAL_FAST_ROTATION, "02", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT}, },
-    { EVAL_FAST_ROTATION, "03", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT}, },
-    { EVAL_FAST_ROTATION, "04", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT}, },
+    // TestType,         Descr,  Scheme,         RDim, MultDepth, SFBits, RWin,  BatchSz, Mode,       Depth, MDepth, ModSize, SecLvl,       KSTech, RSTech,          LDigits, PtMod, StdDev, EvalAddCt, EvalMultCt, KSCt, MultTech, Slots
+    { EVAL_FAST_ROTATION, "01", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+    { EVAL_FAST_ROTATION, "02", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+    { EVAL_FAST_ROTATION, "03", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+    { EVAL_FAST_ROTATION, "04", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
 #if NATIVEINT != 128
-    { EVAL_FAST_ROTATION, "05", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT}, },
-    { EVAL_FAST_ROTATION, "06", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT}, },
-    { EVAL_FAST_ROTATION, "07", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT}, },
-    { EVAL_FAST_ROTATION, "08", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT}, },
+    { EVAL_FAST_ROTATION, "05", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+    { EVAL_FAST_ROTATION, "06", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+    { EVAL_FAST_ROTATION, "07", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+    { EVAL_FAST_ROTATION, "08", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+#endif
+    { EVAL_FAST_ROTATION, "09", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    1},
+    { EVAL_FAST_ROTATION, "10", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    1},
+    { EVAL_FAST_ROTATION, "11", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    1},
+    { EVAL_FAST_ROTATION, "12", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    1},
+#if NATIVEINT != 128
+    { EVAL_FAST_ROTATION, "13", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    1},
+    { EVAL_FAST_ROTATION, "14", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    1},
+    { EVAL_FAST_ROTATION, "15", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    1},
+    { EVAL_FAST_ROTATION, "16", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    1},
+#endif
+    { EVAL_FAST_ROTATION, "17", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    2},
+    { EVAL_FAST_ROTATION, "18", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    2},
+    { EVAL_FAST_ROTATION, "19", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    2},
+    { EVAL_FAST_ROTATION, "20", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    2},
+#if NATIVEINT != 128
+    { EVAL_FAST_ROTATION, "21", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    2},
+    { EVAL_FAST_ROTATION, "22", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    2},
+    { EVAL_FAST_ROTATION, "23", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    2},
+    { EVAL_FAST_ROTATION, "24", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    2},
+#endif
+    { EVAL_FAST_ROTATION, "25", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    4},
+    { EVAL_FAST_ROTATION, "26", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    4},
+    { EVAL_FAST_ROTATION, "27", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    4},
+    { EVAL_FAST_ROTATION, "28", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    4},
+#if NATIVEINT != 128
+    { EVAL_FAST_ROTATION, "29", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    4},
+    { EVAL_FAST_ROTATION, "30", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    4},
+    { EVAL_FAST_ROTATION, "31", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    4},
+    { EVAL_FAST_ROTATION, "32", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    4},
+#endif
+    { EVAL_FAST_ROTATION, "33", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    BATCH},
+    { EVAL_FAST_ROTATION, "34", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    BATCH},
+    { EVAL_FAST_ROTATION, "35", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    BATCH},
+    { EVAL_FAST_ROTATION, "36", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    BATCH},
+#if NATIVEINT != 128
+    { EVAL_FAST_ROTATION, "37", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    BATCH},
+    { EVAL_FAST_ROTATION, "38", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    BATCH},
+    { EVAL_FAST_ROTATION, "39", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    BATCH},
+    { EVAL_FAST_ROTATION, "40", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    BATCH},
+#endif
+    { EVAL_FAST_ROTATION, "41", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    RING_DIM_HALF},
+    { EVAL_FAST_ROTATION, "42", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    RING_DIM_HALF},
+    { EVAL_FAST_ROTATION, "43", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    RING_DIM_HALF},
+    { EVAL_FAST_ROTATION, "44", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    RING_DIM_HALF},
+#if NATIVEINT != 128
+    { EVAL_FAST_ROTATION, "45", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    RING_DIM_HALF},
+    { EVAL_FAST_ROTATION, "46", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    RING_DIM_HALF},
+    { EVAL_FAST_ROTATION, "47", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    RING_DIM_HALF},
+    { EVAL_FAST_ROTATION, "48", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    RING_DIM_HALF},
 #endif
     // ==========================================
-    // TestType,  Descr, Scheme,          RDim, MultDepth, SFBits, RWin,  BatchSz, Mode,       Depth, MDepth, ModSize, SecLvl,       KSTech, RSTech,          LDigits, PtMod, StdDev, EvalAddCt, EvalMultCt, KSCt, MultTech
-    { EVALATINDEX, "01", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT}, },
-    { EVALATINDEX, "02", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT}, },
-    { EVALATINDEX, "03", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT}, },
-    { EVALATINDEX, "04", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT}, },
+    // TestType,  Descr,  Scheme,         RDim, MultDepth, SFBits, RWin,  BatchSz, Mode,       Depth, MDepth, ModSize, SecLvl,       KSTech, RSTech,          LDigits, PtMod, StdDev, EvalAddCt, EvalMultCt, KSCt, MultTech, Slots
+    { EVALATINDEX, "01", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+    { EVALATINDEX, "02", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+    { EVALATINDEX, "03", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+    { EVALATINDEX, "04", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
 #if NATIVEINT != 128
-    { EVALATINDEX, "05", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT}, },
-    { EVALATINDEX, "06", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT}, },
-    { EVALATINDEX, "07", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT}, },
-    { EVALATINDEX, "08", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT}, },
+    { EVALATINDEX, "05", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+    { EVALATINDEX, "06", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+    { EVALATINDEX, "07", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+    { EVALATINDEX, "08", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    0},
+#endif
+    { EVALATINDEX, "09", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    8},
+    { EVALATINDEX, "10", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    8},
+    { EVALATINDEX, "11", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    8},
+    { EVALATINDEX, "12", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    8},
+#if NATIVEINT != 128
+    { EVALATINDEX, "13", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    8},
+    { EVALATINDEX, "14", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    8},
+    { EVALATINDEX, "15", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    8},
+    { EVALATINDEX, "16", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},    8},
+#endif
+    { EVALATINDEX, "17", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},   16},
+    { EVALATINDEX, "18", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},   16},
+    { EVALATINDEX, "19", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},   16},
+    { EVALATINDEX, "20", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},   16},
+#if NATIVEINT != 128
+    { EVALATINDEX, "21", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},   16},
+    { EVALATINDEX, "22", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},   16},
+    { EVALATINDEX, "23", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},   16},
+    { EVALATINDEX, "24", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},   16},
+#endif
+    { EVALATINDEX, "25", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},   RING_DIM_HALF},
+    { EVALATINDEX, "26", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},   RING_DIM_HALF},
+    { EVALATINDEX, "27", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDMANUAL,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},   RING_DIM_HALF},
+    { EVALATINDEX, "28", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FIXEDAUTO,       DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},   RING_DIM_HALF},
+#if NATIVEINT != 128
+    { EVALATINDEX, "29", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},   RING_DIM_HALF},
+    { EVALATINDEX, "30", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},   RING_DIM_HALF},
+    { EVALATINDEX, "31", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},   RING_DIM_HALF},
+    { EVALATINDEX, "32", {CKKSRNS_SCHEME, RING_DIM, 7,     SCALE,  RELIN, BATCH,   OPTIMIZED,  DFLT,  DFLT,   DFLT,    HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT,       DFLT, DFLT},   RING_DIM_HALF},
 #endif
     // ==========================================
     // TestType, Descr, Scheme,         RDim, MultDepth, SFBits, RWin,  BatchSz, Mode,       Depth, MDepth, ModSize, SecLvl,       KSTech, RSTech,          LDigits, PtMod, StdDev, EvalAddCt, EvalMultCt, KSCt, MultTech
@@ -1023,25 +1105,26 @@ protected:
             CryptoContext<Element> cc(UnitTestGenerateContext(testData.params));
 
             const uint32_t ringDim = cc->GetRingDimension();
-            const uint32_t Nh = ringDim >> 1;
+            uint32_t slots = (testData.slots != 0) ? testData.slots : (BATCH != 0) ? BATCH : cc->GetRingDimension() / 2;
 
-            std::vector<std::complex<double>> vectorOfInts1(Nh);
-            for (uint32_t i = 0; i < Nh; i++) {
+            std::vector<std::complex<double>> vectorOfInts1(slots);
+            for (uint32_t i = 0; i < slots; i++) {
                 vectorOfInts1[i] = rand() % 10;
             }
-            Plaintext plaintext1 = cc->MakeCKKSPackedPlaintext(vectorOfInts1);
+            Plaintext plaintext1 = cc->MakeCKKSPackedPlaintext(vectorOfInts1, 1, 0, nullptr, testData.slots);
 
-            std::vector<std::complex<double>> vIntsRightRotate2(Nh);
-            for (uint32_t i = 0; i < Nh; i++) {
-                vIntsRightRotate2[(i + Nh + 2) % Nh] = vectorOfInts1[i];
+            std::vector<std::complex<double>> vIntsRightRotate2(slots);
+            for (uint32_t i = 0; i < slots; i++) {
+                vIntsRightRotate2[(i + slots + 2) % slots] = vectorOfInts1[i];
             }
-            Plaintext plaintextRight2 = cc->MakeCKKSPackedPlaintext(vIntsRightRotate2);
+            Plaintext plaintextRight2 = cc->MakeCKKSPackedPlaintext(vIntsRightRotate2, 1, 0, nullptr, testData.slots);
 
-            std::vector<std::complex<double>> vIntsLeftRotate2(Nh);
-            for (uint32_t i = 0; i < Nh; i++) {
-                vIntsLeftRotate2[(i + Nh - 2) % Nh] = vectorOfInts1[i];
+            std::vector<std::complex<double>> vIntsLeftRotate2(slots);
+            for (uint32_t i = 0; i < slots; i++) {
+              // here 2*slots for the case if slots = 1, to avoid negative index
+                vIntsLeftRotate2[(i + 2*slots - 2) % slots] = vectorOfInts1[i];
             }
-            Plaintext plaintextLeft2 = cc->MakeCKKSPackedPlaintext(vIntsLeftRotate2);
+            Plaintext plaintextLeft2 = cc->MakeCKKSPackedPlaintext(vIntsLeftRotate2, 1, 0, nullptr, testData.slots);
 
             // Generate encryption keys
             KeyPair<Element> kp = cc->KeyGen();
@@ -1057,8 +1140,8 @@ protected:
              * This helps hide the rotation noise and get the correct result without
              * using a smaller relinWindow in BV (when creating the crypto context cc).
              */
-            std::vector<std::complex<double>> vOnes(Nh, 1); // all 1s
-            Plaintext pOnes = cc->MakeCKKSPackedPlaintext(vOnes);
+            std::vector<std::complex<double>> vOnes(slots, 1); // all 1s
+            Plaintext pOnes = cc->MakeCKKSPackedPlaintext(vOnes, 1, 0, nullptr, testData.slots);
             Ciphertext<Element> cOnes = cc->Encrypt(kp.publicKey, pOnes);
             ciphertext1 *= cOnes;
 
@@ -1098,21 +1181,32 @@ protected:
         try {
             CryptoContext<Element> cc(UnitTestGenerateContext(testData.params));
 
-            Plaintext plaintext1 = cc->MakeCKKSPackedPlaintext(vectorOfInts1_8);
+            Plaintext plaintext1 = cc->MakeCKKSPackedPlaintext(vectorOfInts1_8, 1, 0, nullptr, testData.slots);
 
-            // vIntsRightShift2 = { 0,0,1,2,3,4,5,6 };
+            // vIntsRightShift2 = { 0,0,1,2,3,4,5,6 } if slots > 8;
+            // vIntsRightShift2 = { 7,8,1,2,3,4,5,6 } if slots = 8;
             std::vector<std::complex<double>> vIntsRightShift2(VECTOR_SIZE);
+            uint32_t slots = (testData.slots != 0) ? testData.slots : (BATCH != 0) ? BATCH : cc->GetRingDimension() / 2;
             for (usint i = 0; i < VECTOR_SIZE; i++) {
-                vIntsRightShift2[i] = (i >= 2) ? vectorOfInts1_8[i - 2] : 0;
+              if ((slots + i - 2) % slots < VECTOR_SIZE) {
+                vIntsRightShift2[i] = vectorOfInts1_8[(slots + i - 2) % slots];
+              } else {
+                vIntsRightShift2[i] = 0;
+              }
             }
-            Plaintext plaintextRight2 = cc->MakeCKKSPackedPlaintext(vIntsRightShift2);
+            Plaintext plaintextRight2 = cc->MakeCKKSPackedPlaintext(vIntsRightShift2, 1, 0, nullptr, testData.slots);
 
-            // vIntsLeftShift2 = { 3,4,5,6,7,8,0,0 };
+            // vIntsRightShift2 = { 3,4,5,6,7,8,0,0 } if slots > 8;
+            // vIntsRightShift2 = { 3,4,5,6,7,8,1,2 } if slots = 8;
             std::vector<std::complex<double>> vIntsLeftShift2(VECTOR_SIZE);
             for (usint i = 0; i < VECTOR_SIZE; i++) {
-                vIntsLeftShift2[i] = (i < VECTOR_SIZE - 2) ? vectorOfInts1_8[i + 2] : 0;
+              if ((i + 2) % slots < VECTOR_SIZE) {
+                vIntsLeftShift2[i] = vectorOfInts1_8[(i + 2) % slots];
+              } else {
+                vIntsLeftShift2[i] = 0;
+              }
             }
-            Plaintext plaintextLeft2 = cc->MakeCKKSPackedPlaintext(vIntsLeftShift2);
+            Plaintext plaintextLeft2 = cc->MakeCKKSPackedPlaintext(vIntsLeftShift2, 1, 0, nullptr, testData.slots);
 
             // Generate encryption keys
             KeyPair<Element> kp = cc->KeyGen();
@@ -1128,7 +1222,7 @@ protected:
              * This helps hide the rotation noise and get the correct result without
              * using a smaller relinWindow in BV (when creating the crypto context cc).
              */
-            Plaintext pOnes = cc->MakeCKKSPackedPlaintext(vectorOfInts1s);
+            Plaintext pOnes = cc->MakeCKKSPackedPlaintext(vectorOfInts1s, 1, 0, nullptr, testData.slots);
             Ciphertext<Element> cOnes = cc->Encrypt(kp.publicKey, pOnes);
             ciphertext1 *= cOnes;
 
@@ -1312,7 +1406,7 @@ protected:
             for (size_t i = 0; i < max; ++i) {
                 intvec[i] = (rand() % (ptm / 2)) * (rand() % 2 ? 1 : -1);
             }
-            Plaintext plaintextInt = cc->MakeCKKSPackedPlaintext(intvec);
+            Plaintext plaintextInt = cc->MakeCKKSPackedPlaintext(intvec, 1, 0, nullptr, max);
 
             KeyPair<Element> kp = cc->KeyGen();
             EXPECT_EQ(kp.good(), true) << failmsg << " key generation for scalar encrypt/decrypt failed";

--- a/src/pke/unittest/utckksrns/UnitTestCKKSrnsSerialize.cpp
+++ b/src/pke/unittest/utckksrns/UnitTestCKKSrnsSerialize.cpp
@@ -121,7 +121,7 @@ constexpr usint RING_DIM = 512;
 constexpr usint SCALE    = 50;
 constexpr usint MULT_DEPTH = 3;
 constexpr usint RELIN    = 20;
-constexpr usint BATCH    = 8;
+constexpr usint BATCH    = 16;
 // clang-format off
 static std::vector<TEST_CASE_UTCKKSSer> testCases = {
     // TestType,            Descr, Scheme,         RDim,     MultDepth,  SFBits, RWin,  BatchSz, Mode,       Depth, MDepth, ModSize, SecLvl,       KSTech, RSTech,          LDigits, PtMod, StdDev, EvalAddCt, EvalMultCt, KSCt, MultTech


### PR DESCRIPTION
Added slots to plaintext/ciphertext, default value in CryptoContext::MakeCKKSPackedPlaintext is slots = 0, which is same as previous logic.

If slots != 0, then slots should be a power of two

No tests added so far