### PR TITLE
Refactoring class Serializable

### DIFF
--- a/src/binfhe/include/binfhecontext.h
+++ b/src/binfhe/include/binfhecontext.h
@@ -374,9 +374,6 @@ public:
         ar(::cereal::make_nvp("params", m_params));
     }
 
-    std::string SerializedObjectName() const {
-        return "RingGSWBTKey";
-    }
     static uint32_t SerializedVersion() {
         return 1;
     }

--- a/src/binfhe/include/binfhecontext.h
+++ b/src/binfhe/include/binfhecontext.h
@@ -367,7 +367,7 @@ public:
 
     template <class Archive>
     void load(Archive& ar, std::uint32_t const version) {
-        if (version > Serializable::SerializedVersion()) {
+        if (version > this->SerializedVersion()) {
             OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
                                                   " is from a later version of the library");
         }

--- a/src/binfhe/include/binfhecontext.h
+++ b/src/binfhe/include/binfhecontext.h
@@ -367,15 +367,11 @@ public:
 
     template <class Archive>
     void load(Archive& ar, std::uint32_t const version) {
-        if (version > SerializedVersion()) {
+        if (version > Serializable::SerializedVersion()) {
             OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
                                                   " is from a later version of the library");
         }
         ar(::cereal::make_nvp("params", m_params));
-    }
-
-    static uint32_t SerializedVersion() {
-        return 1;
     }
 
     void SetQ(NativeInteger q) const {

--- a/src/binfhe/include/lwecore.h
+++ b/src/binfhe/include/lwecore.h
@@ -225,9 +225,6 @@ public:
         this->PreCompute();
     }
 
-    std::string SerializedObjectName() const {
-        return "LWECryptoParams";
-    }
     static uint32_t SerializedVersion() {
         return 1;
     }
@@ -338,9 +335,6 @@ public:
         ar(::cereal::make_nvp("b", m_b));
     }
 
-    std::string SerializedObjectName() const {
-        return "LWECiphertext";
-    }
     static uint32_t SerializedVersion() {
         return 1;
     }
@@ -408,9 +402,6 @@ public:
         ar(::cereal::make_nvp("s", m_s));
     }
 
-    std::string SerializedObjectName() const {
-        return "LWEPrivateKey";
-    }
     static uint32_t SerializedVersion() {
         return 1;
     }
@@ -481,9 +472,6 @@ public:
         ar(::cereal::make_nvp("k", m_key));
     }
 
-    std::string SerializedObjectName() const {
-        return "LWEPrivateKey";
-    }
     static uint32_t SerializedVersion() {
         return 1;
     }

--- a/src/binfhe/include/lwecore.h
+++ b/src/binfhe/include/lwecore.h
@@ -204,7 +204,7 @@ public:
 
     template <class Archive>
     void load(Archive& ar, std::uint32_t const version) {
-        if (version > SerializedVersion()) {
+        if (version > Serializable::SerializedVersion()) {
             OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
                                                   " is from a later version of the library");
         }
@@ -223,10 +223,6 @@ public:
         ar(::cereal::make_nvp("bKS", m_baseKS));
 
         this->PreCompute();
-    }
-
-    static uint32_t SerializedVersion() {
-        return 1;
     }
 
     void SetQ(NativeInteger q) {
@@ -326,17 +322,13 @@ public:
 
     template <class Archive>
     void load(Archive& ar, std::uint32_t const version) {
-        if (version > SerializedVersion()) {
+        if (version > Serializable::SerializedVersion()) {
             OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
                                                   " is from a later version of the library");
         }
 
         ar(::cereal::make_nvp("a", m_a));
         ar(::cereal::make_nvp("b", m_b));
-    }
-
-    static uint32_t SerializedVersion() {
-        return 1;
     }
 
 private:
@@ -394,7 +386,7 @@ public:
 
     template <class Archive>
     void load(Archive& ar, std::uint32_t const version) {
-        if (version > SerializedVersion()) {
+        if (version > Serializable::SerializedVersion()) {
             OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
                                                   " is from a later version of the library");
         }
@@ -402,9 +394,6 @@ public:
         ar(::cereal::make_nvp("s", m_s));
     }
 
-    static uint32_t SerializedVersion() {
-        return 1;
-    }
     void switchModulus(NativeInteger q) {
         m_s.Mod(q);
         m_s.SetModulus(q);
@@ -464,16 +453,12 @@ public:
 
     template <class Archive>
     void load(Archive& ar, std::uint32_t const version) {
-        if (version > SerializedVersion()) {
+        if (version > Serializable::SerializedVersion()) {
             OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
                                                   " is from a later version of the library");
         }
 
         ar(::cereal::make_nvp("k", m_key));
-    }
-
-    static uint32_t SerializedVersion() {
-        return 1;
     }
 
 private:

--- a/src/binfhe/include/lwecore.h
+++ b/src/binfhe/include/lwecore.h
@@ -204,7 +204,7 @@ public:
 
     template <class Archive>
     void load(Archive& ar, std::uint32_t const version) {
-        if (version > Serializable::SerializedVersion()) {
+        if (version > this->SerializedVersion()) {
             OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
                                                   " is from a later version of the library");
         }
@@ -322,7 +322,7 @@ public:
 
     template <class Archive>
     void load(Archive& ar, std::uint32_t const version) {
-        if (version > Serializable::SerializedVersion()) {
+        if (version > this->SerializedVersion()) {
             OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
                                                   " is from a later version of the library");
         }
@@ -386,7 +386,7 @@ public:
 
     template <class Archive>
     void load(Archive& ar, std::uint32_t const version) {
-        if (version > Serializable::SerializedVersion()) {
+        if (version > this->SerializedVersion()) {
             OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
                                                   " is from a later version of the library");
         }
@@ -453,7 +453,7 @@ public:
 
     template <class Archive>
     void load(Archive& ar, std::uint32_t const version) {
-        if (version > Serializable::SerializedVersion()) {
+        if (version > this->SerializedVersion()) {
             OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
                                                   " is from a later version of the library");
         }

--- a/src/binfhe/include/ringcore.h
+++ b/src/binfhe/include/ringcore.h
@@ -268,9 +268,6 @@ public:
         this->PreCompute();
     }
 
-    std::string SerializedObjectName() const {
-        return "RingGSWCryptoParams";
-    }
     static uint32_t SerializedVersion() {
         return 1;
     }
@@ -411,9 +408,6 @@ public:
         ar(::cereal::make_nvp("elements", m_elements));
     }
 
-    std::string SerializedObjectName() const {
-        return "RingGSWCiphertext";
-    }
     static uint32_t SerializedVersion() {
         return 1;
     }
@@ -497,9 +491,6 @@ public:
         ar(::cereal::make_nvp("key", m_key));
     }
 
-    std::string SerializedObjectName() const {
-        return "RingGSWBTKey";
-    }
     static uint32_t SerializedVersion() {
         return 1;
     }

--- a/src/binfhe/include/ringcore.h
+++ b/src/binfhe/include/ringcore.h
@@ -256,7 +256,7 @@ public:
 
     template <class Archive>
     void load(Archive& ar, std::uint32_t const version) {
-        if (version > Serializable::SerializedVersion()) {
+        if (version > this->SerializedVersion()) {
             OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
                                                   " is from a later version of the library");
         }
@@ -397,7 +397,7 @@ public:
 
     template <class Archive>
     void load(Archive& ar, std::uint32_t const version) {
-        if (version > Serializable::SerializedVersion()) {
+        if (version > this->SerializedVersion()) {
             OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
                                                   " is from a later version of the library");
         }
@@ -476,7 +476,7 @@ public:
 
     template <class Archive>
     void load(Archive& ar, std::uint32_t const version) {
-        if (version > Serializable::SerializedVersion()) {
+        if (version > this->SerializedVersion()) {
             OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
                                                   " is from a later version of the library");
         }

--- a/src/binfhe/include/ringcore.h
+++ b/src/binfhe/include/ringcore.h
@@ -256,7 +256,7 @@ public:
 
     template <class Archive>
     void load(Archive& ar, std::uint32_t const version) {
-        if (version > SerializedVersion()) {
+        if (version > Serializable::SerializedVersion()) {
             OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
                                                   " is from a later version of the library");
         }
@@ -266,10 +266,6 @@ public:
         ar(::cereal::make_nvp("method", m_method));
 
         this->PreCompute();
-    }
-
-    static uint32_t SerializedVersion() {
-        return 1;
     }
 
     void SetQ(NativeInteger q) {
@@ -401,15 +397,11 @@ public:
 
     template <class Archive>
     void load(Archive& ar, std::uint32_t const version) {
-        if (version > SerializedVersion()) {
+        if (version > Serializable::SerializedVersion()) {
             OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
                                                   " is from a later version of the library");
         }
         ar(::cereal::make_nvp("elements", m_elements));
-    }
-
-    static uint32_t SerializedVersion() {
-        return 1;
     }
 
 private:
@@ -484,15 +476,11 @@ public:
 
     template <class Archive>
     void load(Archive& ar, std::uint32_t const version) {
-        if (version > SerializedVersion()) {
+        if (version > Serializable::SerializedVersion()) {
             OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
                                                   " is from a later version of the library");
         }
         ar(::cereal::make_nvp("key", m_key));
-    }
-
-    static uint32_t SerializedVersion() {
-        return 1;
     }
 
 private:

--- a/src/core/include/lattice/elemparams.h
+++ b/src/core/include/lattice/elemparams.h
@@ -247,9 +247,6 @@ public:
         ar(::cereal::make_nvp("br", bigRootOfUnity));
     }
 
-    std::string SerializedObjectName() const {
-        return "ElemParams";
-    }
     static uint32_t SerializedVersion() {
         return 1;
     }

--- a/src/core/include/lattice/elemparams.h
+++ b/src/core/include/lattice/elemparams.h
@@ -234,7 +234,7 @@ public:
 
     template <class Archive>
     void load(Archive& ar, std::uint32_t const version) {
-        if (version > SerializedVersion()) {
+        if (version > Serializable::SerializedVersion()) {
             OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
                                                   " is from a later version of the library");
         }
@@ -245,10 +245,6 @@ public:
         ar(::cereal::make_nvp("ru", rootOfUnity));
         ar(::cereal::make_nvp("bm", bigCiphertextModulus));
         ar(::cereal::make_nvp("br", bigRootOfUnity));
-    }
-
-    static uint32_t SerializedVersion() {
-        return 1;
     }
 
 protected:

--- a/src/core/include/lattice/elemparams.h
+++ b/src/core/include/lattice/elemparams.h
@@ -234,7 +234,7 @@ public:
 
     template <class Archive>
     void load(Archive& ar, std::uint32_t const version) {
-        if (version > Serializable::SerializedVersion()) {
+        if (version > this->SerializedVersion()) {
             OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
                                                   " is from a later version of the library");
         }

--- a/src/core/include/lattice/field2n.h
+++ b/src/core/include/lattice/field2n.h
@@ -339,9 +339,6 @@ public:
         ar(::cereal::make_nvp("f", format));
     }
 
-    std::string SerializedObjectName() const {
-        return "Field2n";
-    }
     static uint32_t SerializedVersion() {
         return 1;
     }

--- a/src/core/include/lattice/field2n.h
+++ b/src/core/include/lattice/field2n.h
@@ -331,7 +331,7 @@ public:
 
     template <class Archive>
     void load(Archive& ar, std::uint32_t const version) {
-        if (version > Serializable::SerializedVersion()) {
+        if (version > this->SerializedVersion()) {
             OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
                                                   " is from a later version of the library");
         }

--- a/src/core/include/lattice/field2n.h
+++ b/src/core/include/lattice/field2n.h
@@ -331,16 +331,12 @@ public:
 
     template <class Archive>
     void load(Archive& ar, std::uint32_t const version) {
-        if (version > SerializedVersion()) {
+        if (version > Serializable::SerializedVersion()) {
             OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
                                                   " is from a later version of the library");
         }
         ar(::cereal::base_class<std::vector<std::complex<double>>>(this));
         ar(::cereal::make_nvp("f", format));
-    }
-
-    static uint32_t SerializedVersion() {
-        return 1;
     }
 
 private:

--- a/src/core/include/lattice/hal/default/dcrtpoly.h
+++ b/src/core/include/lattice/hal/default/dcrtpoly.h
@@ -1315,9 +1315,6 @@ public:
         ar(::cereal::make_nvp("p", this->m_params));
     }
 
-    std::string SerializedObjectName() const override {
-        return "DCRTPoly";
-    }
     static uint32_t SerializedVersion() {
         return 1;
     }

--- a/src/core/include/lattice/hal/default/dcrtpoly.h
+++ b/src/core/include/lattice/hal/default/dcrtpoly.h
@@ -1306,7 +1306,7 @@ public:
 
     template <class Archive>
     void load(Archive& ar, std::uint32_t const version) {
-        if (version > Serializable::SerializedVersion()) {
+        if (version > this->SerializedVersion()) {
             OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
                                                   " is from a later version of the library");
         }

--- a/src/core/include/lattice/hal/default/dcrtpoly.h
+++ b/src/core/include/lattice/hal/default/dcrtpoly.h
@@ -1306,17 +1306,13 @@ public:
 
     template <class Archive>
     void load(Archive& ar, std::uint32_t const version) {
-        if (version > SerializedVersion()) {
+        if (version > Serializable::SerializedVersion()) {
             OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
                                                   " is from a later version of the library");
         }
         ar(::cereal::make_nvp("v", m_vectors));
         ar(::cereal::make_nvp("f", this->m_format));
         ar(::cereal::make_nvp("p", this->m_params));
-    }
-
-    static uint32_t SerializedVersion() {
-        return 1;
     }
 
 protected:

--- a/src/core/include/lattice/ildcrtparams.h
+++ b/src/core/include/lattice/ildcrtparams.h
@@ -363,9 +363,6 @@ public:
         ar(::cereal::make_nvp("m", originalModulus));
     }
 
-    std::string SerializedObjectName() const {
-        return "DCRTParams";
-    }
     static uint32_t SerializedVersion() {
         return 1;
     }

--- a/src/core/include/lattice/ildcrtparams.h
+++ b/src/core/include/lattice/ildcrtparams.h
@@ -354,17 +354,13 @@ public:
 
     template <class Archive>
     void load(Archive& ar, std::uint32_t const version) {
-        if (version > SerializedVersion()) {
+        if (version > Serializable::SerializedVersion()) {
             OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
                                                   " is from a later version of the library");
         }
         ar(::cereal::base_class<ElemParams<IntType>>(this));
         ar(::cereal::make_nvp("p", m_parms));
         ar(::cereal::make_nvp("m", originalModulus));
-    }
-
-    static uint32_t SerializedVersion() {
-        return 1;
     }
 
 private:

--- a/src/core/include/lattice/ildcrtparams.h
+++ b/src/core/include/lattice/ildcrtparams.h
@@ -354,7 +354,7 @@ public:
 
     template <class Archive>
     void load(Archive& ar, std::uint32_t const version) {
-        if (version > Serializable::SerializedVersion()) {
+        if (version > this->SerializedVersion()) {
             OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
                                                   " is from a later version of the library");
         }

--- a/src/core/include/lattice/ilparams.h
+++ b/src/core/include/lattice/ilparams.h
@@ -154,9 +154,6 @@ public:
         ar(::cereal::base_class<ElemParams<IntType>>(this));
     }
 
-    std::string SerializedObjectName() const {
-        return "ILParms";
-    }
     static uint32_t SerializedVersion() {
         return 1;
     }

--- a/src/core/include/lattice/ilparams.h
+++ b/src/core/include/lattice/ilparams.h
@@ -147,7 +147,7 @@ public:
 
     template <class Archive>
     void load(Archive& ar, std::uint32_t const version) {
-        if (version > Serializable::SerializedVersion()) {
+        if (version > this->SerializedVersion()) {
             OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
                                                   " is from a later version of the library");
         }

--- a/src/core/include/lattice/ilparams.h
+++ b/src/core/include/lattice/ilparams.h
@@ -147,15 +147,11 @@ public:
 
     template <class Archive>
     void load(Archive& ar, std::uint32_t const version) {
-        if (version > SerializedVersion()) {
+        if (version > Serializable::SerializedVersion()) {
             OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
                                                   " is from a later version of the library");
         }
         ar(::cereal::base_class<ElemParams<IntType>>(this));
-    }
-
-    static uint32_t SerializedVersion() {
-        return 1;
     }
 };
 

--- a/src/core/include/lattice/poly.h
+++ b/src/core/include/lattice/poly.h
@@ -921,9 +921,6 @@ public:
         ar(::cereal::make_nvp("p", m_params));
     }
 
-    std::string SerializedObjectName() const {
-        return "Poly";
-    }
     static uint32_t SerializedVersion() {
         return 1;
     }

--- a/src/core/include/lattice/poly.h
+++ b/src/core/include/lattice/poly.h
@@ -912,7 +912,7 @@ public:
 
     template <class Archive>
     void load(Archive& ar, std::uint32_t const version) {
-        if (version > Serializable::SerializedVersion()) {
+        if (version > this->SerializedVersion()) {
             OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
                                                   " is from a later version of the library");
         }

--- a/src/core/include/lattice/poly.h
+++ b/src/core/include/lattice/poly.h
@@ -912,17 +912,13 @@ public:
 
     template <class Archive>
     void load(Archive& ar, std::uint32_t const version) {
-        if (version > SerializedVersion()) {
+        if (version > Serializable::SerializedVersion()) {
             OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
                                                   " is from a later version of the library");
         }
         ar(::cereal::make_nvp("v", m_values));
         ar(::cereal::make_nvp("f", m_format));
         ar(::cereal::make_nvp("p", m_params));
-    }
-
-    static uint32_t SerializedVersion() {
-        return 1;
     }
 
 private:

--- a/src/core/include/lattice/trapdoor.h
+++ b/src/core/include/lattice/trapdoor.h
@@ -74,7 +74,7 @@ public:
 
     template <class Archive>
     void load(Archive& ar, std::uint32_t const version) {
-        if (version > Serializable::SerializedVersion()) {
+        if (version > this->SerializedVersion()) {
             OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
                 " is from a later version of the library");
         }

--- a/src/core/include/lattice/trapdoor.h
+++ b/src/core/include/lattice/trapdoor.h
@@ -53,7 +53,7 @@ namespace lbcrypto {
  * based on the hardness of Ring-LWE problem
  */
 template <class Element>
-class RLWETrapdoorPair {
+class RLWETrapdoorPair : public Serializable {
 public:
     // matrix of noise polynomials
     Matrix<Element> m_r;
@@ -74,6 +74,10 @@ public:
 
     template <class Archive>
     void load(Archive& ar, std::uint32_t const version) {
+        if (version > Serializable::SerializedVersion()) {
+            OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
+                " is from a later version of the library");
+        }
         ar(CEREAL_NVP(m_r));
         ar(CEREAL_NVP(m_e));
     }

--- a/src/core/include/math/hal/bigintdyn/mubintvecdyn.h
+++ b/src/core/include/math/hal/bigintdyn/mubintvecdyn.h
@@ -595,9 +595,6 @@ public:
         ar(::cereal::make_nvp("ms", m_modulus_state));
     }
 
-    std::string SerializedObjectName() const {
-        return "ExpVector";
-    }
 
     static uint32_t SerializedVersion() {
         return 1;

--- a/src/core/include/math/hal/bigintdyn/mubintvecdyn.h
+++ b/src/core/include/math/hal/bigintdyn/mubintvecdyn.h
@@ -44,7 +44,6 @@
 #include "math/hal/vector.h"
 #include "math/hal/bigintdyn/ubintdyn.h"
 #include "utils/inttypes.h"
-#include "utils/serializable.h"
 
 /**
  * @namespace bigintdyn
@@ -65,8 +64,7 @@ using BigVector  = xmubintvec;
  */
 
 template <class ubint_el_t>
-class mubintvec : public lbcrypto::BigVectorInterface<mubintvec<ubint_el_t>, ubint_el_t>,
-                  public lbcrypto::Serializable {
+class mubintvec : public lbcrypto::BigVectorInterface<mubintvec<ubint_el_t>, ubint_el_t> {
 public:
     // CONSTRUCTORS
 
@@ -586,7 +584,7 @@ public:
 
     template <class Archive>
     void load(Archive& ar, std::uint32_t const version) {
-        if (version > Serializable::SerializedVersion()) {
+        if (version > this->SerializedVersion()) {
             OPENFHE_THROW(lbcrypto::deserialize_error, "serialized object version " + std::to_string(version) +
                                                             " is from a later version of the library");
         }

--- a/src/core/include/math/hal/bigintdyn/mubintvecdyn.h
+++ b/src/core/include/math/hal/bigintdyn/mubintvecdyn.h
@@ -586,7 +586,7 @@ public:
 
     template <class Archive>
     void load(Archive& ar, std::uint32_t const version) {
-        if (version > SerializedVersion()) {
+        if (version > Serializable::SerializedVersion()) {
             OPENFHE_THROW(lbcrypto::deserialize_error, "serialized object version " + std::to_string(version) +
                                                             " is from a later version of the library");
         }
@@ -595,10 +595,6 @@ public:
         ar(::cereal::make_nvp("ms", m_modulus_state));
     }
 
-
-    static uint32_t SerializedVersion() {
-        return 1;
-    }
 
 private:
     ubint_el_t m_modulus;

--- a/src/core/include/math/hal/bigintdyn/ubintdyn.h
+++ b/src/core/include/math/hal/bigintdyn/ubintdyn.h
@@ -1181,9 +1181,6 @@ public:
         ar(::cereal::make_nvp("s", m_state));
     }
 
-    std::string SerializedObjectName() const {
-        return "DYNInteger";
-    }
 
     static uint32_t SerializedVersion() {
         return 1;

--- a/src/core/include/math/hal/bigintdyn/ubintdyn.h
+++ b/src/core/include/math/hal/bigintdyn/ubintdyn.h
@@ -341,7 +341,7 @@ const double LOG2_10 = 3.32192809;  //!< @brief A pre-computed constant of Log b
 // Definition starts here
 //////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename limb_t>
-class ubint : public lbcrypto::BigIntegerInterface<ubint<limb_t>> {
+class ubint : public lbcrypto::BigIntegerInterface<ubint<limb_t>>, public lbcrypto::Serializable {
 public:
     // CONSTRUCTORS
 
@@ -1172,7 +1172,7 @@ public:
 
     template <class Archive>
     void load(Archive& ar, std::uint32_t const version) {
-        if (version > SerializedVersion()) {
+        if (version > Serializable::SerializedVersion()) {
             OPENFHE_THROW(lbcrypto::deserialize_error, "serialized object version " + std::to_string(version) +
                                                             " is from a later version of the library");
         }
@@ -1181,10 +1181,6 @@ public:
         ar(::cereal::make_nvp("s", m_state));
     }
 
-
-    static uint32_t SerializedVersion() {
-        return 1;
-    }
 
 protected:
     /**

--- a/src/core/include/math/hal/bigintdyn/ubintdyn.h
+++ b/src/core/include/math/hal/bigintdyn/ubintdyn.h
@@ -53,7 +53,6 @@
 #include "math/nbtheory.h"
 #include "utils/inttypes.h"
 #include "utils/memory.h"
-#include "utils/serializable.h"
 #include "utils/utilities.h"
 
 #include "math/hal/integer.h"
@@ -341,7 +340,7 @@ const double LOG2_10 = 3.32192809;  //!< @brief A pre-computed constant of Log b
 // Definition starts here
 //////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename limb_t>
-class ubint : public lbcrypto::BigIntegerInterface<ubint<limb_t>>, public lbcrypto::Serializable {
+class ubint : public lbcrypto::BigIntegerInterface<ubint<limb_t>> {
 public:
     // CONSTRUCTORS
 
@@ -1172,7 +1171,7 @@ public:
 
     template <class Archive>
     void load(Archive& ar, std::uint32_t const version) {
-        if (version > Serializable::SerializedVersion()) {
+        if (version > this->SerializedVersion()) {
             OPENFHE_THROW(lbcrypto::deserialize_error, "serialized object version " + std::to_string(version) +
                                                             " is from a later version of the library");
         }

--- a/src/core/include/math/hal/bigintfxd/mubintvecfxd.h
+++ b/src/core/include/math/hal/bigintfxd/mubintvecfxd.h
@@ -575,9 +575,6 @@ public:
         }
     }
 
-    std::string SerializedObjectName() const {
-        return "FXDInteger";
-    }
 
     static uint32_t SerializedVersion() {
         return 1;

--- a/src/core/include/math/hal/bigintfxd/mubintvecfxd.h
+++ b/src/core/include/math/hal/bigintfxd/mubintvecfxd.h
@@ -40,7 +40,6 @@
 #include <string>
 
 #include "utils/inttypes.h"
-#include "utils/serializable.h"
 
 #include "math/hal/bigintfxd/ubintfxd.h"
 
@@ -60,8 +59,7 @@ using BigVector = BigVectorFixedT<BigInteger>;
  * @brief The class for representing vectors of big binary integers.
  */
 template <class IntegerType>
-class BigVectorFixedT : public lbcrypto::BigVectorInterface<BigVectorFixedT<IntegerType>, IntegerType>,
-                        public lbcrypto::Serializable {
+class BigVectorFixedT : public lbcrypto::BigVectorInterface<BigVectorFixedT<IntegerType>, IntegerType> {
 public:
     // CONSTRUCTORS
 
@@ -550,7 +548,7 @@ public:
     template <class Archive>
     typename std::enable_if<!cereal::traits::is_text_archive<Archive>::value, void>::type load(
         Archive& ar, std::uint32_t const version) {
-        if (version > Serializable::SerializedVersion()) {
+        if (version > this->SerializedVersion()) {
             OPENFHE_THROW(lbcrypto::deserialize_error, "serialized object version " + std::to_string(version) +
                                                             " is from a later version of the library");
         }
@@ -563,7 +561,7 @@ public:
     template <class Archive>
     typename std::enable_if<cereal::traits::is_text_archive<Archive>::value, void>::type load(
         Archive& ar, std::uint32_t const version) {
-        if (version > Serializable::SerializedVersion()) {
+        if (version > this->SerializedVersion()) {
             OPENFHE_THROW(lbcrypto::deserialize_error, "serialized object version " + std::to_string(version) +
                                                             " is from a later version of the library");
         }

--- a/src/core/include/math/hal/bigintfxd/mubintvecfxd.h
+++ b/src/core/include/math/hal/bigintfxd/mubintvecfxd.h
@@ -550,7 +550,7 @@ public:
     template <class Archive>
     typename std::enable_if<!cereal::traits::is_text_archive<Archive>::value, void>::type load(
         Archive& ar, std::uint32_t const version) {
-        if (version > SerializedVersion()) {
+        if (version > Serializable::SerializedVersion()) {
             OPENFHE_THROW(lbcrypto::deserialize_error, "serialized object version " + std::to_string(version) +
                                                             " is from a later version of the library");
         }
@@ -563,7 +563,7 @@ public:
     template <class Archive>
     typename std::enable_if<cereal::traits::is_text_archive<Archive>::value, void>::type load(
         Archive& ar, std::uint32_t const version) {
-        if (version > SerializedVersion()) {
+        if (version > Serializable::SerializedVersion()) {
             OPENFHE_THROW(lbcrypto::deserialize_error, "serialized object version " + std::to_string(version) +
                                                             " is from a later version of the library");
         }
@@ -575,10 +575,6 @@ public:
         }
     }
 
-
-    static uint32_t SerializedVersion() {
-        return 1;
-    }
 
 private:
     // m_data is a pointer to the vector

--- a/src/core/include/math/hal/bigintfxd/ubintfxd.h
+++ b/src/core/include/math/hal/bigintfxd/ubintfxd.h
@@ -1087,9 +1087,6 @@ public:
         ar(::cereal::make_nvp("m", m_MSB));
     }
 
-    std::string SerializedObjectName() const {
-        return "FXDInteger";
-    }
 
     static uint32_t SerializedVersion() {
         return 1;

--- a/src/core/include/math/hal/bigintfxd/ubintfxd.h
+++ b/src/core/include/math/hal/bigintfxd/ubintfxd.h
@@ -256,7 +256,7 @@ const double LOG2_10 = 3.32192809;  //!< @brief A pre-computed constant of Log b
  * @tparam BITLENGTH maximum bitwidth supported for big integers
  */
 template <typename uint_type, usint BITLENGTH>
-class BigIntegerFixedT : public lbcrypto::BigIntegerInterface<BigIntegerFixedT<uint_type, BITLENGTH>> {
+class BigIntegerFixedT : public lbcrypto::BigIntegerInterface<BigIntegerFixedT<uint_type, BITLENGTH>>, public lbcrypto::Serializable {
 public:
     // CONSTRUCTORS
 
@@ -1068,7 +1068,7 @@ public:
     template <class Archive>
     typename std::enable_if<!cereal::traits::is_text_archive<Archive>::value, void>::type load(
         Archive& ar, std::uint32_t const version) {
-        if (version > SerializedVersion()) {
+        if (version > Serializable::SerializedVersion()) {
             OPENFHE_THROW(lbcrypto::deserialize_error, "serialized object version " + std::to_string(version) +
                                                             " is from a later version of the library");
         }
@@ -1079,7 +1079,7 @@ public:
     template <class Archive>
     typename std::enable_if<cereal::traits::is_text_archive<Archive>::value, void>::type load(
         Archive& ar, std::uint32_t const version) {
-        if (version > SerializedVersion()) {
+        if (version > Serializable::SerializedVersion()) {
             OPENFHE_THROW(lbcrypto::deserialize_error, "serialized object version " + std::to_string(version) +
                                                             " is from a later version of the library");
         }
@@ -1087,10 +1087,6 @@ public:
         ar(::cereal::make_nvp("m", m_MSB));
     }
 
-
-    static uint32_t SerializedVersion() {
-        return 1;
-    }
 
 protected:
     /**

--- a/src/core/include/math/hal/bigintfxd/ubintfxd.h
+++ b/src/core/include/math/hal/bigintfxd/ubintfxd.h
@@ -57,7 +57,6 @@
 #include "utils/inttypes.h"
 #include "utils/memory.h"
 #include "utils/openfhebase64.h"
-#include "utils/serializable.h"
 #include "utils/utilities.h"
 
 #include "math/hal/integer.h"
@@ -256,7 +255,7 @@ const double LOG2_10 = 3.32192809;  //!< @brief A pre-computed constant of Log b
  * @tparam BITLENGTH maximum bitwidth supported for big integers
  */
 template <typename uint_type, usint BITLENGTH>
-class BigIntegerFixedT : public lbcrypto::BigIntegerInterface<BigIntegerFixedT<uint_type, BITLENGTH>>, public lbcrypto::Serializable {
+class BigIntegerFixedT : public lbcrypto::BigIntegerInterface<BigIntegerFixedT<uint_type, BITLENGTH>> {
 public:
     // CONSTRUCTORS
 
@@ -1068,7 +1067,7 @@ public:
     template <class Archive>
     typename std::enable_if<!cereal::traits::is_text_archive<Archive>::value, void>::type load(
         Archive& ar, std::uint32_t const version) {
-        if (version > Serializable::SerializedVersion()) {
+        if (version > this->SerializedVersion()) {
             OPENFHE_THROW(lbcrypto::deserialize_error, "serialized object version " + std::to_string(version) +
                                                             " is from a later version of the library");
         }
@@ -1079,7 +1078,7 @@ public:
     template <class Archive>
     typename std::enable_if<cereal::traits::is_text_archive<Archive>::value, void>::type load(
         Archive& ar, std::uint32_t const version) {
-        if (version > Serializable::SerializedVersion()) {
+        if (version > this->SerializedVersion()) {
             OPENFHE_THROW(lbcrypto::deserialize_error, "serialized object version " + std::to_string(version) +
                                                             " is from a later version of the library");
         }

--- a/src/core/include/math/hal/bigintntl/mubintvecntl.h
+++ b/src/core/include/math/hal/bigintntl/mubintvecntl.h
@@ -670,9 +670,6 @@ public:
         }
     }
 
-    std::string SerializedObjectName() const {
-        return "NTLVector";
-    }
 
     static uint32_t SerializedVersion() {
         return 1;

--- a/src/core/include/math/hal/bigintntl/mubintvecntl.h
+++ b/src/core/include/math/hal/bigintntl/mubintvecntl.h
@@ -620,7 +620,7 @@ public:
     template <class Archive>
     typename std::enable_if<!cereal::traits::is_text_archive<Archive>::value, void>::type load(
         Archive& ar, std::uint32_t const version) {
-        if (version > SerializedVersion()) {
+        if (version > Serializable::SerializedVersion()) {
             OPENFHE_THROW(lbcrypto::deserialize_error, "serialized object version " + std::to_string(version) +
                                                             " is from a later version of the library");
         }
@@ -652,7 +652,7 @@ public:
     template <class Archive>
     typename std::enable_if<cereal::traits::is_text_archive<Archive>::value, void>::type load(
         Archive& ar, std::uint32_t const version) {
-        if (version > SerializedVersion()) {
+        if (version > Serializable::SerializedVersion()) {
             OPENFHE_THROW(lbcrypto::deserialize_error, "serialized object version " + std::to_string(version) +
                                                             " is from a later version of the library");
         }
@@ -670,10 +670,6 @@ public:
         }
     }
 
-
-    static uint32_t SerializedVersion() {
-        return 1;
-    }
 
 private:
     // utility function to warn if modulus is no good

--- a/src/core/include/math/hal/bigintntl/mubintvecntl.h
+++ b/src/core/include/math/hal/bigintntl/mubintvecntl.h
@@ -55,7 +55,6 @@
         #include "math/hal/bigintntl/ubintntl.h"
         #include "utils/exception.h"
         #include "utils/inttypes.h"
-        #include "utils/serializable.h"
 
 // defining this forces modulo when you write to the vector (except with at())
 // this is becuase NTL required inputs to modmath to be < modulus but BU does
@@ -87,8 +86,7 @@ using BigVector = myVecP<BigInteger>;
 
 template <typename myT>
 class myVecP : public NTL::Vec<myT>,
-               public lbcrypto::BigVectorInterface<myVecP<myT>, myT>,
-               public lbcrypto::Serializable {
+               public lbcrypto::BigVectorInterface<myVecP<myT>, myT> {
 public:
     // CONSTRUCTORS
 
@@ -620,7 +618,7 @@ public:
     template <class Archive>
     typename std::enable_if<!cereal::traits::is_text_archive<Archive>::value, void>::type load(
         Archive& ar, std::uint32_t const version) {
-        if (version > Serializable::SerializedVersion()) {
+        if (version > this->SerializedVersion()) {
             OPENFHE_THROW(lbcrypto::deserialize_error, "serialized object version " + std::to_string(version) +
                                                             " is from a later version of the library");
         }
@@ -652,7 +650,7 @@ public:
     template <class Archive>
     typename std::enable_if<cereal::traits::is_text_archive<Archive>::value, void>::type load(
         Archive& ar, std::uint32_t const version) {
-        if (version > Serializable::SerializedVersion()) {
+        if (version > this->SerializedVersion()) {
             OPENFHE_THROW(lbcrypto::deserialize_error, "serialized object version " + std::to_string(version) +
                                                             " is from a later version of the library");
         }

--- a/src/core/include/math/hal/bigintntl/ubintntl.h
+++ b/src/core/include/math/hal/bigintntl/ubintntl.h
@@ -1047,9 +1047,6 @@ public:
         *this = s;
     }
 
-    std::string SerializedObjectName() const {
-        return "NTLInteger";
-    }
 
     static uint32_t SerializedVersion() {
         return 1;

--- a/src/core/include/math/hal/bigintntl/ubintntl.h
+++ b/src/core/include/math/hal/bigintntl/ubintntl.h
@@ -1015,7 +1015,7 @@ public:
     template <class Archive>
     typename std::enable_if<!cereal::traits::is_text_archive<Archive>::value, void>::type load(
         Archive& ar, std::uint32_t const version) {
-        if (version > SerializedVersion()) {
+        if (version > Serializable::SerializedVersion()) {
             OPENFHE_THROW(lbcrypto::deserialize_error, "serialized object version " + std::to_string(version) +
                                                             " is from a later version of the library");
         }
@@ -1038,7 +1038,7 @@ public:
     template <class Archive>
     typename std::enable_if<cereal::traits::is_text_archive<Archive>::value, void>::type load(
         Archive& ar, std::uint32_t const version) {
-        if (version > SerializedVersion()) {
+        if (version > Serializable::SerializedVersion()) {
             OPENFHE_THROW(lbcrypto::deserialize_error, "serialized object version " + std::to_string(version) +
                                                             " is from a later version of the library");
         }
@@ -1047,10 +1047,6 @@ public:
         *this = s;
     }
 
-
-    static uint32_t SerializedVersion() {
-        return 1;
-    }
 
 private:
     // adapter kits

--- a/src/core/include/math/hal/bigintntl/ubintntl.h
+++ b/src/core/include/math/hal/bigintntl/ubintntl.h
@@ -62,7 +62,6 @@
 
         #include "utils/openfhebase64.h"
         #include "utils/parallel.h"
-        #include "utils/serializable.h"
 
         #include "utils/exception.h"
         #include "utils/inttypes.h"
@@ -1015,7 +1014,7 @@ public:
     template <class Archive>
     typename std::enable_if<!cereal::traits::is_text_archive<Archive>::value, void>::type load(
         Archive& ar, std::uint32_t const version) {
-        if (version > Serializable::SerializedVersion()) {
+        if (version > this->SerializedVersion()) {
             OPENFHE_THROW(lbcrypto::deserialize_error, "serialized object version " + std::to_string(version) +
                                                             " is from a later version of the library");
         }
@@ -1038,7 +1037,7 @@ public:
     template <class Archive>
     typename std::enable_if<cereal::traits::is_text_archive<Archive>::value, void>::type load(
         Archive& ar, std::uint32_t const version) {
-        if (version > Serializable::SerializedVersion()) {
+        if (version > this->SerializedVersion()) {
             OPENFHE_THROW(lbcrypto::deserialize_error, "serialized object version " + std::to_string(version) +
                                                             " is from a later version of the library");
         }

--- a/src/core/include/math/hal/integer.h
+++ b/src/core/include/math/hal/integer.h
@@ -38,11 +38,12 @@
 
 #include <string>
 #include "utils/inttypes.h"
+#include "utils/serializable.h"
 
 namespace lbcrypto {
 
 template <typename T>
-class BigIntegerInterface {
+class BigIntegerInterface : public Serializable {
 public:
     // CONSTRUCTORS
 

--- a/src/core/include/math/hal/intnat/mubintvecnat.h
+++ b/src/core/include/math/hal/intnat/mubintvecnat.h
@@ -633,9 +633,6 @@ public:
         ar(::cereal::make_nvp("m", m_modulus));
     }
 
-    std::string SerializedObjectName() const {
-        return "NativeVectorT";
-    }
 
     static uint32_t SerializedVersion() {
         return 1;

--- a/src/core/include/math/hal/intnat/mubintvecnat.h
+++ b/src/core/include/math/hal/intnat/mubintvecnat.h
@@ -45,7 +45,6 @@
 #include "math/hal/vector.h"
 
 #include "utils/inttypes.h"
-#include "utils/serializable.h"
 #include "utils/blockAllocator/xvector.h"
 
 // the following should be set to 1 in order to have native vector use block
@@ -113,8 +112,7 @@ bool operator!=(const NAlloc<T>&, const NAlloc<U>&) { return false; }
 #endif
 
 template <class IntegerType>
-class NativeVectorT : public lbcrypto::BigVectorInterface<NativeVectorT<IntegerType>, IntegerType>,
-                      public lbcrypto::Serializable {
+class NativeVectorT : public lbcrypto::BigVectorInterface<NativeVectorT<IntegerType>, IntegerType> {
 public:
     typedef IntegerType BVInt;
 
@@ -604,7 +602,7 @@ public:
     template <class Archive>
     typename std::enable_if<!cereal::traits::is_text_archive<Archive>::value, void>::type load(
         Archive& ar, std::uint32_t const version) {
-        if (version > Serializable::SerializedVersion()) {
+        if (version > this->SerializedVersion()) {
             OPENFHE_THROW(lbcrypto::deserialize_error, "serialized object version " + std::to_string(version) +
                                                             " is from a later version of the library");
         }
@@ -625,7 +623,7 @@ public:
     template <class Archive>
     typename std::enable_if<cereal::traits::is_text_archive<Archive>::value, void>::type load(
         Archive& ar, std::uint32_t const version) {
-        if (version > Serializable::SerializedVersion()) {
+        if (version > this->SerializedVersion()) {
             OPENFHE_THROW(lbcrypto::deserialize_error, "serialized object version " + std::to_string(version) +
                                                             " is from a later version of the library");
         }

--- a/src/core/include/math/hal/intnat/mubintvecnat.h
+++ b/src/core/include/math/hal/intnat/mubintvecnat.h
@@ -604,7 +604,7 @@ public:
     template <class Archive>
     typename std::enable_if<!cereal::traits::is_text_archive<Archive>::value, void>::type load(
         Archive& ar, std::uint32_t const version) {
-        if (version > SerializedVersion()) {
+        if (version > Serializable::SerializedVersion()) {
             OPENFHE_THROW(lbcrypto::deserialize_error, "serialized object version " + std::to_string(version) +
                                                             " is from a later version of the library");
         }
@@ -625,7 +625,7 @@ public:
     template <class Archive>
     typename std::enable_if<cereal::traits::is_text_archive<Archive>::value, void>::type load(
         Archive& ar, std::uint32_t const version) {
-        if (version > SerializedVersion()) {
+        if (version > Serializable::SerializedVersion()) {
             OPENFHE_THROW(lbcrypto::deserialize_error, "serialized object version " + std::to_string(version) +
                                                             " is from a later version of the library");
         }
@@ -633,10 +633,6 @@ public:
         ar(::cereal::make_nvp("m", m_modulus));
     }
 
-
-    static uint32_t SerializedVersion() {
-        return 1;
-    }
 
 private:
     // m_data is a pointer to the vector

--- a/src/core/include/math/hal/intnat/ubintnat.h
+++ b/src/core/include/math/hal/intnat/ubintnat.h
@@ -2025,9 +2025,6 @@ public:
     }
 #endif
 
-    std::string SerializedObjectName() const {
-        return "NATInteger";
-    }
 
     static uint32_t SerializedVersion() {
         return 1;

--- a/src/core/include/math/hal/intnat/ubintnat.h
+++ b/src/core/include/math/hal/intnat/ubintnat.h
@@ -58,7 +58,6 @@
 #include "utils/inttypes.h"
 #include "utils/memory.h"
 #include "utils/openfhebase64.h"
-#include "utils/serializable.h"
 
 #if NATIVEINT == 128
     // need the BigInteger to handle double 128-bit word
@@ -144,7 +143,7 @@ struct DoubleDataType<unsigned __int128> {
  * @tparam NativeInt native unsigned integer type
  */
 template <typename NativeInt>
-class NativeIntegerT : public lbcrypto::BigIntegerInterface<NativeIntegerT<NativeInt>>, public lbcrypto::Serializable {
+class NativeIntegerT : public lbcrypto::BigIntegerInterface<NativeIntegerT<NativeInt>> {
 public:
     using Integer         = NativeInt;
     using DNativeInt      = typename DoubleDataType<NativeInt>::DoubleType;
@@ -1952,7 +1951,7 @@ public:
     template <class Archive, typename T = void>
     typename std::enable_if<std::is_same<NativeInt, U64BITS>::value || std::is_same<NativeInt, U32BITS>::value, T>::type
     load(Archive& ar, std::uint32_t const version) {
-        if (version > Serializable::SerializedVersion()) {
+        if (version > this->SerializedVersion()) {
             OPENFHE_THROW(lbcrypto::deserialize_error, "serialized object version " + std::to_string(version) +
                                                             " is from a later version of the library");
         }
@@ -1964,7 +1963,7 @@ public:
     typename std::enable_if<
         std::is_same<NativeInt, U128BITS>::value && !cereal::traits::is_text_archive<Archive>::value, void>::type
     load(Archive& ar, std::uint32_t const version) {
-        if (version > Serializable::SerializedVersion()) {
+        if (version > this->SerializedVersion()) {
             OPENFHE_THROW(lbcrypto::deserialize_error, "serialized object version " + std::to_string(version) +
                                                             " is from a later version of the library");
         }
@@ -1980,7 +1979,7 @@ public:
     typename std::enable_if<std::is_same<NativeInt, U128BITS>::value && cereal::traits::is_text_archive<Archive>::value,
                             void>::type
     load(Archive& ar, std::uint32_t const version) {
-        if (version > Serializable::SerializedVersion()) {
+        if (version > this->SerializedVersion()) {
             OPENFHE_THROW(lbcrypto::deserialize_error, "serialized object version " + std::to_string(version) +
                                                             " is from a later version of the library");
         }

--- a/src/core/include/math/hal/intnat/ubintnat.h
+++ b/src/core/include/math/hal/intnat/ubintnat.h
@@ -144,7 +144,7 @@ struct DoubleDataType<unsigned __int128> {
  * @tparam NativeInt native unsigned integer type
  */
 template <typename NativeInt>
-class NativeIntegerT : public lbcrypto::BigIntegerInterface<NativeIntegerT<NativeInt>> {
+class NativeIntegerT : public lbcrypto::BigIntegerInterface<NativeIntegerT<NativeInt>>, public lbcrypto::Serializable {
 public:
     using Integer         = NativeInt;
     using DNativeInt      = typename DoubleDataType<NativeInt>::DoubleType;
@@ -1952,7 +1952,7 @@ public:
     template <class Archive, typename T = void>
     typename std::enable_if<std::is_same<NativeInt, U64BITS>::value || std::is_same<NativeInt, U32BITS>::value, T>::type
     load(Archive& ar, std::uint32_t const version) {
-        if (version > SerializedVersion()) {
+        if (version > Serializable::SerializedVersion()) {
             OPENFHE_THROW(lbcrypto::deserialize_error, "serialized object version " + std::to_string(version) +
                                                             " is from a later version of the library");
         }
@@ -1964,7 +1964,7 @@ public:
     typename std::enable_if<
         std::is_same<NativeInt, U128BITS>::value && !cereal::traits::is_text_archive<Archive>::value, void>::type
     load(Archive& ar, std::uint32_t const version) {
-        if (version > SerializedVersion()) {
+        if (version > Serializable::SerializedVersion()) {
             OPENFHE_THROW(lbcrypto::deserialize_error, "serialized object version " + std::to_string(version) +
                                                             " is from a later version of the library");
         }
@@ -1980,7 +1980,7 @@ public:
     typename std::enable_if<std::is_same<NativeInt, U128BITS>::value && cereal::traits::is_text_archive<Archive>::value,
                             void>::type
     load(Archive& ar, std::uint32_t const version) {
-        if (version > SerializedVersion()) {
+        if (version > Serializable::SerializedVersion()) {
             OPENFHE_THROW(lbcrypto::deserialize_error, "serialized object version " + std::to_string(version) +
                                                             " is from a later version of the library");
         }
@@ -2025,10 +2025,6 @@ public:
     }
 #endif
 
-
-    static uint32_t SerializedVersion() {
-        return 1;
-    }
 
     static constexpr unsigned MaxBits() {
         return m_uintBitLength;

--- a/src/core/include/math/hal/vector.h
+++ b/src/core/include/math/hal/vector.h
@@ -38,11 +38,12 @@
 
 #include <string>
 #include "utils/inttypes.h"
+#include "utils/serializable.h"
 
 namespace lbcrypto {
 
 template <typename T, typename I>
-class BigVectorInterface {
+class BigVectorInterface : public Serializable {
 public:
     typedef I Integer;
 

--- a/src/core/include/math/matrix.h
+++ b/src/core/include/math/matrix.h
@@ -683,9 +683,6 @@ public:
         // users will need to SetAllocator for any newly deserialized matrix
     }
 
-    std::string SerializedObjectName() const {
-        return "Matrix";
-    }
     static uint32_t SerializedVersion() {
         return 1;
     }

--- a/src/core/include/math/matrix.h
+++ b/src/core/include/math/matrix.h
@@ -672,7 +672,7 @@ public:
 
     template <class Archive>
     void load(Archive& ar, std::uint32_t const version) {
-        if (version > SerializedVersion()) {
+        if (version > Serializable::SerializedVersion()) {
             OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
                                                   " is from a later version of the library");
         }
@@ -681,10 +681,6 @@ public:
         ar(::cereal::make_nvp("c", cols));
 
         // users will need to SetAllocator for any newly deserialized matrix
-    }
-
-    static uint32_t SerializedVersion() {
-        return 1;
     }
 
 private:

--- a/src/core/include/math/matrix.h
+++ b/src/core/include/math/matrix.h
@@ -672,7 +672,7 @@ public:
 
     template <class Archive>
     void load(Archive& ar, std::uint32_t const version) {
-        if (version > Serializable::SerializedVersion()) {
+        if (version > this->SerializedVersion()) {
             OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
                                                   " is from a later version of the library");
         }

--- a/src/core/include/utils/serializable.h
+++ b/src/core/include/utils/serializable.h
@@ -40,6 +40,7 @@
 #include <iostream>
 #include <string>
 #include <vector>
+#include "utils/type_name.h"
 
 #ifndef CEREAL_RAPIDJSON_HAS_STDSTRING
     #define CEREAL_RAPIDJSON_HAS_STDSTRING 1
@@ -90,8 +91,12 @@ class Serializable {
 public:
     virtual ~Serializable() {}
 
-    virtual std::string SerializedObjectName() const = 0;
+    virtual std::string SerializedObjectName() const {
+        return objectTypeName(this);
+    }
 };
+
+
 
 // helper template to stream vector contents provided T has an stream operator<<
 template <typename T>

--- a/src/core/include/utils/serializable.h
+++ b/src/core/include/utils/serializable.h
@@ -94,6 +94,10 @@ public:
     virtual std::string SerializedObjectName() const {
         return objectTypeName(this);
     }
+
+    static uint32_t SerializedVersion() {
+        return 1;
+    }
 };
 
 

--- a/src/pke/include/ciphertext.h
+++ b/src/pke/include/ciphertext.h
@@ -569,7 +569,6 @@ class CiphertextImpl : public CryptoObject<Element> {
     ar(cereal::make_nvp("m", m_metadataMap));
   }
 
-  std::string SerializedObjectName() const { return "Ciphertext"; }
   static uint32_t SerializedVersion() { return 1; }
 
  private:

--- a/src/pke/include/ciphertext.h
+++ b/src/pke/include/ciphertext.h
@@ -552,7 +552,7 @@ class CiphertextImpl : public CryptoObject<Element> {
 
   template <class Archive>
   void load(Archive& ar, std::uint32_t const version) {
-    if (version > SerializedVersion()) {
+    if (version > Serializable::SerializedVersion()) {
       OPENFHE_THROW(deserialize_error,
                      "serialized object version " + std::to_string(version) +
                          " is from a later version of the library");
@@ -568,8 +568,6 @@ class CiphertextImpl : public CryptoObject<Element> {
     ar(cereal::make_nvp("sl", m_slots));
     ar(cereal::make_nvp("m", m_metadataMap));
   }
-
-  static uint32_t SerializedVersion() { return 1; }
 
  private:
   // FUTURE ENHANCEMENT: current value of error norm

--- a/src/pke/include/ciphertext.h
+++ b/src/pke/include/ciphertext.h
@@ -552,7 +552,7 @@ class CiphertextImpl : public CryptoObject<Element> {
 
   template <class Archive>
   void load(Archive& ar, std::uint32_t const version) {
-    if (version > Serializable::SerializedVersion()) {
+    if (version > this->SerializedVersion()) {
       OPENFHE_THROW(deserialize_error,
                      "serialized object version " + std::to_string(version) +
                          " is from a later version of the library");

--- a/src/pke/include/cryptocontext.h
+++ b/src/pke/include/cryptocontext.h
@@ -2449,7 +2449,7 @@ protected:
 
   template <class Archive>
   void load(Archive& ar, std::uint32_t const version) {
-    if (version > Serializable::SerializedVersion()) {
+    if (version > this->SerializedVersion()) {
       OPENFHE_THROW(deserialize_error,
                      "serialized object version " + std::to_string(version) +
                          " is from a later version of the library");

--- a/src/pke/include/cryptocontext.h
+++ b/src/pke/include/cryptocontext.h
@@ -2449,7 +2449,7 @@ protected:
 
   template <class Archive>
   void load(Archive& ar, std::uint32_t const version) {
-    if (version > SerializedVersion()) {
+    if (version > Serializable::SerializedVersion()) {
       OPENFHE_THROW(deserialize_error,
                      "serialized object version " + std::to_string(version) +
                          " is from a later version of the library");
@@ -2466,8 +2466,6 @@ protected:
     // object that's already existing in memory if it DOES exist, use it. If it
     // does NOT exist, add this to the cache of all contexts
   }
-
-  static uint32_t SerializedVersion() { return 1; }
 };
 
 }  // namespace lbcrypto

--- a/src/pke/include/cryptocontext.h
+++ b/src/pke/include/cryptocontext.h
@@ -2467,7 +2467,6 @@ protected:
     // does NOT exist, add this to the cache of all contexts
   }
 
-  virtual std::string SerializedObjectName() const { return "CryptoContext"; }
   static uint32_t SerializedVersion() { return 1; }
 };
 

--- a/src/pke/include/cryptoobject.h
+++ b/src/pke/include/cryptoobject.h
@@ -135,7 +135,6 @@ class CryptoObject {
   }
 
 
-  std::string SerializedObjectName() const { return "CryptoObject"; }
   static uint32_t SerializedVersion() { return 1; }
 };
 

--- a/src/pke/include/cryptoobject.h
+++ b/src/pke/include/cryptoobject.h
@@ -119,7 +119,7 @@ class CryptoObject : public Serializable {
 
   template <class Archive>
   void load(Archive& ar, std::uint32_t const version) {
-    if (version > Serializable::SerializedVersion()) {
+    if (version > this->SerializedVersion()) {
       OPENFHE_THROW(deserialize_error,
                      "serialized object version " + std::to_string(version) +
                          " is from a later version of the library");

--- a/src/pke/include/cryptoobject.h
+++ b/src/pke/include/cryptoobject.h
@@ -57,7 +57,7 @@ class CryptoContextFactory;
  * A class to aid in referring to the crypto context that an object belongs to
  */
 template <typename Element>
-class CryptoObject {
+class CryptoObject : public Serializable {
  protected:
   CryptoContext<Element> context;  // crypto context this object belongs to
                                    // tag used to find the evaluation key needed
@@ -119,7 +119,7 @@ class CryptoObject {
 
   template <class Archive>
   void load(Archive& ar, std::uint32_t const version) {
-    if (version > SerializedVersion()) {
+    if (version > Serializable::SerializedVersion()) {
       OPENFHE_THROW(deserialize_error,
                      "serialized object version " + std::to_string(version) +
                          " is from a later version of the library");
@@ -133,9 +133,6 @@ class CryptoObject {
         context->getSchemeId()
         );
   }
-
-
-  static uint32_t SerializedVersion() { return 1; }
 };
 
 }

--- a/src/pke/include/encoding/encodingparams.h
+++ b/src/pke/include/encoding/encodingparams.h
@@ -301,7 +301,6 @@ class EncodingParamsImpl : public lbcrypto::Serializable {
     ar(::cereal::make_nvp("bs", m_batchSize));
   }
 
-  std::string SerializedObjectName() const { return "EncodingParms"; }
   static uint32_t SerializedVersion() { return 1; }
 };
 

--- a/src/pke/include/encoding/encodingparams.h
+++ b/src/pke/include/encoding/encodingparams.h
@@ -288,7 +288,7 @@ class EncodingParamsImpl : public lbcrypto::Serializable {
 
   template <class Archive>
   void load(Archive &ar, std::uint32_t const version) {
-    if (version > SerializedVersion()) {
+    if (version > Serializable::SerializedVersion()) {
       OPENFHE_THROW(deserialize_error,
                      "serialized object version " + std::to_string(version) +
                          " is from a later version of the library");
@@ -301,7 +301,6 @@ class EncodingParamsImpl : public lbcrypto::Serializable {
     ar(::cereal::make_nvp("bs", m_batchSize));
   }
 
-  static uint32_t SerializedVersion() { return 1; }
 };
 
 inline std::ostream &operator<<(std::ostream &out,

--- a/src/pke/include/encoding/encodingparams.h
+++ b/src/pke/include/encoding/encodingparams.h
@@ -288,7 +288,7 @@ class EncodingParamsImpl : public lbcrypto::Serializable {
 
   template <class Archive>
   void load(Archive &ar, std::uint32_t const version) {
-    if (version > Serializable::SerializedVersion()) {
+    if (version > this->SerializedVersion()) {
       OPENFHE_THROW(deserialize_error,
                      "serialized object version " + std::to_string(version) +
                          " is from a later version of the library");

--- a/src/pke/include/key/evalkey.h
+++ b/src/pke/include/key/evalkey.h
@@ -257,7 +257,6 @@ class EvalKeyImpl : public Key<Element> {
   void load(Archive &ar, std::uint32_t const version) {
     ar(::cereal::base_class<Key<Element>>(this));
   }
-  std::string SerializedObjectName() const { return "EvalKey"; }
 };
 
 }  // namespace lbcrypto

--- a/src/pke/include/key/evalkey.h
+++ b/src/pke/include/key/evalkey.h
@@ -255,6 +255,10 @@ class EvalKeyImpl : public Key<Element> {
 
   template <class Archive>
   void load(Archive &ar, std::uint32_t const version) {
+    if (version > Serializable::SerializedVersion()) {
+        OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
+            " is from a later version of the library");
+    }
     ar(::cereal::base_class<Key<Element>>(this));
   }
 };

--- a/src/pke/include/key/evalkey.h
+++ b/src/pke/include/key/evalkey.h
@@ -255,7 +255,7 @@ class EvalKeyImpl : public Key<Element> {
 
   template <class Archive>
   void load(Archive &ar, std::uint32_t const version) {
-    if (version > Serializable::SerializedVersion()) {
+    if (version > this->SerializedVersion()) {
         OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
             " is from a later version of the library");
     }

--- a/src/pke/include/key/evalkeyrelin.h
+++ b/src/pke/include/key/evalkeyrelin.h
@@ -267,7 +267,6 @@ class EvalKeyRelinImpl : public EvalKeyImpl<Element> {
     ar(::cereal::base_class<EvalKeyImpl<Element>>(this));
     ar(::cereal::make_nvp("k", m_rKey));
   }
-  std::string SerializedObjectName() const { return "EvalKeyRelin"; }
   static uint32_t SerializedVersion() { return 1; }
 
  private:

--- a/src/pke/include/key/evalkeyrelin.h
+++ b/src/pke/include/key/evalkeyrelin.h
@@ -259,7 +259,7 @@ class EvalKeyRelinImpl : public EvalKeyImpl<Element> {
 
   template <class Archive>
   void load(Archive &ar, std::uint32_t const version) {
-    if (version > SerializedVersion()) {
+    if (version > Serializable::SerializedVersion()) {
       OPENFHE_THROW(deserialize_error,
                      "serialized object version " + std::to_string(version) +
                          " is from a later version of the library");
@@ -267,7 +267,6 @@ class EvalKeyRelinImpl : public EvalKeyImpl<Element> {
     ar(::cereal::base_class<EvalKeyImpl<Element>>(this));
     ar(::cereal::make_nvp("k", m_rKey));
   }
-  static uint32_t SerializedVersion() { return 1; }
 
  private:
   // private member to store vector of vector of Element.

--- a/src/pke/include/key/evalkeyrelin.h
+++ b/src/pke/include/key/evalkeyrelin.h
@@ -259,7 +259,7 @@ class EvalKeyRelinImpl : public EvalKeyImpl<Element> {
 
   template <class Archive>
   void load(Archive &ar, std::uint32_t const version) {
-    if (version > Serializable::SerializedVersion()) {
+    if (version > this->SerializedVersion()) {
       OPENFHE_THROW(deserialize_error,
                      "serialized object version " + std::to_string(version) +
                          " is from a later version of the library");

--- a/src/pke/include/key/key.h
+++ b/src/pke/include/key/key.h
@@ -50,7 +50,7 @@ namespace lbcrypto {
  * @tparam Element a ring element.
  */
 template <class Element>
-class Key : public CryptoObject<Element>, public Serializable {
+class Key : public CryptoObject<Element> {
  public:
   explicit Key(CryptoContext<Element> cc = 0, const std::string &id = "")
       : CryptoObject<Element>(cc, id) {}
@@ -67,6 +67,10 @@ class Key : public CryptoObject<Element>, public Serializable {
 
   template <class Archive>
   void load(Archive &ar, std::uint32_t const version) {
+    if (version > Serializable::SerializedVersion()) {
+        OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
+            " is from a later version of the library");
+    }
     ar(::cereal::base_class<CryptoObject<Element>>(this));
   }
 

--- a/src/pke/include/key/key.h
+++ b/src/pke/include/key/key.h
@@ -67,7 +67,7 @@ class Key : public CryptoObject<Element> {
 
   template <class Archive>
   void load(Archive &ar, std::uint32_t const version) {
-    if (version > Serializable::SerializedVersion()) {
+    if (version > this->SerializedVersion()) {
         OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
             " is from a later version of the library");
     }

--- a/src/pke/include/key/privatekey.h
+++ b/src/pke/include/key/privatekey.h
@@ -167,7 +167,6 @@ class PrivateKeyImpl : public Key<Element> {
     ar(::cereal::make_nvp("s", m_sk));
   }
 
-  std::string SerializedObjectName() const { return "PrivateKey"; }
   static uint32_t SerializedVersion() { return 1; }
 
  private:

--- a/src/pke/include/key/privatekey.h
+++ b/src/pke/include/key/privatekey.h
@@ -158,7 +158,7 @@ class PrivateKeyImpl : public Key<Element> {
 
   template <class Archive>
   void load(Archive &ar, std::uint32_t const version) {
-    if (version > SerializedVersion()) {
+    if (version > Serializable::SerializedVersion()) {
       OPENFHE_THROW(deserialize_error,
                      "serialized object version " + std::to_string(version) +
                          " is from a later version of the library");
@@ -166,8 +166,6 @@ class PrivateKeyImpl : public Key<Element> {
     ar(::cereal::base_class<Key<Element>>(this));
     ar(::cereal::make_nvp("s", m_sk));
   }
-
-  static uint32_t SerializedVersion() { return 1; }
 
  private:
   Element m_sk;

--- a/src/pke/include/key/privatekey.h
+++ b/src/pke/include/key/privatekey.h
@@ -158,7 +158,7 @@ class PrivateKeyImpl : public Key<Element> {
 
   template <class Archive>
   void load(Archive &ar, std::uint32_t const version) {
-    if (version > Serializable::SerializedVersion()) {
+    if (version > this->SerializedVersion()) {
       OPENFHE_THROW(deserialize_error,
                      "serialized object version " + std::to_string(version) +
                          " is from a later version of the library");

--- a/src/pke/include/key/publickey.h
+++ b/src/pke/include/key/publickey.h
@@ -191,7 +191,6 @@ class PublicKeyImpl : public Key<Element> {
     ar(::cereal::make_nvp("h", m_h));
   }
 
-  std::string SerializedObjectName() const { return "PublicKey"; }
   static uint32_t SerializedVersion() { return 1; }
 
  private:

--- a/src/pke/include/key/publickey.h
+++ b/src/pke/include/key/publickey.h
@@ -182,7 +182,7 @@ class PublicKeyImpl : public Key<Element> {
 
   template <class Archive>
   void load(Archive &ar, std::uint32_t const version) {
-    if (version > SerializedVersion()) {
+    if (version > Serializable::SerializedVersion()) {
       OPENFHE_THROW(deserialize_error,
                      "serialized object version " + std::to_string(version) +
                          " is from a later version of the library");
@@ -190,8 +190,6 @@ class PublicKeyImpl : public Key<Element> {
     ar(::cereal::base_class<Key<Element>>(this));
     ar(::cereal::make_nvp("h", m_h));
   }
-
-  static uint32_t SerializedVersion() { return 1; }
 
  private:
   std::vector<Element> m_h;

--- a/src/pke/include/key/publickey.h
+++ b/src/pke/include/key/publickey.h
@@ -182,7 +182,7 @@ class PublicKeyImpl : public Key<Element> {
 
   template <class Archive>
   void load(Archive &ar, std::uint32_t const version) {
-    if (version > Serializable::SerializedVersion()) {
+    if (version > this->SerializedVersion()) {
       OPENFHE_THROW(deserialize_error,
                      "serialized object version " + std::to_string(version) +
                          " is from a later version of the library");

--- a/src/pke/include/keyswitch/keyswitch-bv.h
+++ b/src/pke/include/keyswitch/keyswitch-bv.h
@@ -104,7 +104,6 @@ class KeySwitchBV : public KeySwitchRNS {
     ar(cereal::base_class<KeySwitchRNS>(this));
   }
 
-  virtual std::string SerializedObjectName() const override { return "KeySwitchBV"; }
 };
 
 }  // namespace lbcrypto

--- a/src/pke/include/keyswitch/keyswitch-bv.h
+++ b/src/pke/include/keyswitch/keyswitch-bv.h
@@ -101,7 +101,7 @@ class KeySwitchBV : public KeySwitchRNS {
 
   template <class Archive>
   void load(Archive &ar, const std::uint32_t version) {
-    if (version > Serializable::SerializedVersion()) {
+    if (version > this->SerializedVersion()) {
         OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
             " is from a later version of the library");
     }

--- a/src/pke/include/keyswitch/keyswitch-bv.h
+++ b/src/pke/include/keyswitch/keyswitch-bv.h
@@ -100,7 +100,11 @@ class KeySwitchBV : public KeySwitchRNS {
   }
 
   template <class Archive>
-  void load(Archive &ar) {
+  void load(Archive &ar, const std::uint32_t version) {
+    if (version > Serializable::SerializedVersion()) {
+        OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
+            " is from a later version of the library");
+    }
     ar(cereal::base_class<KeySwitchRNS>(this));
   }
 

--- a/src/pke/include/keyswitch/keyswitch-hybrid.h
+++ b/src/pke/include/keyswitch/keyswitch-hybrid.h
@@ -114,7 +114,6 @@ class KeySwitchHYBRID : public KeySwitchRNS {
     ar(cereal::base_class<KeySwitchRNS>(this));
   }
 
-  virtual std::string SerializedObjectName() const override { return "KeySwitchHYBRID"; }
 };
 
 }  // namespace lbcrypto

--- a/src/pke/include/keyswitch/keyswitch-hybrid.h
+++ b/src/pke/include/keyswitch/keyswitch-hybrid.h
@@ -111,7 +111,7 @@ class KeySwitchHYBRID : public KeySwitchRNS {
 
   template <class Archive>
   void load(Archive &ar, const std::uint32_t version) {
-    if (version > Serializable::SerializedVersion()) {
+    if (version > this->SerializedVersion()) {
         OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
             " is from a later version of the library");
     }

--- a/src/pke/include/keyswitch/keyswitch-hybrid.h
+++ b/src/pke/include/keyswitch/keyswitch-hybrid.h
@@ -110,7 +110,11 @@ class KeySwitchHYBRID : public KeySwitchRNS {
   }
 
   template <class Archive>
-  void load(Archive &ar) {
+  void load(Archive &ar, const std::uint32_t version) {
+    if (version > Serializable::SerializedVersion()) {
+        OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
+            " is from a later version of the library");
+    }
     ar(cereal::base_class<KeySwitchRNS>(this));
   }
 

--- a/src/pke/include/keyswitch/keyswitch-rns.h
+++ b/src/pke/include/keyswitch/keyswitch-rns.h
@@ -66,7 +66,6 @@ class KeySwitchRNS : public KeySwitchBase<DCRTPoly> {
     ar(cereal::base_class<KeySwitchBase<DCRTPoly>>(this));
   }
 
-  virtual std::string SerializedObjectName() const { return "KeySwitchRNS"; }
 };
 
 }  // namespace lbcrypto

--- a/src/pke/include/keyswitch/keyswitch-rns.h
+++ b/src/pke/include/keyswitch/keyswitch-rns.h
@@ -64,7 +64,7 @@ class KeySwitchRNS : public KeySwitchBase<DCRTPoly>, public Serializable {
 
   template <class Archive>
   void load(Archive &ar, const std::uint32_t version) {
-    if (version > Serializable::SerializedVersion()) {
+    if (version > this->SerializedVersion()) {
         OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
             " is from a later version of the library");
     }

--- a/src/pke/include/keyswitch/keyswitch-rns.h
+++ b/src/pke/include/keyswitch/keyswitch-rns.h
@@ -37,6 +37,7 @@
 #define LBCRYPTO_CRYPTO_KEYSWITCH_RNS_H
 
 #include "keyswitch/keyswitch-base.h"
+#include "utils/serializable.h"
 
 /**
  * @namespace lbcrypto
@@ -48,7 +49,7 @@ namespace lbcrypto {
  * @brief A child of KeySwitchBase for use with RNS keyswitching
  * @tparam Element a ring element.
  */
-class KeySwitchRNS : public KeySwitchBase<DCRTPoly> {
+class KeySwitchRNS : public KeySwitchBase<DCRTPoly>, public Serializable {
  public:
   virtual ~KeySwitchRNS() {}
 
@@ -62,7 +63,11 @@ class KeySwitchRNS : public KeySwitchBase<DCRTPoly> {
   }
 
   template <class Archive>
-  void load(Archive &ar) {
+  void load(Archive &ar, const std::uint32_t version) {
+    if (version > Serializable::SerializedVersion()) {
+        OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
+            " is from a later version of the library");
+    }
     ar(cereal::base_class<KeySwitchBase<DCRTPoly>>(this));
   }
 

--- a/src/pke/include/metadata.h
+++ b/src/pke/include/metadata.h
@@ -122,11 +122,6 @@ class Metadata {
   }
 
   /**
-   * SerializedObjectName method for serialization
-   */
-  virtual std::string SerializedObjectName() const { return "Metadata"; }
-
-  /**
    * SerializedVersion method for serialization
    */
   static uint32_t SerializedVersion() { return 1; }

--- a/src/pke/include/metadata.h
+++ b/src/pke/include/metadata.h
@@ -114,7 +114,7 @@ class Metadata : public Serializable {
    */
   template <class Archive>
   void load(Archive& ar, std::uint32_t const version) {
-    if (version > Serializable::SerializedVersion()) {
+    if (version > this->SerializedVersion()) {
       OPENFHE_THROW(deserialize_error,
                      "serialized object version " + std::to_string(version) +
                          " is from a later version of the library");
@@ -207,7 +207,7 @@ class MetadataTest : public Metadata {
    */
   template <class Archive>
   void load(Archive& ar, std::uint32_t const version) {
-    if (version > Serializable::SerializedVersion()) {
+    if (version > this->SerializedVersion()) {
       OPENFHE_THROW(deserialize_error,
                      "serialized object version " + std::to_string(version) +
                          " is from a later version of the library");

--- a/src/pke/include/metadata.h
+++ b/src/pke/include/metadata.h
@@ -45,7 +45,7 @@ using MetadataMap = std::shared_ptr<std::map<std::string, std::shared_ptr<Metada
 /**
  * @brief Empty metadata container
  */
-class Metadata {
+class Metadata : public Serializable {
  public:
   /**
    * Default constructor
@@ -114,17 +114,12 @@ class Metadata {
    */
   template <class Archive>
   void load(Archive& ar, std::uint32_t const version) {
-    if (version > SerializedVersion()) {
+    if (version > Serializable::SerializedVersion()) {
       OPENFHE_THROW(deserialize_error,
                      "serialized object version " + std::to_string(version) +
                          " is from a later version of the library");
     }
   }
-
-  /**
-   * SerializedVersion method for serialization
-   */
-  static uint32_t SerializedVersion() { return 1; }
 };
 
 /**
@@ -212,7 +207,7 @@ class MetadataTest : public Metadata {
    */
   template <class Archive>
   void load(Archive& ar, std::uint32_t const version) {
-    if (version > SerializedVersion()) {
+    if (version > Serializable::SerializedVersion()) {
       OPENFHE_THROW(deserialize_error,
                      "serialized object version " + std::to_string(version) +
                          " is from a later version of the library");

--- a/src/pke/include/scheme/bfvrns/bfvrns-advancedshe.h
+++ b/src/pke/include/scheme/bfvrns/bfvrns-advancedshe.h
@@ -58,7 +58,6 @@ public:
     ar(cereal::base_class<AdvancedSHERNS>(this));
   }
 
-  std::string SerializedObjectName() const { return "AdvancedSHEBFVRNS"; }
 };
 }  // namespace lbcrypto
 

--- a/src/pke/include/scheme/bfvrns/bfvrns-advancedshe.h
+++ b/src/pke/include/scheme/bfvrns/bfvrns-advancedshe.h
@@ -54,7 +54,11 @@ public:
   }
 
   template <class Archive>
-  void load(Archive &ar) {
+  void load(Archive &ar, const std::uint32_t version) {
+    if (version > Serializable::SerializedVersion()) {
+        OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
+            " is from a later version of the library");
+    }
     ar(cereal::base_class<AdvancedSHERNS>(this));
   }
 

--- a/src/pke/include/scheme/bfvrns/bfvrns-advancedshe.h
+++ b/src/pke/include/scheme/bfvrns/bfvrns-advancedshe.h
@@ -55,7 +55,7 @@ public:
 
   template <class Archive>
   void load(Archive &ar, const std::uint32_t version) {
-    if (version > Serializable::SerializedVersion()) {
+    if (version > this->SerializedVersion()) {
         OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
             " is from a later version of the library");
     }

--- a/src/pke/include/scheme/bfvrns/bfvrns-cryptoparameters.h
+++ b/src/pke/include/scheme/bfvrns/bfvrns-cryptoparameters.h
@@ -101,7 +101,7 @@ public:
 
   template <class Archive>
   void load(Archive& ar, std::uint32_t const version) {
-      if (version > Serializable::SerializedVersion()) {
+      if (version > this->SerializedVersion()) {
           std::string errMsg("serialized object version " + std::to_string(version) +
               " is from a later version of the library");
           OPENFHE_THROW(deserialize_error, errMsg);

--- a/src/pke/include/scheme/bfvrns/bfvrns-cryptoparameters.h
+++ b/src/pke/include/scheme/bfvrns/bfvrns-cryptoparameters.h
@@ -113,7 +113,6 @@ public:
           m_numPartQ, m_auxBits, m_extraBits);
   }
 
-  std::string SerializedObjectName() const override { return "CryptoParametersBFVRNS"; }
   static uint32_t SerializedVersion() { return 1; }
 };
 

--- a/src/pke/include/scheme/bfvrns/bfvrns-cryptoparameters.h
+++ b/src/pke/include/scheme/bfvrns/bfvrns-cryptoparameters.h
@@ -101,7 +101,7 @@ public:
 
   template <class Archive>
   void load(Archive& ar, std::uint32_t const version) {
-      if (version > SerializedVersion()) {
+      if (version > Serializable::SerializedVersion()) {
           std::string errMsg("serialized object version " + std::to_string(version) +
               " is from a later version of the library");
           OPENFHE_THROW(deserialize_error, errMsg);
@@ -113,7 +113,6 @@ public:
           m_numPartQ, m_auxBits, m_extraBits);
   }
 
-  static uint32_t SerializedVersion() { return 1; }
 };
 
 }  // namespace lbcrypto

--- a/src/pke/include/scheme/bfvrns/bfvrns-leveledshe.h
+++ b/src/pke/include/scheme/bfvrns/bfvrns-leveledshe.h
@@ -101,7 +101,6 @@ public:
     ar(cereal::base_class<LeveledSHERNS>(this));
   }
 
-  std::string SerializedObjectName() const { return "LeveledSHEBFVRNS"; }
 };
 }  // namespace lbcrypto
 

--- a/src/pke/include/scheme/bfvrns/bfvrns-leveledshe.h
+++ b/src/pke/include/scheme/bfvrns/bfvrns-leveledshe.h
@@ -97,7 +97,11 @@ public:
   }
 
   template <class Archive>
-  void load(Archive &ar) {
+  void load(Archive &ar, const std::uint32_t version) {
+    if (version > Serializable::SerializedVersion()) {
+        OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
+            " is from a later version of the library");
+    }
     ar(cereal::base_class<LeveledSHERNS>(this));
   }
 

--- a/src/pke/include/scheme/bfvrns/bfvrns-leveledshe.h
+++ b/src/pke/include/scheme/bfvrns/bfvrns-leveledshe.h
@@ -98,7 +98,7 @@ public:
 
   template <class Archive>
   void load(Archive &ar, const std::uint32_t version) {
-    if (version > Serializable::SerializedVersion()) {
+    if (version > this->SerializedVersion()) {
         OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
             " is from a later version of the library");
     }

--- a/src/pke/include/scheme/bfvrns/bfvrns-multiparty.h
+++ b/src/pke/include/scheme/bfvrns/bfvrns-multiparty.h
@@ -57,7 +57,6 @@ public:
   template <class Archive>
   void load(Archive &ar, std::uint32_t const version) {}
 
-  std::string SerializedObjectName() const { return "MultipartyBFVRNS"; }
 };
 }  // namespace lbcrypto
 

--- a/src/pke/include/scheme/bfvrns/bfvrns-parametergeneration.h
+++ b/src/pke/include/scheme/bfvrns/bfvrns-parametergeneration.h
@@ -66,9 +66,6 @@ public:
   template <class Archive>
   void load(Archive &ar, std::uint32_t const version) {}
 
-  std::string SerializedObjectName() const {
-    return "ParameterGenerationBFVRNS";
-  }
 };
 
 }  // namespace lbcrypto

--- a/src/pke/include/scheme/bfvrns/bfvrns-pke.h
+++ b/src/pke/include/scheme/bfvrns/bfvrns-pke.h
@@ -122,7 +122,6 @@ public:
     ar(cereal::base_class<PKERNS>(this));
   }
 
-  std::string SerializedObjectName() const { return "PKEBFVRNS"; }
 };
 }  // namespace lbcrypto
 

--- a/src/pke/include/scheme/bfvrns/bfvrns-pke.h
+++ b/src/pke/include/scheme/bfvrns/bfvrns-pke.h
@@ -118,7 +118,11 @@ public:
   }
 
   template <class Archive>
-  void load(Archive &ar) {
+  void load(Archive &ar, const std::uint32_t version) {
+    if (version > Serializable::SerializedVersion()) {
+        OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
+            " is from a later version of the library");
+    }
     ar(cereal::base_class<PKERNS>(this));
   }
 

--- a/src/pke/include/scheme/bfvrns/bfvrns-pke.h
+++ b/src/pke/include/scheme/bfvrns/bfvrns-pke.h
@@ -119,7 +119,7 @@ public:
 
   template <class Archive>
   void load(Archive &ar, const std::uint32_t version) {
-    if (version > Serializable::SerializedVersion()) {
+    if (version > this->SerializedVersion()) {
         OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
             " is from a later version of the library");
     }

--- a/src/pke/include/scheme/bfvrns/bfvrns-pre.h
+++ b/src/pke/include/scheme/bfvrns/bfvrns-pre.h
@@ -58,7 +58,6 @@ public:
     ar(cereal::base_class<PRERNS>(this));
   }
 
-  std::string SerializedObjectName() const { return "PREBFVRNS"; }
 };
 }  // namespace lbcrypto
 

--- a/src/pke/include/scheme/bfvrns/bfvrns-pre.h
+++ b/src/pke/include/scheme/bfvrns/bfvrns-pre.h
@@ -55,7 +55,7 @@ public:
 
   template <class Archive>
   void load(Archive &ar, const std::uint32_t version) {
-    if (version > Serializable::SerializedVersion()) {
+    if (version > this->SerializedVersion()) {
         OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
             " is from a later version of the library");
     }

--- a/src/pke/include/scheme/bfvrns/bfvrns-pre.h
+++ b/src/pke/include/scheme/bfvrns/bfvrns-pre.h
@@ -54,7 +54,11 @@ public:
   }
 
   template <class Archive>
-  void load(Archive &ar) {
+  void load(Archive &ar, const std::uint32_t version) {
+    if (version > Serializable::SerializedVersion()) {
+        OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
+            " is from a later version of the library");
+    }
     ar(cereal::base_class<PRERNS>(this));
   }
 

--- a/src/pke/include/scheme/bfvrns/bfvrns-scheme.h
+++ b/src/pke/include/scheme/bfvrns/bfvrns-scheme.h
@@ -77,7 +77,6 @@ public:
     ar(cereal::base_class<SchemeRNS>(this));
   }
 
-  virtual std::string SerializedObjectName() const override { return "SchemeBFVRNS"; }
 };
 }  // namespace lbcrypto
 

--- a/src/pke/include/scheme/bfvrns/bfvrns-scheme.h
+++ b/src/pke/include/scheme/bfvrns/bfvrns-scheme.h
@@ -74,7 +74,7 @@ public:
 
   template <class Archive>
   void load(Archive &ar, std::uint32_t const version) {
-    if (version > Serializable::SerializedVersion()) {
+    if (version > this->SerializedVersion()) {
         OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
             " is from a later version of the library");
     }

--- a/src/pke/include/scheme/bfvrns/bfvrns-scheme.h
+++ b/src/pke/include/scheme/bfvrns/bfvrns-scheme.h
@@ -74,6 +74,10 @@ public:
 
   template <class Archive>
   void load(Archive &ar, std::uint32_t const version) {
+    if (version > Serializable::SerializedVersion()) {
+        OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
+            " is from a later version of the library");
+    }
     ar(cereal::base_class<SchemeRNS>(this));
   }
 

--- a/src/pke/include/scheme/bgvrns/bgvrns-advancedshe.h
+++ b/src/pke/include/scheme/bgvrns/bgvrns-advancedshe.h
@@ -59,7 +59,6 @@ public:
     ar(cereal::base_class<AdvancedSHERNS>(this));
   }
 
-  std::string SerializedObjectName() const { return "AdvancedSHEBGVRNS"; }
 };
 
 }  // namespace lbcrypto

--- a/src/pke/include/scheme/bgvrns/bgvrns-advancedshe.h
+++ b/src/pke/include/scheme/bgvrns/bgvrns-advancedshe.h
@@ -55,7 +55,11 @@ public:
   }
 
   template <class Archive>
-  void load(Archive &ar) {
+  void load(Archive &ar, const std::uint32_t version) {
+    if (version > Serializable::SerializedVersion()) {
+        OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
+            " is from a later version of the library");
+    }
     ar(cereal::base_class<AdvancedSHERNS>(this));
   }
 

--- a/src/pke/include/scheme/bgvrns/bgvrns-advancedshe.h
+++ b/src/pke/include/scheme/bgvrns/bgvrns-advancedshe.h
@@ -56,7 +56,7 @@ public:
 
   template <class Archive>
   void load(Archive &ar, const std::uint32_t version) {
-    if (version > Serializable::SerializedVersion()) {
+    if (version > this->SerializedVersion()) {
         OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
             " is from a later version of the library");
     }

--- a/src/pke/include/scheme/bgvrns/bgvrns-cryptoparameters.h
+++ b/src/pke/include/scheme/bgvrns/bgvrns-cryptoparameters.h
@@ -102,7 +102,7 @@ public:
 
   template <class Archive>
   void load(Archive& ar, std::uint32_t const version) {
-      if (version > Serializable::SerializedVersion()) {
+      if (version > this->SerializedVersion()) {
           std::string errMsg("serialized object version " + std::to_string(version) +
               " is from a later version of the library");
           OPENFHE_THROW(deserialize_error, errMsg);

--- a/src/pke/include/scheme/bgvrns/bgvrns-cryptoparameters.h
+++ b/src/pke/include/scheme/bgvrns/bgvrns-cryptoparameters.h
@@ -113,7 +113,6 @@ public:
           m_numPartQ, m_auxBits, m_extraBits);
   }
 
-  std::string SerializedObjectName() const override { return "CryptoParametersBGVRNS"; }
   static uint32_t SerializedVersion() { return 1; }
 };
 

--- a/src/pke/include/scheme/bgvrns/bgvrns-cryptoparameters.h
+++ b/src/pke/include/scheme/bgvrns/bgvrns-cryptoparameters.h
@@ -102,7 +102,7 @@ public:
 
   template <class Archive>
   void load(Archive& ar, std::uint32_t const version) {
-      if (version > SerializedVersion()) {
+      if (version > Serializable::SerializedVersion()) {
           std::string errMsg("serialized object version " + std::to_string(version) +
               " is from a later version of the library");
           OPENFHE_THROW(deserialize_error, errMsg);
@@ -113,7 +113,6 @@ public:
           m_numPartQ, m_auxBits, m_extraBits);
   }
 
-  static uint32_t SerializedVersion() { return 1; }
 };
 
 }  // namespace lbcrypto

--- a/src/pke/include/scheme/bgvrns/bgvrns-leveledshe.h
+++ b/src/pke/include/scheme/bgvrns/bgvrns-leveledshe.h
@@ -80,7 +80,11 @@ public:
   }
 
   template <class Archive>
-  void load(Archive &ar) {
+  void load(Archive &ar, const std::uint32_t version) {
+    if (version > Serializable::SerializedVersion()) {
+        OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
+            " is from a later version of the library");
+    }
     ar(cereal::base_class<LeveledSHERNS>(this));
   }
 

--- a/src/pke/include/scheme/bgvrns/bgvrns-leveledshe.h
+++ b/src/pke/include/scheme/bgvrns/bgvrns-leveledshe.h
@@ -84,7 +84,6 @@ public:
     ar(cereal::base_class<LeveledSHERNS>(this));
   }
 
-  std::string SerializedObjectName() const { return "LeveledSHEBGVRNS"; }
 };
 
 }  // namespace lbcrypto

--- a/src/pke/include/scheme/bgvrns/bgvrns-leveledshe.h
+++ b/src/pke/include/scheme/bgvrns/bgvrns-leveledshe.h
@@ -81,7 +81,7 @@ public:
 
   template <class Archive>
   void load(Archive &ar, const std::uint32_t version) {
-    if (version > Serializable::SerializedVersion()) {
+    if (version > this->SerializedVersion()) {
         OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
             " is from a later version of the library");
     }

--- a/src/pke/include/scheme/bgvrns/bgvrns-multiparty.h
+++ b/src/pke/include/scheme/bgvrns/bgvrns-multiparty.h
@@ -61,7 +61,6 @@ public:
   template <class Archive>
   void load(Archive &ar, std::uint32_t const version) {}
 
-  std::string SerializedObjectName() const { return "MultipartyBGVRNS"; }
 };
 }  // namespace lbcrypto
 

--- a/src/pke/include/scheme/bgvrns/bgvrns-parametergeneration.h
+++ b/src/pke/include/scheme/bgvrns/bgvrns-parametergeneration.h
@@ -123,9 +123,6 @@ public:
   template <class Archive>
   void load(Archive &ar, std::uint32_t const version) {}
 
-  std::string SerializedObjectName() const {
-    return "ParameterGenerationBGVRNS";
-  }
 };
 
 }  // namespace lbcrypto

--- a/src/pke/include/scheme/bgvrns/bgvrns-pke.h
+++ b/src/pke/include/scheme/bgvrns/bgvrns-pke.h
@@ -93,7 +93,6 @@ public:
     ar(cereal::base_class<PKERNS>(this));
   }
 
-  std::string SerializedObjectName() const { return "PKEBGVRNS"; }
 };
 }  // namespace lbcrypto
 

--- a/src/pke/include/scheme/bgvrns/bgvrns-pke.h
+++ b/src/pke/include/scheme/bgvrns/bgvrns-pke.h
@@ -89,7 +89,11 @@ public:
   }
 
   template <class Archive>
-  void load(Archive &ar) {
+  void load(Archive &ar, const std::uint32_t version) {
+    if (version > Serializable::SerializedVersion()) {
+        OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
+            " is from a later version of the library");
+    }
     ar(cereal::base_class<PKERNS>(this));
   }
 

--- a/src/pke/include/scheme/bgvrns/bgvrns-pke.h
+++ b/src/pke/include/scheme/bgvrns/bgvrns-pke.h
@@ -90,7 +90,7 @@ public:
 
   template <class Archive>
   void load(Archive &ar, const std::uint32_t version) {
-    if (version > Serializable::SerializedVersion()) {
+    if (version > this->SerializedVersion()) {
         OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
             " is from a later version of the library");
     }

--- a/src/pke/include/scheme/bgvrns/bgvrns-pre.h
+++ b/src/pke/include/scheme/bgvrns/bgvrns-pre.h
@@ -58,7 +58,6 @@ public:
     ar(cereal::base_class<PRERNS>(this));
   }
 
-  std::string SerializedObjectName() const { return "PREBGVRNS"; }
 };
 }  // namespace lbcrypto
 

--- a/src/pke/include/scheme/bgvrns/bgvrns-pre.h
+++ b/src/pke/include/scheme/bgvrns/bgvrns-pre.h
@@ -55,7 +55,7 @@ public:
 
   template <class Archive>
   void load(Archive &ar, const std::uint32_t version) {
-    if (version > Serializable::SerializedVersion()) {
+    if (version > this->SerializedVersion()) {
       OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
                     " is from a later version of the library");
     }

--- a/src/pke/include/scheme/bgvrns/bgvrns-pre.h
+++ b/src/pke/include/scheme/bgvrns/bgvrns-pre.h
@@ -54,7 +54,11 @@ public:
   }
 
   template <class Archive>
-  void load(Archive &ar) {
+  void load(Archive &ar, const std::uint32_t version) {
+    if (version > Serializable::SerializedVersion()) {
+      OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
+                    " is from a later version of the library");
+    }
     ar(cereal::base_class<PRERNS>(this));
   }
 

--- a/src/pke/include/scheme/bgvrns/bgvrns-scheme.h
+++ b/src/pke/include/scheme/bgvrns/bgvrns-scheme.h
@@ -78,7 +78,6 @@ public:
     ar(cereal::base_class<SchemeRNS>(this));
   }
 
-  virtual std::string SerializedObjectName() const override { return "SchemeBGVRNS"; }
 };
 }  // namespace lbcrypto
 

--- a/src/pke/include/scheme/bgvrns/bgvrns-scheme.h
+++ b/src/pke/include/scheme/bgvrns/bgvrns-scheme.h
@@ -75,7 +75,7 @@ public:
 
   template <class Archive>
   void load(Archive &ar, std::uint32_t const version) {
-    if (version > Serializable::SerializedVersion()) {
+    if (version > this->SerializedVersion()) {
         OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
             " is from a later version of the library");
     }

--- a/src/pke/include/scheme/bgvrns/bgvrns-scheme.h
+++ b/src/pke/include/scheme/bgvrns/bgvrns-scheme.h
@@ -75,6 +75,10 @@ public:
 
   template <class Archive>
   void load(Archive &ar, std::uint32_t const version) {
+    if (version > Serializable::SerializedVersion()) {
+        OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
+            " is from a later version of the library");
+    }
     ar(cereal::base_class<SchemeRNS>(this));
   }
 

--- a/src/pke/include/scheme/ckksrns/ckksrns-advancedshe.h
+++ b/src/pke/include/scheme/ckksrns/ckksrns-advancedshe.h
@@ -69,7 +69,6 @@ public:
     ar(cereal::base_class<AdvancedSHERNS>(this));
   }
 
-  std::string SerializedObjectName() const { return "AdvancedSHECKKSRNS"; }
 };
 
 }  // namespace lbcrypto

--- a/src/pke/include/scheme/ckksrns/ckksrns-advancedshe.h
+++ b/src/pke/include/scheme/ckksrns/ckksrns-advancedshe.h
@@ -65,7 +65,11 @@ public:
   }
 
   template <class Archive>
-  void load(Archive &ar) {
+  void load(Archive &ar, const std::uint32_t version) {
+    if (version > Serializable::SerializedVersion()) {
+        OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
+            " is from a later version of the library");
+    }
     ar(cereal::base_class<AdvancedSHERNS>(this));
   }
 

--- a/src/pke/include/scheme/ckksrns/ckksrns-advancedshe.h
+++ b/src/pke/include/scheme/ckksrns/ckksrns-advancedshe.h
@@ -66,7 +66,7 @@ public:
 
   template <class Archive>
   void load(Archive &ar, const std::uint32_t version) {
-    if (version > Serializable::SerializedVersion()) {
+    if (version > this->SerializedVersion()) {
         OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
             " is from a later version of the library");
     }

--- a/src/pke/include/scheme/ckksrns/ckksrns-cryptoparameters.h
+++ b/src/pke/include/scheme/ckksrns/ckksrns-cryptoparameters.h
@@ -102,7 +102,7 @@ public:
 
   template <class Archive>
   void load(Archive& ar, std::uint32_t const version) {
-      if (version > Serializable::SerializedVersion()) {
+      if (version > this->SerializedVersion()) {
           std::string errMsg("serialized object version " + std::to_string(version) +
               " is from a later version of the library");
           OPENFHE_THROW(deserialize_error, errMsg);

--- a/src/pke/include/scheme/ckksrns/ckksrns-cryptoparameters.h
+++ b/src/pke/include/scheme/ckksrns/ckksrns-cryptoparameters.h
@@ -113,7 +113,6 @@ public:
           m_numPartQ, m_auxBits, m_extraBits);
   }
 
-  std::string SerializedObjectName() const override { return "CryptoParametersCKKSRNS"; }
   static uint32_t SerializedVersion() { return 1; }
 };
 

--- a/src/pke/include/scheme/ckksrns/ckksrns-cryptoparameters.h
+++ b/src/pke/include/scheme/ckksrns/ckksrns-cryptoparameters.h
@@ -102,7 +102,7 @@ public:
 
   template <class Archive>
   void load(Archive& ar, std::uint32_t const version) {
-      if (version > SerializedVersion()) {
+      if (version > Serializable::SerializedVersion()) {
           std::string errMsg("serialized object version " + std::to_string(version) +
               " is from a later version of the library");
           OPENFHE_THROW(deserialize_error, errMsg);
@@ -113,7 +113,6 @@ public:
           m_numPartQ, m_auxBits, m_extraBits);
   }
 
-  static uint32_t SerializedVersion() { return 1; }
 };
 
 }  // namespace lbcrypto

--- a/src/pke/include/scheme/ckksrns/ckksrns-leveledshe.h
+++ b/src/pke/include/scheme/ckksrns/ckksrns-leveledshe.h
@@ -175,7 +175,11 @@ public:
   }
 
   template <class Archive>
-  void load(Archive &ar) {
+  void load(Archive &ar, const std::uint32_t version) {
+    if (version > Serializable::SerializedVersion()) {
+        OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
+            " is from a later version of the library");
+    }
     ar(cereal::base_class<LeveledSHERNS>(this));
   }
 

--- a/src/pke/include/scheme/ckksrns/ckksrns-leveledshe.h
+++ b/src/pke/include/scheme/ckksrns/ckksrns-leveledshe.h
@@ -176,7 +176,7 @@ public:
 
   template <class Archive>
   void load(Archive &ar, const std::uint32_t version) {
-    if (version > Serializable::SerializedVersion()) {
+    if (version > this->SerializedVersion()) {
         OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
             " is from a later version of the library");
     }

--- a/src/pke/include/scheme/ckksrns/ckksrns-leveledshe.h
+++ b/src/pke/include/scheme/ckksrns/ckksrns-leveledshe.h
@@ -179,7 +179,6 @@ public:
     ar(cereal::base_class<LeveledSHERNS>(this));
   }
 
-  std::string SerializedObjectName() const { return "LeveledSHECKKSRNS"; }
 };
 
 }  // namespace lbcrypto

--- a/src/pke/include/scheme/ckksrns/ckksrns-multiparty.h
+++ b/src/pke/include/scheme/ckksrns/ckksrns-multiparty.h
@@ -62,7 +62,6 @@ public:
   template <class Archive>
   void load(Archive &ar, std::uint32_t const version) {}
 
-  std::string SerializedObjectName() const { return "MultipartyCKKSRNS"; }
 };
 
 }  // namespace lbcrypto

--- a/src/pke/include/scheme/ckksrns/ckksrns-parametergeneration.h
+++ b/src/pke/include/scheme/ckksrns/ckksrns-parametergeneration.h
@@ -67,9 +67,6 @@ public:
   template <class Archive>
   void load(Archive &ar, std::uint32_t const version) {}
 
-  std::string SerializedObjectName() const {
-    return "ParameterGenerationCKKSRNS";
-  }
 };
 
 }  // namespace lbcrypto

--- a/src/pke/include/scheme/ckksrns/ckksrns-pke.h
+++ b/src/pke/include/scheme/ckksrns/ckksrns-pke.h
@@ -65,7 +65,6 @@ public:
     ar(cereal::base_class<PKERNS>(this));
   }
 
-  std::string SerializedObjectName() const { return "PKECKKSRNS"; }
 };
 
 }  // namespace lbcrypto

--- a/src/pke/include/scheme/ckksrns/ckksrns-pke.h
+++ b/src/pke/include/scheme/ckksrns/ckksrns-pke.h
@@ -62,7 +62,7 @@ public:
 
   template <class Archive>
   void load(Archive &ar, const std::uint32_t version) {
-    if (version > Serializable::SerializedVersion()) {
+    if (version > this->SerializedVersion()) {
         OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
             " is from a later version of the library");
     }

--- a/src/pke/include/scheme/ckksrns/ckksrns-pke.h
+++ b/src/pke/include/scheme/ckksrns/ckksrns-pke.h
@@ -61,7 +61,11 @@ public:
   }
 
   template <class Archive>
-  void load(Archive &ar) {
+  void load(Archive &ar, const std::uint32_t version) {
+    if (version > Serializable::SerializedVersion()) {
+        OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
+            " is from a later version of the library");
+    }
     ar(cereal::base_class<PKERNS>(this));
   }
 

--- a/src/pke/include/scheme/ckksrns/ckksrns-pre.h
+++ b/src/pke/include/scheme/ckksrns/ckksrns-pre.h
@@ -60,7 +60,6 @@ public:
     ar(cereal::base_class<PRERNS>(this));
   }
 
-  std::string SerializedObjectName() const { return "PRECKKSRNS"; }
 };
 
 }  // namespace lbcrypto

--- a/src/pke/include/scheme/ckksrns/ckksrns-pre.h
+++ b/src/pke/include/scheme/ckksrns/ckksrns-pre.h
@@ -56,7 +56,11 @@ public:
   }
 
   template <class Archive>
-  void load(Archive &ar) {
+  void load(Archive &ar, const std::uint32_t version) {
+    if (version > Serializable::SerializedVersion()) {
+        OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
+            " is from a later version of the library");
+    }
     ar(cereal::base_class<PRERNS>(this));
   }
 

--- a/src/pke/include/scheme/ckksrns/ckksrns-pre.h
+++ b/src/pke/include/scheme/ckksrns/ckksrns-pre.h
@@ -57,7 +57,7 @@ public:
 
   template <class Archive>
   void load(Archive &ar, const std::uint32_t version) {
-    if (version > Serializable::SerializedVersion()) {
+    if (version > this->SerializedVersion()) {
         OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
             " is from a later version of the library");
     }

--- a/src/pke/include/scheme/ckksrns/ckksrns-scheme.h
+++ b/src/pke/include/scheme/ckksrns/ckksrns-scheme.h
@@ -80,7 +80,6 @@ public:
     ar(cereal::base_class<SchemeRNS>(this));
   }
 
-  virtual std::string SerializedObjectName() const override { return "SchemeCKKSRNS"; }
 };
 
 }  // namespace lbcrypto

--- a/src/pke/include/scheme/ckksrns/ckksrns-scheme.h
+++ b/src/pke/include/scheme/ckksrns/ckksrns-scheme.h
@@ -77,6 +77,10 @@ public:
 
   template <class Archive>
   void load(Archive &ar, std::uint32_t const version) {
+    if (version > Serializable::SerializedVersion()) {
+        OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
+            " is from a later version of the library");
+    }
     ar(cereal::base_class<SchemeRNS>(this));
   }
 

--- a/src/pke/include/scheme/ckksrns/ckksrns-scheme.h
+++ b/src/pke/include/scheme/ckksrns/ckksrns-scheme.h
@@ -77,7 +77,7 @@ public:
 
   template <class Archive>
   void load(Archive &ar, std::uint32_t const version) {
-    if (version > Serializable::SerializedVersion()) {
+    if (version > this->SerializedVersion()) {
         OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
             " is from a later version of the library");
     }

--- a/src/pke/include/schemebase/base-cryptoparameters.h
+++ b/src/pke/include/schemebase/base-cryptoparameters.h
@@ -160,7 +160,6 @@ class CryptoParametersBase : public Serializable {
     ar(::cereal::make_nvp("enp", m_encodingParams));
   }
 
-  std::string SerializedObjectName() const { return "CryptoParametersBase"; }
   static uint32_t SerializedVersion() { return 1; }
 
  protected:

--- a/src/pke/include/schemebase/base-cryptoparameters.h
+++ b/src/pke/include/schemebase/base-cryptoparameters.h
@@ -151,7 +151,7 @@ class CryptoParametersBase : public Serializable {
 
   template <class Archive>
   void load(Archive &ar, std::uint32_t const version) {
-    if (version > Serializable::SerializedVersion()) {
+    if (version > this->SerializedVersion()) {
       OPENFHE_THROW(deserialize_error,
                      "serialized object version " + std::to_string(version) +
                          " is from a later version of the library");

--- a/src/pke/include/schemebase/base-cryptoparameters.h
+++ b/src/pke/include/schemebase/base-cryptoparameters.h
@@ -151,7 +151,7 @@ class CryptoParametersBase : public Serializable {
 
   template <class Archive>
   void load(Archive &ar, std::uint32_t const version) {
-    if (version > SerializedVersion()) {
+    if (version > Serializable::SerializedVersion()) {
       OPENFHE_THROW(deserialize_error,
                      "serialized object version " + std::to_string(version) +
                          " is from a later version of the library");
@@ -159,8 +159,6 @@ class CryptoParametersBase : public Serializable {
     ar(::cereal::make_nvp("elp", m_params));
     ar(::cereal::make_nvp("enp", m_encodingParams));
   }
-
-  static uint32_t SerializedVersion() { return 1; }
 
  protected:
   explicit CryptoParametersBase(const PlaintextModulus &plaintextModulus) {

--- a/src/pke/include/schemebase/base-multiparty.h
+++ b/src/pke/include/schemebase/base-multiparty.h
@@ -300,7 +300,6 @@ class MultipartyBase {
   template <class Archive>
   void load(Archive &ar, std::uint32_t const version) {}
 
-  std::string SerializedObjectName() const { return "MultiPartyBase"; }
 };
 
 }  // namespace lbcrypto

--- a/src/pke/include/schemebase/base-parametergeneration.h
+++ b/src/pke/include/schemebase/base-parametergeneration.h
@@ -166,7 +166,6 @@ public:
   template <class Archive>
   void load(Archive &ar, std::uint32_t const version) {}
 
-  std::string SerializedObjectName() const { return "ParameterGenerationBase"; }
 };
 
 }  // namespace lbcrypto

--- a/src/pke/include/schemebase/base-scheme.h
+++ b/src/pke/include/schemebase/base-scheme.h
@@ -33,6 +33,7 @@
 #define LBCRYPTO_CRYPTO_BASE_SCHEME_H
 
 #include "utils/caller_info.h"
+#include "utils/serializable.h"
 
 #include "key/allkey.h"
 
@@ -60,7 +61,7 @@ namespace lbcrypto {
  * @tparam Element a ring element.
  */
 template <typename Element>
-class SchemeBase {
+class SchemeBase : public Serializable {
   using ParmType = typename Element::Params;
   using IntType = typename Element::Integer;
   using DugType = typename Element::DugType;
@@ -1815,10 +1816,9 @@ class SchemeBase {
 
   template <class Archive>
   void load(Archive &ar, std::uint32_t const version) {
-    if (version > SerializedVersion()) {
-      OPENFHE_THROW(deserialize_error,
-                     "serialized object version " + std::to_string(version) +
-                         " is from a later version of the library");
+    if (version > Serializable::SerializedVersion()) {
+      OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
+                    " is from a later version of the library");
     }
 
     usint enabled;
@@ -1826,9 +1826,7 @@ class SchemeBase {
     this->Enable(enabled);
   }
 
-  static uint32_t SerializedVersion() { return 1; }
-
-  friend std::ostream &operator<<(std::ostream &out,
+      friend std::ostream &operator<<(std::ostream &out,
                                   const SchemeBase<Element> &s) {
     out << typeid(s).name() << ":";
     out << " ParamsGen "

--- a/src/pke/include/schemebase/base-scheme.h
+++ b/src/pke/include/schemebase/base-scheme.h
@@ -1826,8 +1826,6 @@ class SchemeBase {
     this->Enable(enabled);
   }
 
-  virtual std::string SerializedObjectName() const { return "SchemeBase"; }
-
   static uint32_t SerializedVersion() { return 1; }
 
   friend std::ostream &operator<<(std::ostream &out,

--- a/src/pke/include/schemebase/base-scheme.h
+++ b/src/pke/include/schemebase/base-scheme.h
@@ -1816,7 +1816,7 @@ class SchemeBase : public Serializable {
 
   template <class Archive>
   void load(Archive &ar, std::uint32_t const version) {
-    if (version > Serializable::SerializedVersion()) {
+    if (version > this->SerializedVersion()) {
       OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
                     " is from a later version of the library");
     }

--- a/src/pke/include/schemebase/rlwe-cryptoparameters.h
+++ b/src/pke/include/schemebase/rlwe-cryptoparameters.h
@@ -351,8 +351,6 @@ class CryptoParametersRLWE : public CryptoParametersBase<Element> {
     ar(::cereal::make_nvp("slv", m_stdLevel));
   }
 
-  std::string SerializedObjectName() const { return "CryptoParametersRLWE"; }
-
  protected:
   // standard deviation in Discrete Gaussian Distribution
   float m_distributionParameter;

--- a/src/pke/include/schemebase/rlwe-cryptoparameters.h
+++ b/src/pke/include/schemebase/rlwe-cryptoparameters.h
@@ -338,7 +338,7 @@ class CryptoParametersRLWE : public CryptoParametersBase<Element> {
 
   template <class Archive>
   void load(Archive &ar, std::uint32_t const version) {
-    if (version > Serializable::SerializedVersion()) {
+    if (version > this->SerializedVersion()) {
         OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
             " is from a later version of the library");
     }

--- a/src/pke/include/schemebase/rlwe-cryptoparameters.h
+++ b/src/pke/include/schemebase/rlwe-cryptoparameters.h
@@ -42,7 +42,6 @@
 #include "lattice/lat-hal.h"
 #include "schemebase/base-cryptoparameters.h"
 #include "constants.h"
-#include "utils/serializable.h"
 
 // TODO - temp include for the SecurityLevel
 #include "lattice/stdlatticeparms.h"
@@ -339,6 +338,10 @@ class CryptoParametersRLWE : public CryptoParametersBase<Element> {
 
   template <class Archive>
   void load(Archive &ar, std::uint32_t const version) {
+    if (version > Serializable::SerializedVersion()) {
+        OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
+            " is from a later version of the library");
+    }
     ar(::cereal::base_class<CryptoParametersBase<Element>>(this));
     ar(::cereal::make_nvp("dp", m_distributionParameter));
     m_dgg.SetStd(m_distributionParameter);

--- a/src/pke/include/schemerns/rns-advancedshe.h
+++ b/src/pke/include/schemerns/rns-advancedshe.h
@@ -64,7 +64,6 @@ class AdvancedSHERNS : public AdvancedSHEBase<DCRTPoly> {
     ar(cereal::base_class<AdvancedSHEBase<DCRTPoly>>(this));
   }
 
-  std::string SerializedObjectName() const { return "AdvancedSHERNS"; }
 };
 
 }  // namespace lbcrypto

--- a/src/pke/include/schemerns/rns-advancedshe.h
+++ b/src/pke/include/schemerns/rns-advancedshe.h
@@ -62,7 +62,7 @@ class AdvancedSHERNS : public AdvancedSHEBase<DCRTPoly>, public Serializable {
 
   template <class Archive>
   void load(Archive &ar, const std::uint32_t version) {
-    if (version > Serializable::SerializedVersion()) {
+    if (version > this->SerializedVersion()) {
         OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
             " is from a later version of the library");
     }

--- a/src/pke/include/schemerns/rns-advancedshe.h
+++ b/src/pke/include/schemerns/rns-advancedshe.h
@@ -35,6 +35,7 @@
 #include "lattice/lat-hal.h"
 
 #include "schemebase/base-advancedshe.h"
+#include "utils/serializable.h"
 
 /**
  * @namespace lbcrypto
@@ -46,7 +47,7 @@ namespace lbcrypto {
  * @brief Abstract base class for derived HE algorithms
  * @tparam Element a ring element.
  */
-class AdvancedSHERNS : public AdvancedSHEBase<DCRTPoly> {
+class AdvancedSHERNS : public AdvancedSHEBase<DCRTPoly>, public Serializable {
  public:
   virtual ~AdvancedSHERNS() {}
 
@@ -60,7 +61,11 @@ class AdvancedSHERNS : public AdvancedSHEBase<DCRTPoly> {
   }
 
   template <class Archive>
-  void load(Archive &ar) {
+  void load(Archive &ar, const std::uint32_t version) {
+    if (version > Serializable::SerializedVersion()) {
+        OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
+            " is from a later version of the library");
+    }
     ar(cereal::base_class<AdvancedSHEBase<DCRTPoly>>(this));
   }
 

--- a/src/pke/include/schemerns/rns-cryptoparameters.h
+++ b/src/pke/include/schemerns/rns-cryptoparameters.h
@@ -1626,7 +1626,7 @@ public:
 
   template <class Archive>
   void load(Archive& ar, std::uint32_t const version) {
-      if (version > SerializedVersion()) {
+      if (version > Serializable::SerializedVersion()) {
           std::string errMsg("serialized object version " + std::to_string(version) +
               " is from a later version of the library");
           OPENFHE_THROW(deserialize_error, errMsg);
@@ -1641,7 +1641,6 @@ public:
       ar(cereal::make_nvp("eb", m_extraBits));
   }
 
-  static uint32_t SerializedVersion() { return 1; }
 };
 
 }  // namespace lbcrypto

--- a/src/pke/include/schemerns/rns-cryptoparameters.h
+++ b/src/pke/include/schemerns/rns-cryptoparameters.h
@@ -1626,7 +1626,7 @@ public:
 
   template <class Archive>
   void load(Archive& ar, std::uint32_t const version) {
-      if (version > Serializable::SerializedVersion()) {
+      if (version > this->SerializedVersion()) {
           std::string errMsg("serialized object version " + std::to_string(version) +
               " is from a later version of the library");
           OPENFHE_THROW(deserialize_error, errMsg);

--- a/src/pke/include/schemerns/rns-cryptoparameters.h
+++ b/src/pke/include/schemerns/rns-cryptoparameters.h
@@ -1641,7 +1641,6 @@ public:
       ar(cereal::make_nvp("eb", m_extraBits));
   }
 
-  virtual std::string SerializedObjectName() const override { return "SchemeParametersRNS"; }
   static uint32_t SerializedVersion() { return 1; }
 };
 

--- a/src/pke/include/schemerns/rns-leveledshe.h
+++ b/src/pke/include/schemerns/rns-leveledshe.h
@@ -384,7 +384,7 @@ class LeveledSHERNS : public LeveledSHEBase<DCRTPoly>, public Serializable {
 
   template <class Archive>
   void load(Archive &ar, const std::uint32_t version) {
-    if (version > Serializable::SerializedVersion()) {
+    if (version > this->SerializedVersion()) {
         OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
             " is from a later version of the library");
     }

--- a/src/pke/include/schemerns/rns-leveledshe.h
+++ b/src/pke/include/schemerns/rns-leveledshe.h
@@ -386,7 +386,6 @@ class LeveledSHERNS : public LeveledSHEBase<DCRTPoly> {
     ar(cereal::base_class<LeveledSHEBase<DCRTPoly>>(this));
   }
 
-  std::string SerializedObjectName() const { return "LeveledSHERNS"; }
 };
 
 }  // namespace lbcrypto

--- a/src/pke/include/schemerns/rns-leveledshe.h
+++ b/src/pke/include/schemerns/rns-leveledshe.h
@@ -35,6 +35,7 @@
 #include "lattice/lat-hal.h"
 
 #include "schemebase/base-leveledshe.h"
+#include "utils/serializable.h"
 
 /**
  * @namespace lbcrypto
@@ -46,7 +47,7 @@ namespace lbcrypto {
  * @brief Abstract interface class for LBC SHE algorithms
  * @tparam Element a ring element.
  */
-class LeveledSHERNS : public LeveledSHEBase<DCRTPoly> {
+class LeveledSHERNS : public LeveledSHEBase<DCRTPoly>, public Serializable {
  public:
   virtual ~LeveledSHERNS() {}
 
@@ -382,7 +383,11 @@ class LeveledSHERNS : public LeveledSHEBase<DCRTPoly> {
   }
 
   template <class Archive>
-  void load(Archive &ar) {
+  void load(Archive &ar, const std::uint32_t version) {
+    if (version > Serializable::SerializedVersion()) {
+        OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
+            " is from a later version of the library");
+    }
     ar(cereal::base_class<LeveledSHEBase<DCRTPoly>>(this));
   }
 

--- a/src/pke/include/schemerns/rns-multiparty.h
+++ b/src/pke/include/schemerns/rns-multiparty.h
@@ -99,7 +99,6 @@ public:
   template <class Archive>
   void load(Archive &ar, std::uint32_t const version) {}
 
-  std::string SerializedObjectName() const { return "MultipartyRNS"; }
 };
 
 }  // namespace lbcrypto

--- a/src/pke/include/schemerns/rns-parametergeneration.h
+++ b/src/pke/include/schemerns/rns-parametergeneration.h
@@ -160,8 +160,6 @@ class ParameterGenerationRNS : public ParameterGenerationBase<DCRTPoly> {
   template <class Archive>
   void load(Archive &ar, std::uint32_t const version) {}
 
-  std::string SerializedObjectName() const { return "ParameterGenerationRNS"; }
-
   protected:
     enum DCRT_MODULUS {
       DEFAULT_EXTRA_MOD_SIZE = 20,

--- a/src/pke/include/schemerns/rns-pke.h
+++ b/src/pke/include/schemerns/rns-pke.h
@@ -137,7 +137,6 @@ class PKERNS : public PKEBase<DCRTPoly> {
     ar(cereal::base_class<PKEBase<DCRTPoly>>(this));
   }
 
-  std::string SerializedObjectName() const { return "PKERNS"; }
 };
 
 }  // namespace lbcrypto

--- a/src/pke/include/schemerns/rns-pke.h
+++ b/src/pke/include/schemerns/rns-pke.h
@@ -135,7 +135,7 @@ class PKERNS : public PKEBase<DCRTPoly>, public Serializable {
 
   template <class Archive>
   void load(Archive &ar, const std::uint32_t version) {
-    if (version > Serializable::SerializedVersion()) {
+    if (version > this->SerializedVersion()) {
         OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
             " is from a later version of the library");
     }

--- a/src/pke/include/schemerns/rns-pke.h
+++ b/src/pke/include/schemerns/rns-pke.h
@@ -35,6 +35,7 @@
 #include "lattice/lat-hal.h"
 
 #include "schemebase/base-pke.h"
+#include "utils/serializable.h"
 
 /**
  * @namespace lbcrypto
@@ -46,7 +47,7 @@ namespace lbcrypto {
  * @brief Abstract interface for encryption algorithm
  * @tparam Element a ring element.
  */
-class PKERNS : public PKEBase<DCRTPoly> {
+class PKERNS : public PKEBase<DCRTPoly>, public Serializable {
   using ParmType = typename DCRTPoly::Params;
   using IntType = typename DCRTPoly::Integer;
   using DugType = typename DCRTPoly::DugType;
@@ -133,7 +134,11 @@ class PKERNS : public PKEBase<DCRTPoly> {
   }
 
   template <class Archive>
-  void load(Archive &ar) {
+  void load(Archive &ar, const std::uint32_t version) {
+    if (version > Serializable::SerializedVersion()) {
+        OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
+            " is from a later version of the library");
+    }
     ar(cereal::base_class<PKEBase<DCRTPoly>>(this));
   }
 

--- a/src/pke/include/schemerns/rns-pre.h
+++ b/src/pke/include/schemerns/rns-pre.h
@@ -70,7 +70,6 @@ public:
     ar(cereal::base_class<PREBase<DCRTPoly>>(this));
   }
 
-  std::string SerializedObjectName() const { return "PRERNS"; }
 };
 
 } // namespace lbcrypto

--- a/src/pke/include/schemerns/rns-pre.h
+++ b/src/pke/include/schemerns/rns-pre.h
@@ -35,6 +35,7 @@
 #include "lattice/lat-hal.h"
 
 #include "schemebase/base-pre.h"
+#include "utils/serializable.h"
 
 /**
  * @namespace lbcrypto
@@ -46,7 +47,7 @@ namespace lbcrypto {
  * @brief Abstract interface class for LBC PRE algorithms
  * @tparam Element a ring element.
  */
-class PRERNS : public PREBase<DCRTPoly> {
+class PRERNS : public PREBase<DCRTPoly>, public Serializable {
   using ParmType = typename DCRTPoly::Params;
   using IntType = typename DCRTPoly::Integer;
   using DugType = typename DCRTPoly::DugType;
@@ -66,7 +67,11 @@ public:
   }
 
   template <class Archive>
-  void load(Archive &ar) {
+  void load(Archive &ar, const std::uint32_t version) {
+    if (version > Serializable::SerializedVersion()) {
+        OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
+            " is from a later version of the library");
+    }
     ar(cereal::base_class<PREBase<DCRTPoly>>(this));
   }
 

--- a/src/pke/include/schemerns/rns-pre.h
+++ b/src/pke/include/schemerns/rns-pre.h
@@ -68,7 +68,7 @@ public:
 
   template <class Archive>
   void load(Archive &ar, const std::uint32_t version) {
-    if (version > Serializable::SerializedVersion()) {
+    if (version > this->SerializedVersion()) {
         OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
             " is from a later version of the library");
     }

--- a/src/pke/include/schemerns/rns-scheme.h
+++ b/src/pke/include/schemerns/rns-scheme.h
@@ -90,7 +90,6 @@ public:
     ar(cereal::base_class<SchemeBase<DCRTPoly>>(this));
   }
 
-  virtual std::string SerializedObjectName() const override { return "SchemeRNS"; }
 };
 
 }  // namespace lbcrypto

--- a/src/pke/include/schemerns/rns-scheme.h
+++ b/src/pke/include/schemerns/rns-scheme.h
@@ -87,7 +87,7 @@ public:
 
   template <class Archive>
   void load(Archive &ar, std::uint32_t const version) {
-    if (version > Serializable::SerializedVersion()) {
+    if (version > this->SerializedVersion()) {
         OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
             " is from a later version of the library");
     }

--- a/src/pke/include/schemerns/rns-scheme.h
+++ b/src/pke/include/schemerns/rns-scheme.h
@@ -87,6 +87,11 @@ public:
 
   template <class Archive>
   void load(Archive &ar, std::uint32_t const version) {
+    if (version > Serializable::SerializedVersion()) {
+        OPENFHE_THROW(deserialize_error, "serialized object version " + std::to_string(version) +
+            " is from a later version of the library");
+    }
+
     ar(cereal::base_class<SchemeBase<DCRTPoly>>(this));
   }
 


### PR DESCRIPTION
In the class Serializable
- implement virtual SerializedObjectName() to return the correct type name of any object derived from Serializable and remove all other implementations of SerializedObjectName().
- implement static SerializedVersion() and remove all other implementations of SerializedVersion()
Make sure that
- all classes having save() and load() implemented are derived from Serializable
- the version number is checked in every load() function (as some classes miss a. or b. or both of them)