### PR TITLE
Add issue template, PR template, and various QOL things

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,101 @@
+name: OpenFHE Code Bug Report
+description: Use this template to report any issues in the code
+title: "[Bug In Code]: "
+labels: [ "code-bug", "triage" ]
+body:
+  - type: dropdown
+    id: issue-type
+    attributes:
+      label: Issue Type
+      description: What type of issue would you like to report?
+      multiple: false
+      options:
+        - Bug
+        - Build/Install
+        - Performance
+        - Others
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: |
+        Please make sure that this is a bug in the OpenFHE code. All help requests should be directed to [OpenFHE Discourse](https://openfhe.discourse.group/c/user-questions/17)
+
+  - type: input
+    id: version
+    attributes:
+      label: OpenFHE Version
+      description: What version of OpenFHE was installed? This information can be found in the `CMakeLists.txt` file.
+      placeholder: ex,. OpenFHE `Major.Minor.Patch`.
+    validations:
+      required: true
+
+
+  - type: dropdown
+    id: support
+    attributes:
+      label: Is this an official OpenFHE product?
+      options:
+        - "Yes"
+        - "No"
+
+
+  - type: input
+    id: OS
+    attributes:
+      label: OS Platform and Distribution
+      description: Please list your OS and distribution
+      placeholder: e.g., Linux Ubuntu 16.04
+    validations:
+      required: true
+
+  - type: input
+    id: compiler
+    attributes:
+      label: Compiler and Version
+      description: Please list your compiler and the version number
+      placeholder: e.g., gcc-12
+    validations:
+      required: false
+
+  - type: textarea
+    id: build-information
+    attributes:
+      label: CMake Output
+      description: Copy-paste the output of a fresh `CMake` run
+    validations:
+      required: false
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: Current Behavior
+      description: Also tell us, what did you expect to happen?
+      placeholder: Tell us what you see!
+    validations:
+      required: true
+
+  - type: textarea
+    id: code-to-reproduce
+    attributes:
+      label: Standalone Code To Reproduce the Issue
+      description: Provide a reproducible test case that is the bare minimum necessary to generate the problem. If necessary please share a link to a separate github repo which we can use to reproduce the error.
+      placeholder: Format any code with backticks
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant Log Output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell
+
+
+
+  - type: textarea
+    id: misc_info
+    attributes:
+      label: Relevant Misc. Information
+      description: Please add any other relevant information. This will be automatically formatted into code, so no need for backticks.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     url: https://openfhe.discourse.group/c/user-questions/17
     about: Please ask for help regarding code here.
   - name: OpenFHE Security Reports
-    url: contact@openfhe.org
+    url:  https://github.com/openfheorg/openfhe-development#links-and-resources
     about: Please report security vulnerabilities here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false  # Whether we should allow them to use a non-template issue
+contact_links:
+  - name: OpenFHE Support and Questions
+    url: https://openfhe.discourse.group/c/user-questions/17
+    about: Please ask for help regarding code here.
+  - name: OpenFHE Security Reports
+    url: contact@openfhe.org
+    about: Please report security vulnerabilities here.

--- a/.github/ISSUE_TEMPLATE/doc_report.yml
+++ b/.github/ISSUE_TEMPLATE/doc_report.yml
@@ -1,0 +1,36 @@
+name: OpenFHE Documentation Report
+description: Use this template to any issues with the documentation
+title: "[Bug In Documentation]: "
+labels: [ "documentation-bug", "triage" ]
+body:
+  - type: dropdown
+    id: issue-type
+    attributes:
+      label: Issue Type
+      description: What type of issue would you like to report?
+      multiple: false
+      options:
+        - Documentation Feature Request
+        - Bug in Documentation
+        - Incorrect Documentation
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: |
+        Please make sure that pertains only to documentation. All help requests should be directed to [OpenFHE Discourse](https://openfhe.discourse.group/c/user-questions/17)
+
+  - type: textarea
+    id: doc-error
+    attributes:
+      label: The erroneous documentation
+      description: Provide the URL to the documentation and briefly state why the existing documentation is incorrect
+      placeholder: Tell us what you see!
+    validations:
+      required: true
+
+  - type: textarea
+    id: fix
+    attributes:
+      label: URL to PR
+      description: Please paste the URL to a PR fix if relevant

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,47 @@
+name: Feature Request
+description: Request a feature
+title: "[Feature Request]: "
+labels: [ "feature-request", "triage" ]
+body:
+  - type: textarea
+    id: featuredescription
+    attributes:
+      label: Feature Description
+      description: Briefly describe the feature below
+      placeholder: "OpenFHE should have feature X"
+    validations:
+      required: true
+
+
+  - type: textarea
+    id: reasoning
+    attributes:
+      label: Briefly Describe Why This Feature Is Important
+      placeholder: "This feature is useful because of X"
+
+
+  - type: dropdown
+    id: will-you-do-it
+    attributes:
+      label: Are You Willing to Implement This Feature?
+      options:
+        - "Yes"
+        - "No"
+    validations:
+      required: true
+
+
+  - type: textarea
+    id: url
+    attributes:
+      label: Pull Request URL
+      placeholder: Please Paste The Pull Request URL(if applicable)
+
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/openfheorg/openfhe-development#code-of-conduct)
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+# Description
+
+Please include a summary of the change and which issue is fixed.
+
+Fixes # (issue)
+
+**Note** In your contribution, you are expected to include the type of PR this is in the title. See [labeler](labeler.yml) for various examples. Common tags include:
+
+- `fix: fixes bug in X`
+
+- `docs: fixes incorrectly documented Y`
+
+# How Has This Been Tested?
+
+< Tests >
+
+# Checklist:
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] Any dependent changes have been merged and published in downstream modules

--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,3 @@
+# Pull Request Templates
+
+Based on [Vantage AI: How to enforce good Pull Requests on Github](https://www.vantage-ai.com/blog/how-to-enforce-good-pull-requests-on-github)

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,5 +1,5 @@
 # Adds a label depending on the files/ directories that were changed. Makes it easier for us to determine
-# who should be looking at it
+# who should be looking at it.
 
 ci/cd:
   - .github/workflows/*

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,29 @@
+# Adds a label depending on the files/ directories that were changed. Makes it easier for us to determine
+# who should be looking at it
+
+ci/cd:
+  - .github/workflows/*
+  - ./cicd/*
+
+documentation:
+  - README.md
+  - ./*.md
+  - ./docs/*
+
+benchmark:
+  - ./benchmark/*
+
+docker:
+  - ./docker/*
+
+binfhe:
+  - ./src/binfhe/*
+
+core:
+  - ./src/core/*
+
+pke:
+  - ./src/pke/*
+
+tests:
+  - ./test/*

--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,44 @@
+# Always validate the PR title, and ignore the commits
+titleOnly: true
+# By default types specified in commitizen/conventional-commit-types is used.
+# See: https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json
+# You can override the valid types
+types:
+  # Features
+  - feat
+  - Feat
+  - Feature
+  # Fixes
+  - fix
+  - Fix
+  # Documentation
+  - docs
+  - Docs
+  - doc
+  - Doc
+  # Styles
+  - style
+  - Style
+  # Refactor
+  - refactor
+  - Refactor
+  # Performance
+  - perf
+  - Perf
+  # Tests
+  - test
+  - Test
+  - tests
+  - Tests
+  # Builds
+  - build
+  - Build
+  # CI
+  - ci
+  - CI
+  # Chore
+  - chore
+  - Chore
+  # CI
+  - revert
+  - Revert

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,13 @@
+# Labels PRs by triaging them to include tags
+name: Pull Request Labeling
+
+on:
+  - pull_request
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v3
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
# 1) Issue Templates

`.github/ISSUE_TEMPLATE`s :

- ``Provides templates for users to create issues and automatically adds tags. Makes it easier for us to get the information we need right off the bat. See [iquah1/github_templates_test/issues](https://github.com/iquah1/github_templates_test/issues/new/choose) for example in action. 

- Adds `config.yml` which specifies the types of issues a user can open. If they want support, or to report a security flaw, it directs them to the appropriate location i.e our discourse's **Library Questions** category, and our **readme** for the URL to report the bug.

# 2) PR Templates

Added `PULL_REQUEST_TEMPLATE` which provides a basic PR template to ensure that the user has filled in all the relevant information and has conducted all the steps. Before each merge we should probably check that they have done all the steps one final time. 

To see this in action try to open a PR on [iquah1/github_templates_test/pulls](https://github.com/iquah1/github_templates_test/pulls)

# 3) PR Labelers

In the same way we have auto-tags for open issues, we have auto-tags for our PRs. This allows us to quickly determine who should review the PRs.

See:

## 3.1) Automatic Labeler based on what files/ folder was changed

- `workflows/pr-labeler.yml`, defines the workflow
- `labeler.yml`, depending on the folder that was changed, adds a label to the PR

See how the `cicd` label is added to the side? It's because I modified the `.github/workflows` file and it automatically applied it

## 3.2) Semantic Parser

- `semantic.yml`

**NOTE**: not sure if `semantic.yml` is necessary.

 To make a long story short, `semantic.yml` enforces a tag at the beginning of the PR name. The idea behind this is to allow us to determine at a glance what the PR encompasses. See [semantic.yml](https://github.com/openfheorg/openfhe-development/blob/78db85657203feeec8254a228dd07a7260003db6/.github /semantic.yml) for the relevant tags. If the PR doesn't start with one of those terms our checker will prevent merging

**Aditional note** for `semantic.yml` tagging to work we need to install [semantic-pr](https://github.com/marketplace/semantic-prs) , but it is free,

