### PR TITLE
Fixed memory leak in LongDivisionPoly() and LongDivisionChebyshev() a…

### DIFF
--- a/benchmark/src/Lattice.cpp
+++ b/benchmark/src/Lattice.cpp
@@ -59,8 +59,7 @@ static E makeElement(std::shared_ptr<lbcrypto::ILParamsImpl<typename E::Integer>
 
 template <typename E>
 static E makeElement(std::shared_ptr<lbcrypto::ILDCRTParams<typename E::Integer>> p) {
-    std::shared_ptr<ILParamsImpl<typename E::Integer>> params(
-        new ILParamsImpl<typename E::Integer>(p->GetCyclotomicOrder(), p->GetModulus(), 1));
+    auto params = std::make_shared<ILParamsImpl<typename E::Integer>>(p->GetCyclotomicOrder(), p->GetModulus(), 1);
     typename E::Vector vec = makeVector<typename E::Vector>(params->GetRingDimension(), params->GetModulus());
 
     typename E::PolyLargeType bigE(params);

--- a/benchmark/src/poly-benchmark-16k.cpp
+++ b/benchmark/src/poly-benchmark-16k.cpp
@@ -63,7 +63,7 @@ static NativePoly makeElement(std::shared_ptr<ILNativeParams> params, Format for
 }
 
 static M2DCRTPoly makeElement(std::shared_ptr<M2DCRTParams> p, Format format) {
-    std::shared_ptr<M2Params> params(new M2Params(p->GetCyclotomicOrder(), p->GetModulus(), 1));
+    auto params  = std::make_shared<M2Params>(p->GetCyclotomicOrder(), p->GetModulus(), 1);
     M2Vector vec = makeVector<M2Vector>(params->GetRingDimension(), params->GetModulus());
 
     M2DCRTPoly::PolyLargeType bigE(params);
@@ -80,7 +80,7 @@ static void GenerateNativeParms(std::shared_ptr<ILNativeParams>& parmArray) {
     NativeInteger root         = RootOfUnity<NativeInteger>(m, modulo);
 
     ChineseRemainderTransformFTT<NativeVector>().PreCompute(root, m, modulo);
-    parmArray = std::shared_ptr<ILNativeParams>(new ILNativeParams(m, modulo, root));
+    parmArray = std::make_shared<ILNativeParams>(m, modulo, root);
 }
 
 static void GenerateDCRTParms(std::map<usint, std::shared_ptr<M2DCRTParams>>& parmArray) {
@@ -101,7 +101,7 @@ static void GenerateDCRTParms(std::map<usint, std::shared_ptr<M2DCRTParams>>& pa
 
         ChineseRemainderTransformFTT<NativeVector>().PreCompute(roots, m, moduli);
 
-        parmArray[t] = std::shared_ptr<M2DCRTParams>(new M2DCRTParams(m, moduli, roots));
+        parmArray[t] = std::make_shared<M2DCRTParams>(m, moduli, roots);
     }
 }
 

--- a/benchmark/src/poly-benchmark-1k.cpp
+++ b/benchmark/src/poly-benchmark-1k.cpp
@@ -63,7 +63,7 @@ static NativePoly makeElement(std::shared_ptr<ILNativeParams> params, Format for
 }
 
 static M2DCRTPoly makeElement(std::shared_ptr<M2DCRTParams> p, Format format) {
-    std::shared_ptr<M2Params> params(new M2Params(p->GetCyclotomicOrder(), p->GetModulus(), 1));
+    auto params  = std::make_shared<M2Params>(p->GetCyclotomicOrder(), p->GetModulus(), 1);
     M2Vector vec = makeVector<M2Vector>(params->GetRingDimension(), params->GetModulus());
 
     M2DCRTPoly::PolyLargeType bigE(params);
@@ -80,7 +80,7 @@ static void GenerateNativeParms(std::shared_ptr<ILNativeParams>& parmArray) {
     NativeInteger root         = RootOfUnity<NativeInteger>(m, modulo);
 
     ChineseRemainderTransformFTT<NativeVector>().PreCompute(root, m, modulo);
-    parmArray = std::shared_ptr<ILNativeParams>(new ILNativeParams(m, modulo, root));
+    parmArray = std::make_shared<ILNativeParams>(m, modulo, root);
 }
 
 static void GenerateDCRTParms(std::map<usint, std::shared_ptr<M2DCRTParams>>& parmArray) {
@@ -101,7 +101,7 @@ static void GenerateDCRTParms(std::map<usint, std::shared_ptr<M2DCRTParams>>& pa
 
         ChineseRemainderTransformFTT<NativeVector>().PreCompute(roots, m, moduli);
 
-        parmArray[t] = std::shared_ptr<M2DCRTParams>(new M2DCRTParams(m, moduli, roots));
+        parmArray[t] = std::make_shared<M2DCRTParams>(m, moduli, roots);
     }
 }
 

--- a/benchmark/src/poly-benchmark-4k.cpp
+++ b/benchmark/src/poly-benchmark-4k.cpp
@@ -63,7 +63,7 @@ static NativePoly makeElement(std::shared_ptr<ILNativeParams> params, Format for
 }
 
 static M2DCRTPoly makeElement(std::shared_ptr<M2DCRTParams> p, Format format) {
-    std::shared_ptr<M2Params> params(new M2Params(p->GetCyclotomicOrder(), p->GetModulus(), 1));
+    auto params  = std::make_shared<M2Params>(p->GetCyclotomicOrder(), p->GetModulus(), 1);
     M2Vector vec = makeVector<M2Vector>(params->GetRingDimension(), params->GetModulus());
 
     M2DCRTPoly::PolyLargeType bigE(params);
@@ -80,7 +80,7 @@ static void GenerateNativeParms(std::shared_ptr<ILNativeParams>& parmArray) {
     NativeInteger root         = RootOfUnity<NativeInteger>(m, modulo);
 
     ChineseRemainderTransformFTT<NativeVector>().PreCompute(root, m, modulo);
-    parmArray = std::shared_ptr<ILNativeParams>(new ILNativeParams(m, modulo, root));
+    parmArray = std::make_shared<ILNativeParams>(m, modulo, root);
 }
 
 static void GenerateDCRTParms(std::map<usint, std::shared_ptr<M2DCRTParams>>& parmArray) {
@@ -101,7 +101,7 @@ static void GenerateDCRTParms(std::map<usint, std::shared_ptr<M2DCRTParams>>& pa
 
         ChineseRemainderTransformFTT<NativeVector>().PreCompute(roots, m, moduli);
 
-        parmArray[t] = std::shared_ptr<M2DCRTParams>(new M2DCRTParams(m, moduli, roots));
+        parmArray[t] = std::make_shared<M2DCRTParams>(m, moduli, roots);
     }
 }
 

--- a/benchmark/src/poly-benchmark-64k.cpp
+++ b/benchmark/src/poly-benchmark-64k.cpp
@@ -63,7 +63,7 @@ static NativePoly makeElement(std::shared_ptr<ILNativeParams> params, Format for
 }
 
 static M2DCRTPoly makeElement(std::shared_ptr<M2DCRTParams> p, Format format) {
-    std::shared_ptr<M2Params> params(new M2Params(p->GetCyclotomicOrder(), p->GetModulus(), 1));
+    auto params  = std::make_shared<M2Params>(p->GetCyclotomicOrder(), p->GetModulus(), 1);
     M2Vector vec = makeVector<M2Vector>(params->GetRingDimension(), params->GetModulus());
 
     M2DCRTPoly::PolyLargeType bigE(params);
@@ -80,7 +80,7 @@ static void GenerateNativeParms(std::shared_ptr<ILNativeParams>& parmArray) {
     NativeInteger root         = RootOfUnity<NativeInteger>(m, modulo);
 
     ChineseRemainderTransformFTT<NativeVector>().PreCompute(root, m, modulo);
-    parmArray = std::shared_ptr<ILNativeParams>(new ILNativeParams(m, modulo, root));
+    parmArray = std::make_shared<ILNativeParams>(m, modulo, root);
 }
 
 static void GenerateDCRTParms(std::map<usint, std::shared_ptr<M2DCRTParams>>& parmArray) {
@@ -101,7 +101,7 @@ static void GenerateDCRTParms(std::map<usint, std::shared_ptr<M2DCRTParams>>& pa
 
         ChineseRemainderTransformFTT<NativeVector>().PreCompute(roots, m, moduli);
 
-        parmArray[t] = std::shared_ptr<M2DCRTParams>(new M2DCRTParams(m, moduli, roots));
+        parmArray[t] = std::make_shared<M2DCRTParams>(m, moduli, roots);
     }
 }
 

--- a/src/core/lib/math/discretegaussiangeneratorgeneric.cpp
+++ b/src/core/lib/math/discretegaussiangeneratorgeneric.cpp
@@ -89,10 +89,10 @@ void BaseSampler::GenerateProbMatrix(double stddev, double mean) {
     b_matrixSize = 2 * fin + 1;
     hammingWeights.resize(64, 0);
     probMatrix.resize(b_matrixSize);
-    double* probs = new double[b_matrixSize];
-    double S      = 0.0;
-    b_std         = stddev;
-    double error  = 1.0;
+    std::vector<double> probs(b_matrixSize);
+    double S     = 0.0;
+    b_std        = stddev;
+    double error = 1.0;
     for (int i = -1 * fin; i <= fin; i++) {
         double prob = pow(M_E, -pow((i - mean), 2) / (2. * stddev * stddev));
         S += prob;
@@ -106,7 +106,6 @@ void BaseSampler::GenerateProbMatrix(double stddev, double mean) {
             hammingWeights[j] += ((probMatrix[i] >> (63 - j)) & 1);
         }
     }
-    delete[] probs;
     GenerateDDGTree(probMatrix);
 }
 

--- a/src/core/unittest/UnitTest128.cpp
+++ b/src/core/unittest/UnitTest128.cpp
@@ -122,8 +122,8 @@ TEST(UT128, NTT_operations) {
 
     ILNativeParams params(m1, modulus, rootOfUnity);
     ILNativeParams params2(m1 / 2, modulus, rootOfUnity);
-    std::shared_ptr<ILNativeParams> x1p(new ILNativeParams(params));
-    std::shared_ptr<ILNativeParams> x2p(new ILNativeParams(params2));
+    auto x1p = std::make_shared<ILNativeParams>(params);
+    auto x2p = std::make_shared<ILNativeParams>(params2);
 
     NativePoly x1(x1p, Format::COEFFICIENT);
     x1 = {431, 3414, 1234, 7845, 2145, 7415, 5471, 8452};

--- a/src/pke/include/scheme/ckksrns/ckksrns-utils.h
+++ b/src/pke/include/scheme/ckksrns/ckksrns-utils.h
@@ -36,6 +36,7 @@
 #include <complex>
 #include <iostream>
 #include <stdint.h>
+#include <memory>
 
 /*
  * Subroutines used by the linear transformation homomorphic capability
@@ -46,6 +47,9 @@ namespace lbcrypto {
 struct longDiv {
     std::vector<double> q;
     std::vector<double> r;
+
+    longDiv() {}
+    longDiv(const std::vector<double>& q0, const std::vector<double>& r0) : q(q0), r(r0) {}
 };
 
 /**
@@ -63,7 +67,7 @@ uint32_t Degree(const std::vector<double>& coefficients);
  * @param &g the vector of coefficients of the divisor.
  * @return a struct with the coefficients for the quotient and remainder.
  */
-longDiv* LongDivisionPoly(const std::vector<double>& f, const std::vector<double>& g);
+std::shared_ptr<longDiv> LongDivisionPoly(const std::vector<double>& f, const std::vector<double>& g);
 
 /**
  * Computes the quotient and remainder of the long division of two polynomials in the Chebyshev series basis
@@ -72,7 +76,7 @@ longDiv* LongDivisionPoly(const std::vector<double>& f, const std::vector<double
  * @param &g the vector of coefficients of the divisor.
  * @return a struct with the coefficients for the quotient and remainder.
  */
-longDiv* LongDivisionChebyshev(const std::vector<double>& f, const std::vector<double>& g);
+std::shared_ptr<longDiv> LongDivisionChebyshev(const std::vector<double>& f, const std::vector<double>& g);
 
 /**
  * Computes the values of the internal degrees k and m needed in the Paterson-Stockmeyer algorithm

--- a/src/pke/lib/scheme/bfvrns/bfvrns-leveledshe.cpp
+++ b/src/pke/lib/scheme/bfvrns/bfvrns-leveledshe.cpp
@@ -298,8 +298,7 @@ Ciphertext<DCRTPoly> LeveledSHEBFVRNS::EvalMult(ConstCiphertext<DCRTPoly> cipher
         cvMult[1] -= cvMult[0];
     }
     else {  // if size of any of the ciphertexts > 2
-        bool* isFirstAdd = new bool[cvMultSize];
-        std::fill_n(isFirstAdd, cvMultSize, true);
+        std::vector<bool> isFirstAdd(cvMultSize, true);
 
         for (size_t i = 0; i < cv1Size; i++) {
             for (size_t j = 0; j < cv2Size; j++) {
@@ -312,12 +311,9 @@ Ciphertext<DCRTPoly> LeveledSHEBFVRNS::EvalMult(ConstCiphertext<DCRTPoly> cipher
                 }
             }
         }
-
-        delete[] isFirstAdd;
     }
 #else
-    bool* isFirstAdd = new bool[cvMultSize];
-    std::fill_n(isFirstAdd, cvMultSize, true);
+    std::vector<bool> isFirstAdd(cvMultSize, true);
 
     for (size_t i = 0; i < cv1Size; i++) {
         for (size_t j = 0; j < cv2Size; j++) {
@@ -330,8 +326,6 @@ Ciphertext<DCRTPoly> LeveledSHEBFVRNS::EvalMult(ConstCiphertext<DCRTPoly> cipher
             }
         }
     }
-
-    delete[] isFirstAdd;
 #endif
 
     if (cryptoParams->GetMultiplicationTechnique() == HPS) {

--- a/src/pke/lib/scheme/ckksrns/ckksrns-advancedshe.cpp
+++ b/src/pke/lib/scheme/ckksrns/ckksrns-advancedshe.cpp
@@ -220,7 +220,7 @@ Ciphertext<DCRTPoly> AdvancedSHECKKSRNS::InnerEvalPolyPS(ConstCiphertext<DCRTPol
     std::vector<double> xkm(int32_t(k2m2k + k) + 1, 0.0);
     xkm.back() = 1;
 
-    longDiv* divqr = LongDivisionPoly(coefficients, xkm);
+    auto divqr = LongDivisionPoly(coefficients, xkm);
 
     // Subtract x^{k(2^{m-1} - 1)} from r
     std::vector<double> r2 = divqr->r;
@@ -234,7 +234,7 @@ Ciphertext<DCRTPoly> AdvancedSHECKKSRNS::InnerEvalPolyPS(ConstCiphertext<DCRTPol
     }
 
     // Divide r2 by q
-    longDiv* divcs = LongDivisionPoly(r2, divqr->q);
+    auto divcs = LongDivisionPoly(r2, divqr->q);
 
     // Add x^{k(2^{m-1} - 1)} to s
     std::vector<double> s2 = divcs->r;
@@ -469,8 +469,8 @@ Ciphertext<DCRTPoly> AdvancedSHECKKSRNS::EvalPolyPS(ConstCiphertext<DCRTPoly> x,
 
     // Divide f2 by x^{k*2^{m-1}}
     std::vector<double> xkm(int32_t(k2m2k + k) + 1, 0.0);
-    xkm.back()     = 1;
-    longDiv* divqr = LongDivisionPoly(f2, xkm);
+    xkm.back() = 1;
+    auto divqr = LongDivisionPoly(f2, xkm);
 
     // Subtract x^{k(2^{m-1} - 1)} from r
     std::vector<double> r2 = divqr->r;
@@ -484,7 +484,7 @@ Ciphertext<DCRTPoly> AdvancedSHECKKSRNS::EvalPolyPS(ConstCiphertext<DCRTPoly> x,
     }
 
     // Divide r2 by q
-    longDiv* divcs = LongDivisionPoly(r2, divqr->q);
+    auto divcs = LongDivisionPoly(r2, divqr->q);
 
     // Add x^{k(2^{m-1} - 1)} to s
     std::vector<double> s2 = divcs->r;
@@ -729,8 +729,8 @@ Ciphertext<DCRTPoly> AdvancedSHECKKSRNS::InnerEvalChebyshevPS(ConstCiphertext<DC
 
     // Divide coefficients by T^{k*2^{m-1}}
     std::vector<double> Tkm(int32_t(k2m2k + k) + 1, 0.0);
-    Tkm.back()     = 1;
-    longDiv* divqr = LongDivisionChebyshev(coefficients, Tkm);
+    Tkm.back() = 1;
+    auto divqr = LongDivisionChebyshev(coefficients, Tkm);
 
     // Subtract x^{k(2^{m-1} - 1)} from r
     std::vector<double> r2 = divqr->r;
@@ -744,7 +744,7 @@ Ciphertext<DCRTPoly> AdvancedSHECKKSRNS::InnerEvalChebyshevPS(ConstCiphertext<DC
     }
 
     // Divide r2 by q
-    longDiv* divcs = LongDivisionChebyshev(r2, divqr->q);
+    auto divcs = LongDivisionChebyshev(r2, divqr->q);
 
     // Add x^{k(2^{m-1} - 1)} to s
     std::vector<double> s2 = divcs->r;
@@ -1002,8 +1002,8 @@ Ciphertext<DCRTPoly> AdvancedSHECKKSRNS::EvalChebyshevSeriesPS(ConstCiphertext<D
 
     // Divide f2 by T^{k*2^{m-1}}
     std::vector<double> Tkm(int32_t(k2m2k + k) + 1, 0.0);
-    Tkm.back()     = 1;
-    longDiv* divqr = LongDivisionChebyshev(f2, Tkm);
+    Tkm.back() = 1;
+    auto divqr = LongDivisionChebyshev(f2, Tkm);
 
     // Subtract x^{k(2^{m-1} - 1)} from r
     std::vector<double> r2 = divqr->r;
@@ -1017,7 +1017,7 @@ Ciphertext<DCRTPoly> AdvancedSHECKKSRNS::EvalChebyshevSeriesPS(ConstCiphertext<D
     }
 
     // Divide r2 by q
-    longDiv* divcs = LongDivisionChebyshev(r2, divqr->q);
+    auto divcs = LongDivisionChebyshev(r2, divqr->q);
 
     // Add x^{k(2^{m-1} - 1)} to s
     std::vector<double> s2 = divcs->r;

--- a/src/pke/lib/scheme/ckksrns/ckksrns-utils.cpp
+++ b/src/pke/lib/scheme/ckksrns/ckksrns-utils.cpp
@@ -61,7 +61,7 @@ uint32_t Degree(const std::vector<double>& coefficients) {
             deg += 1;
         }
         else
-          break;
+            break;
     }
     return coefficients.size() - deg;
 }
@@ -70,7 +70,7 @@ uint32_t Degree(const std::vector<double>& coefficients) {
 coefficient is not zero. LongDivisionPoly returns the vector of coefficients for the
 quotient and remainder of the division f/g. longDiv is a struct that contains the
 vectors of coefficients for the quotient and rest. */
-longDiv* LongDivisionPoly(const std::vector<double>& f, const std::vector<double>& g) {
+std::shared_ptr<longDiv> LongDivisionPoly(const std::vector<double>& f, const std::vector<double>& g) {
     uint32_t n = Degree(f);
     uint32_t k = Degree(g);
 
@@ -116,10 +116,7 @@ longDiv* LongDivisionPoly(const std::vector<double>& f, const std::vector<double
         r = f;
     }
 
-    longDiv* div = new longDiv;
-    *div         = {q, r};
-
-    return div;
+    return std::make_shared<longDiv>(q, r);
 }
 
 /* f and g are vectors of Chebyshev interpolation coefficients of the two polynomials.
@@ -128,7 +125,7 @@ vector of Chebyshev interpolation coefficients for the quotient and remainder of
 division f/g. longDiv is a struct that contains the vectors of coefficients for the
 quotient and rest. We assume that the zero-th coefficient is c0, not c0/2 and returns
 the same format.*/
-longDiv* LongDivisionChebyshev(const std::vector<double>& f, const std::vector<double>& g) {
+std::shared_ptr<longDiv> LongDivisionChebyshev(const std::vector<double>& f, const std::vector<double>& g) {
     uint32_t n = Degree(f);
     uint32_t k = Degree(g);
 
@@ -233,10 +230,7 @@ longDiv* LongDivisionChebyshev(const std::vector<double>& f, const std::vector<d
         r = f;
     }
 
-    longDiv* div = new longDiv;
-    *div         = {q, r};
-
-    return div;
+    return std::make_shared<longDiv>(q, r);
 }
 
 /* Compute positive integers k,m such that n < k(2^m-1) and k close to sqrt(n/2) */

--- a/src/pke/lib/schemerns/rns-multiparty.cpp
+++ b/src/pke/lib/schemerns/rns-multiparty.cpp
@@ -112,7 +112,7 @@ EvalKey<DCRTPoly> MultipartyRNS::MultiMultEvalKey(PrivateKey<DCRTPoly> privateKe
 
     const DggType& dgg = cryptoParams->GetDiscreteGaussianGenerator();
 
-    EvalKey<DCRTPoly> evalKeyResult(new EvalKeyRelinImpl<DCRTPoly>(evalKey->GetCryptoContext()));
+    EvalKey<DCRTPoly> evalKeyResult = std::make_shared<EvalKeyRelinImpl<DCRTPoly>>(evalKey->GetCryptoContext());
 
     const std::vector<DCRTPoly>& a0 = evalKey->GetAVector();
     const std::vector<DCRTPoly>& b0 = evalKey->GetBVector();

--- a/src/pke/unittest/utbfvrns/UnitTestBFVrnsCRTOperations.cpp
+++ b/src/pke/unittest/utbfvrns/UnitTestBFVrnsCRTOperations.cpp
@@ -81,7 +81,7 @@ TEST_F(UTBFVRNS_CRT, BFVrns_FastBaseConvqToBskMontgomery) {
     parameters.batchSize = 8;
     parameters.secretKeyDist = UNIFORM_TERNARY;
     parameters.multiplicationTechnique = BEHZ;
-    
+
     CryptoContext<Element> cc(UnitTestGenerateContext(parameters));
 
     const std::shared_ptr<ILDCRTParams<BigInteger>> params =
@@ -102,8 +102,8 @@ TEST_F(UTBFVRNS_CRT, BFVrns_FastBaseConvqToBskMontgomery) {
 
     ILNativeParams polyParams0(m1, modulus0, rootOfUnity0);
     ILNativeParams polyParams1(m1, modulus1, rootOfUnity1);
-    std::shared_ptr<ILNativeParams> x0p(new ILNativeParams(polyParams0));
-    std::shared_ptr<ILNativeParams> x1p(new ILNativeParams(polyParams1));
+    auto x0p = std::make_shared<ILNativeParams>(polyParams0);
+    auto x1p = std::make_shared<ILNativeParams>(polyParams1);
 
     NativePoly poly0(x0p, Format::EVALUATION);
     NativePoly poly1(x1p, Format::EVALUATION);
@@ -138,9 +138,9 @@ TEST_F(UTBFVRNS_CRT, BFVrns_FastBaseConvqToBskMontgomery) {
     ILNativeParams polyParams2(m1, modulus2, rootOfUnity2);
     ILNativeParams polyParams3(m1, modulus3, rootOfUnity3);
     ILNativeParams polyParams4(m1, modulus4, rootOfUnity4);
-    std::shared_ptr<ILNativeParams> x2p(new ILNativeParams(polyParams2));
-    std::shared_ptr<ILNativeParams> x3p(new ILNativeParams(polyParams3));
-    std::shared_ptr<ILNativeParams> x4p(new ILNativeParams(polyParams4));
+    auto x2p = std::make_shared<ILNativeParams>(polyParams2);
+    auto x3p = std::make_shared<ILNativeParams>(polyParams3);
+    auto x4p = std::make_shared<ILNativeParams>(polyParams4);
     NativePoly ans0(x0p, Format::EVALUATION);
     NativePoly ans1(x1p, Format::EVALUATION);
     NativePoly ans2(x2p, Format::EVALUATION);
@@ -190,8 +190,8 @@ TEST_F(UTBFVRNS_CRT, BFVrns_FastExpandCRTBasisPloverQ) {
 
     ILNativeParams polyParams0(m1, modulus0, rootOfUnity0);
     ILNativeParams polyParams1(m1, modulus1, rootOfUnity1);
-    std::shared_ptr<ILNativeParams> x0p(new ILNativeParams(polyParams0));
-    std::shared_ptr<ILNativeParams> x1p(new ILNativeParams(polyParams1));
+    auto x0p = std::make_shared<ILNativeParams>(polyParams0);
+    auto x1p = std::make_shared<ILNativeParams>(polyParams1);
 
     NativePoly poly0(x0p, Format::COEFFICIENT);
     NativePoly poly1(x1p, Format::COEFFICIENT);
@@ -228,8 +228,8 @@ TEST_F(UTBFVRNS_CRT, BFVrns_FastExpandCRTBasisPloverQ) {
 
     ILNativeParams polyParams2(m1, modulus2, rootOfUnity2);
     ILNativeParams polyParams3(m1, modulus3, rootOfUnity3);
-    std::shared_ptr<ILNativeParams> x2p(new ILNativeParams(polyParams2));
-    std::shared_ptr<ILNativeParams> x3p(new ILNativeParams(polyParams3));
+    auto x2p = std::make_shared<ILNativeParams>(polyParams2);
+    auto x3p = std::make_shared<ILNativeParams>(polyParams3);
     NativePoly ans0(x0p, Format::COEFFICIENT);
     NativePoly ans1(x1p, Format::COEFFICIENT);
     NativePoly ans2(x2p, Format::COEFFICIENT);


### PR DESCRIPTION
…nd replaced calls to new() with std::make_shared<>