### PR TITLE
operations with plaintexts without decoding and encoding again

### DIFF
--- a/src/pke/include/scheme/bgvrns/bgvrns-leveledshe.h
+++ b/src/pke/include/scheme/bgvrns/bgvrns-leveledshe.h
@@ -65,11 +65,6 @@ public:
     void AdjustLevelsAndDepthToOneInPlace(Ciphertext<DCRTPoly>& ciphertext1,
                                           Ciphertext<DCRTPoly>& ciphertext2) const override;
 
-    DCRTPoly AdjustLevelsAndDepthInPlace(Ciphertext<DCRTPoly>& ciphertext, ConstPlaintext plaintext) const override;
-
-    DCRTPoly AdjustLevelsAndDepthToOneInPlace(Ciphertext<DCRTPoly>& ciphertext,
-                                              ConstPlaintext plaintext) const override;
-
     /////////////////////////////////////
     // SERIALIZATION
     /////////////////////////////////////

--- a/src/pke/include/scheme/ckksrns/ckksrns-leveledshe.h
+++ b/src/pke/include/scheme/ckksrns/ckksrns-leveledshe.h
@@ -161,11 +161,6 @@ public:
     void AdjustLevelsAndDepthToOneInPlace(Ciphertext<DCRTPoly>& ciphertext1,
                                           Ciphertext<DCRTPoly>& ciphertext2) const override;
 
-    DCRTPoly AdjustLevelsAndDepthInPlace(Ciphertext<DCRTPoly>& ciphertext, ConstPlaintext plaintext) const override;
-
-    DCRTPoly AdjustLevelsAndDepthToOneInPlace(Ciphertext<DCRTPoly>& ciphertext,
-                                              ConstPlaintext plaintext) const override;
-
     std::vector<DCRTPoly::Integer> GetElementForEvalAddOrSub(ConstCiphertext<DCRTPoly> ciphertext,
                                                              double constant) const;
 

--- a/src/pke/include/schemebase/base-leveledshe.h
+++ b/src/pke/include/schemebase/base-leveledshe.h
@@ -758,13 +758,21 @@ public:
         OPENFHE_THROW(config_error, "Leveled Operations are not supported for this scheme");
     }
 
-    virtual void AdjustLevelsAndDepthInPlace(Ciphertext<Element>& ciphertext1,
-                                             Ciphertext<Element>& ciphertext2) const {
+    virtual void AdjustLevelsAndDepthInPlace(Ciphertext<Element>& ciphertext1, Ciphertext<Element>& ciphertext2) const {
         OPENFHE_THROW(config_error, "Mutable Operations are not supported for this scheme");
     }
 
     virtual void AdjustLevelsAndDepthToOneInPlace(Ciphertext<Element>& ciphertext1,
                                                   Ciphertext<Element>& ciphertext2) const {
+        OPENFHE_THROW(config_error, "Mutable Operations are not supported for this scheme");
+    }
+
+    // TODO (Andrey) : Move these functions to protected or to rns?
+    virtual void AdjustForAddOrSubInPlace(Ciphertext<Element>& ciphertext1, Ciphertext<Element>& ciphertext2) const {
+        OPENFHE_THROW(config_error, "Mutable Operations are not supported for this scheme");
+    }
+
+    virtual void AdjustForMultInPlace(Ciphertext<Element>& ciphertext1, Ciphertext<Element>& ciphertext2) const {
         OPENFHE_THROW(config_error, "Mutable Operations are not supported for this scheme");
     }
 

--- a/src/pke/include/schemebase/base-leveledshe.h
+++ b/src/pke/include/schemebase/base-leveledshe.h
@@ -714,7 +714,7 @@ public:
    * @param levels the number of towers to drop.
    * @return ciphertext after the modulus reduction performed.
    */
-    virtual Ciphertext<DCRTPoly> ModReduceInternal(ConstCiphertext<DCRTPoly> ciphertext, size_t levels) const {
+    virtual Ciphertext<Element> ModReduceInternal(ConstCiphertext<Element> ciphertext, size_t levels) const {
         OPENFHE_THROW(config_error, "ModReduce is not supported for this scheme");
     }
 
@@ -725,7 +725,7 @@ public:
    * @param levels the number of towers to drop.
    * @details \p cipherText will have modulus reduction performed in-place.
    */
-    virtual void ModReduceInternalInPlace(Ciphertext<DCRTPoly>& ciphertext, size_t levels) const {
+    virtual void ModReduceInternalInPlace(Ciphertext<Element>& ciphertext, size_t levels) const {
         OPENFHE_THROW(config_error, "ModReduce is not supported for this scheme");
     }
 
@@ -738,7 +738,7 @@ public:
    * @param levels the number of towers to drop.
    * @return resulting ciphertext.
    */
-    virtual Ciphertext<DCRTPoly> LevelReduceInternal(ConstCiphertext<DCRTPoly> ciphertext, size_t levels) const {
+    virtual Ciphertext<Element> LevelReduceInternal(ConstCiphertext<Element> ciphertext, size_t levels) const {
         OPENFHE_THROW(config_error, "LevelReduce is not supported for this scheme");
     }
 
@@ -750,36 +750,25 @@ public:
    * @param cipherText1 is the ciphertext to be level reduced in-place
    * @param levels the number of towers to drop.
    */
-    virtual void LevelReduceInternalInPlace(Ciphertext<DCRTPoly>& ciphertext, size_t levels) const {
+    virtual void LevelReduceInternalInPlace(Ciphertext<Element>& ciphertext, size_t levels) const {
         OPENFHE_THROW(config_error, "LevelReduce is not supported for this scheme");
     }
 
-    virtual void AdjustLevelsInPlace(Ciphertext<DCRTPoly>& ciphertext1, Ciphertext<DCRTPoly>& ciphertext2) const {
+    virtual void AdjustLevelsInPlace(Ciphertext<Element>& ciphertext1, Ciphertext<Element>& ciphertext2) const {
         OPENFHE_THROW(config_error, "Leveled Operations are not supported for this scheme");
     }
 
-    virtual void AdjustLevelsAndDepthInPlace(Ciphertext<DCRTPoly>& ciphertext1,
-                                             Ciphertext<DCRTPoly>& ciphertext2) const {
+    virtual void AdjustLevelsAndDepthInPlace(Ciphertext<Element>& ciphertext1,
+                                             Ciphertext<Element>& ciphertext2) const {
         OPENFHE_THROW(config_error, "Mutable Operations are not supported for this scheme");
     }
 
-    virtual void AdjustLevelsAndDepthToOneInPlace(Ciphertext<DCRTPoly>& ciphertext1,
-                                                  Ciphertext<DCRTPoly>& ciphertext2) const {
+    virtual void AdjustLevelsAndDepthToOneInPlace(Ciphertext<Element>& ciphertext1,
+                                                  Ciphertext<Element>& ciphertext2) const {
         OPENFHE_THROW(config_error, "Mutable Operations are not supported for this scheme");
     }
 
-    virtual DCRTPoly AdjustLevelsInPlace(Ciphertext<DCRTPoly>& ciphertext, ConstPlaintext plaintext) const {
-        OPENFHE_THROW(config_error, "Leveled Operations are not supported for this scheme");
-    }
-
-    virtual DCRTPoly AdjustLevelsAndDepthInPlace(Ciphertext<DCRTPoly>& ciphertext, ConstPlaintext plaintext) const {
-        OPENFHE_THROW(config_error, "Mutable Operations are not supported for this scheme");
-    }
-
-    virtual DCRTPoly AdjustLevelsAndDepthToOneInPlace(Ciphertext<DCRTPoly>& ciphertext,
-                                                      ConstPlaintext plaintext) const {
-        OPENFHE_THROW(config_error, "Mutable Operations are not supported for this scheme");
-    }
+    virtual Ciphertext<Element> MorphPlaintext(ConstPlaintext plaintext, ConstCiphertext<Element> ciphertext) const;
 
 protected:
     /////////////////////////////////////////

--- a/src/pke/include/schemebase/base-scheme.h
+++ b/src/pke/include/schemebase/base-scheme.h
@@ -1379,37 +1379,6 @@ public:
         OPENFHE_THROW(config_error, "AdjustLevelsAndDepthToOneInPlace has not been enabled for this scheme.");
     }
 
-    virtual DCRTPoly AdjustLevelsInPlace(Ciphertext<DCRTPoly>& ciphertext, ConstPlaintext plaintext) const {
-        if (m_LeveledSHE) {
-            if (!ciphertext)
-                OPENFHE_THROW(config_error, "Input ciphertext1 is nullptr");
-
-            return m_LeveledSHE->AdjustLevelsInPlace(ciphertext, plaintext);
-        }
-        OPENFHE_THROW(config_error, "AdjustLevelsInPlace has not been enabled for this scheme.");
-    }
-
-    virtual DCRTPoly AdjustLevelsAndDepthInPlace(Ciphertext<DCRTPoly>& ciphertext, ConstPlaintext plaintext) const {
-        if (m_LeveledSHE) {
-            if (!ciphertext)
-                OPENFHE_THROW(config_error, "Input ciphertext1 is nullptr");
-
-            return m_LeveledSHE->AdjustLevelsAndDepthInPlace(ciphertext, plaintext);
-        }
-        OPENFHE_THROW(config_error, "AdjustLevelsAndDepthInPlace has not been enabled for this scheme.");
-    }
-
-    virtual DCRTPoly AdjustLevelsAndDepthToOneInPlace(Ciphertext<DCRTPoly>& ciphertext,
-                                                      ConstPlaintext plaintext) const {
-        if (m_LeveledSHE) {
-            if (!ciphertext)
-                OPENFHE_THROW(config_error, "Input ciphertext1 is nullptr");
-
-            return m_LeveledSHE->AdjustLevelsAndDepthToOneInPlace(ciphertext, plaintext);
-        }
-        OPENFHE_THROW(config_error, "AdjustLevelsAndDepthToOneInPlace has not been enabled for this scheme.");
-    }
-
     /////////////////////////////////////////
     // Advanced SHE Wrapper
     /////////////////////////////////////////

--- a/src/pke/include/schemerns/rns-leveledshe.h
+++ b/src/pke/include/schemerns/rns-leveledshe.h
@@ -342,8 +342,6 @@ protected:
 
     void AdjustLevelsInPlace(Ciphertext<DCRTPoly>& ciphertext1, Ciphertext<DCRTPoly>& ciphertext2) const override;
 
-    DCRTPoly AdjustLevelsInPlace(Ciphertext<DCRTPoly>& ciphertext, ConstPlaintext plaintext) const override;
-
     /////////////////////////////////////
     // SERIALIZATION
     /////////////////////////////////////

--- a/src/pke/include/schemerns/rns-leveledshe.h
+++ b/src/pke/include/schemerns/rns-leveledshe.h
@@ -342,6 +342,10 @@ protected:
 
     void AdjustLevelsInPlace(Ciphertext<DCRTPoly>& ciphertext1, Ciphertext<DCRTPoly>& ciphertext2) const override;
 
+    void AdjustForAddOrSubInPlace(Ciphertext<DCRTPoly>& ciphertext1, Ciphertext<DCRTPoly>& ciphertext2) const override;
+
+    void AdjustForMultInPlace(Ciphertext<DCRTPoly>& ciphertext1, Ciphertext<DCRTPoly>& ciphertext2) const override;
+
     /////////////////////////////////////
     // SERIALIZATION
     /////////////////////////////////////

--- a/src/pke/lib/scheme/bgvrns/bgvrns-leveledshe.cpp
+++ b/src/pke/lib/scheme/bgvrns/bgvrns-leveledshe.cpp
@@ -231,31 +231,6 @@ void LeveledSHEBGVRNS::AdjustLevelsAndDepthToOneInPlace(Ciphertext<DCRTPoly>& ci
     }
 }
 
-DCRTPoly LeveledSHEBGVRNS::AdjustLevelsAndDepthInPlace(Ciphertext<DCRTPoly>& ciphertext,
-                                                       ConstPlaintext plaintext) const {
-    CryptoContext<DCRTPoly> cc = ciphertext->GetCryptoContext();
-    Plaintext ptx;
-    if (plaintext->GetEncodingType() == Packed) {
-        auto values = plaintext->GetPackedValue();
-        ptx         = cc->MakePackedPlaintext(values, ciphertext->GetDepth(), ciphertext->GetLevel());
-    }
-    else if (plaintext->GetEncodingType() == CoefPacked) {
-        auto values = plaintext->GetCoefPackedValue();
-        ptx         = cc->MakeCoefPackedPlaintext(values, ciphertext->GetDepth(), ciphertext->GetLevel());
-    }
-
-    ptx->GetElement<DCRTPoly>().SetFormat(Format::EVALUATION);
-    return ptx->GetElement<DCRTPoly>();
-}
-
-DCRTPoly LeveledSHEBGVRNS::AdjustLevelsAndDepthToOneInPlace(Ciphertext<DCRTPoly>& ciphertext,
-                                                            ConstPlaintext plaintext) const {
-    if (ciphertext->GetDepth() == 2) {
-        ModReduceInternalInPlace(ciphertext, BASE_NUM_LEVELS_TO_DROP);
-    }
-    return AdjustLevelsAndDepthInPlace(ciphertext, plaintext);
-}
-
 void LeveledSHEBGVRNS::EvalMultCoreInPlace(Ciphertext<DCRTPoly>& ciphertext, const NativeInteger& constant) const {
     const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersBGVRNS>(ciphertext->GetCryptoParameters());
 

--- a/src/pke/lib/scheme/ckksrns/ckksrns-leveledshe.cpp
+++ b/src/pke/lib/scheme/ckksrns/ckksrns-leveledshe.cpp
@@ -606,22 +606,6 @@ void LeveledSHECKKSRNS::AdjustLevelsAndDepthToOneInPlace(Ciphertext<DCRTPoly>& c
     }
 }
 
-DCRTPoly LeveledSHECKKSRNS::AdjustLevelsAndDepthInPlace(Ciphertext<DCRTPoly>& ciphertext,
-                                                        ConstPlaintext plaintext) const {
-    CryptoContext<DCRTPoly> cc = ciphertext->GetCryptoContext();
-    auto values                = plaintext->GetCKKSPackedValue();
-    Plaintext ptx              = cc->MakeCKKSPackedPlaintext(values, ciphertext->GetDepth(), ciphertext->GetLevel());
-    return ptx->GetElement<DCRTPoly>();
-}
-
-DCRTPoly LeveledSHECKKSRNS::AdjustLevelsAndDepthToOneInPlace(Ciphertext<DCRTPoly>& ciphertext,
-                                                             ConstPlaintext plaintext) const {
-    if (ciphertext->GetDepth() == 2) {
-        ModReduceInternalInPlace(ciphertext, BASE_NUM_LEVELS_TO_DROP);
-    }
-    return AdjustLevelsAndDepthInPlace(ciphertext, plaintext);
-}
-
 void LeveledSHECKKSRNS::EvalMultCoreInPlace(Ciphertext<DCRTPoly>& ciphertext, double constant) const {
     const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersCKKSRNS>(ciphertext->GetCryptoParameters());
 

--- a/src/pke/lib/schemebase/base-leveledshe.cpp
+++ b/src/pke/lib/schemebase/base-leveledshe.cpp
@@ -556,6 +556,23 @@ Ciphertext<Element> LeveledSHEBase<Element>::LevelReduce(ConstCiphertext<Element
     return result;
 }
 
+template <class Element>
+Ciphertext<Element> LeveledSHEBase<Element>::MorphPlaintext(ConstPlaintext plaintext, ConstCiphertext<Element> ciphertext) const {
+  auto result = ciphertext->CloneEmpty();
+
+  result->SetDepth(plaintext->GetDepth());
+  result->SetLevel(plaintext->GetLevel());
+  result->SetScalingFactor(plaintext->GetScalingFactor());
+  result->SetScalingFactorInt(plaintext->GetScalingFactorInt());
+  result->SetSlots(plaintext->GetSlots());
+
+  Element pt = plaintext->GetElement<Element>();
+  pt.SetFormat(EVALUATION);
+  result->SetElements({pt});
+
+  return result;
+}
+
 /////////////////////////////////////////
 // CORE OPERATION
 /////////////////////////////////////////

--- a/src/pke/lib/schemerns/rns-leveledshe.cpp
+++ b/src/pke/lib/schemerns/rns-leveledshe.cpp
@@ -125,11 +125,16 @@ void LeveledSHERNS::EvalAddInPlace(Ciphertext<DCRTPoly>& ciphertext, ConstPlaint
         return;
     }
 
-    DCRTPoly pt = cryptoParams->GetScalingTechnique() == FIXEDMANUAL ?
-                      AdjustLevelsInPlace(ciphertext, plaintext) :
-                      AdjustLevelsAndDepthInPlace(ciphertext, plaintext);
+    auto ctmorphed = MorphPlaintext(plaintext, ciphertext);
 
-    EvalAddCoreInPlace(ciphertext, pt);
+    if (cryptoParams->GetScalingTechnique() == FIXEDMANUAL) {
+        AdjustLevelsInPlace(ciphertext, ctmorphed);
+    }
+    else {
+        AdjustLevelsAndDepthInPlace(ciphertext, ctmorphed);
+    }
+
+    EvalAddCoreInPlace(ciphertext, ctmorphed->GetElements()[0]);
 }
 
 Ciphertext<DCRTPoly> LeveledSHERNS::EvalAddMutable(Ciphertext<DCRTPoly>& ciphertext, Plaintext plaintext) const {
@@ -141,11 +146,16 @@ Ciphertext<DCRTPoly> LeveledSHERNS::EvalAddMutable(Ciphertext<DCRTPoly>& ciphert
         return EvalAddCore(ciphertext, pt);
     }
 
-    DCRTPoly pt = cryptoParams->GetScalingTechnique() == FIXEDMANUAL ?
-                      AdjustLevelsInPlace(ciphertext, plaintext) :
-                      AdjustLevelsAndDepthInPlace(ciphertext, plaintext);
+    auto ctmorphed = MorphPlaintext(plaintext, ciphertext);
 
-    return EvalAddCore(ciphertext, pt);
+    if (cryptoParams->GetScalingTechnique() == FIXEDMANUAL) {
+        AdjustLevelsInPlace(ciphertext, ctmorphed);
+    }
+    else {
+        AdjustLevelsAndDepthInPlace(ciphertext, ctmorphed);
+    }
+
+    return EvalAddCore(ciphertext, ctmorphed->GetElements()[0]);
 }
 
 void LeveledSHERNS::EvalAddMutableInPlace(Ciphertext<DCRTPoly>& ciphertext, Plaintext plaintext) const {
@@ -158,11 +168,16 @@ void LeveledSHERNS::EvalAddMutableInPlace(Ciphertext<DCRTPoly>& ciphertext, Plai
         return;
     }
 
-    DCRTPoly pt = cryptoParams->GetScalingTechnique() == FIXEDMANUAL ?
-                      AdjustLevelsInPlace(ciphertext, plaintext) :
-                      AdjustLevelsAndDepthInPlace(ciphertext, plaintext);
+    auto ctmorphed = MorphPlaintext(plaintext, ciphertext);
 
-    EvalAddCoreInPlace(ciphertext, pt);
+    if (cryptoParams->GetScalingTechnique() == FIXEDMANUAL) {
+        AdjustLevelsInPlace(ciphertext, ctmorphed);
+    }
+    else {
+        AdjustLevelsAndDepthInPlace(ciphertext, ctmorphed);
+    }
+
+    EvalAddCoreInPlace(ciphertext, ctmorphed->GetElements()[0]);
 }
 
 /////////////////////////////////////////
@@ -254,11 +269,16 @@ void LeveledSHERNS::EvalSubInPlace(Ciphertext<DCRTPoly>& ciphertext, ConstPlaint
         return;
     }
 
-    DCRTPoly pt = cryptoParams->GetScalingTechnique() == FIXEDMANUAL ?
-                      AdjustLevelsInPlace(ciphertext, plaintext) :
-                      AdjustLevelsAndDepthInPlace(ciphertext, plaintext);
+    auto ctmorphed = MorphPlaintext(plaintext, ciphertext);
 
-    EvalSubCoreInPlace(ciphertext, pt);
+    if (cryptoParams->GetScalingTechnique() == FIXEDMANUAL) {
+        AdjustLevelsInPlace(ciphertext, ctmorphed);
+    }
+    else {
+        AdjustLevelsAndDepthInPlace(ciphertext, ctmorphed);
+    }
+
+    EvalSubCoreInPlace(ciphertext, ctmorphed->GetElements()[0]);
 }
 
 Ciphertext<DCRTPoly> LeveledSHERNS::EvalSubMutable(Ciphertext<DCRTPoly>& ciphertext, Plaintext plaintext) const {
@@ -270,14 +290,16 @@ Ciphertext<DCRTPoly> LeveledSHERNS::EvalSubMutable(Ciphertext<DCRTPoly>& ciphert
         return EvalSubCore(ciphertext, pt);
     }
 
+    auto ctmorphed = MorphPlaintext(plaintext, ciphertext);
+
     if (cryptoParams->GetScalingTechnique() == FIXEDMANUAL) {
-        Ciphertext<DCRTPoly> c = ciphertext->Clone();
-        DCRTPoly pt            = AdjustLevelsInPlace(c, plaintext);
-        return EvalSubCore(c, pt);
+        AdjustLevelsInPlace(ciphertext, ctmorphed);
+    }
+    else {
+        AdjustLevelsAndDepthInPlace(ciphertext, ctmorphed);
     }
 
-    DCRTPoly pt = AdjustLevelsAndDepthInPlace(ciphertext, plaintext);
-    return EvalSubCore(ciphertext, pt);
+    return EvalSubCore(ciphertext, ctmorphed->GetElements()[0]);
 }
 
 void LeveledSHERNS::EvalSubMutableInPlace(Ciphertext<DCRTPoly>& ciphertext, Plaintext plaintext) const {
@@ -290,14 +312,16 @@ void LeveledSHERNS::EvalSubMutableInPlace(Ciphertext<DCRTPoly>& ciphertext, Plai
         return;
     }
 
+    auto ctmorphed = MorphPlaintext(plaintext, ciphertext);
+
     if (cryptoParams->GetScalingTechnique() == FIXEDMANUAL) {
-        DCRTPoly pt = AdjustLevelsInPlace(ciphertext, plaintext);
-        EvalSubCoreInPlace(ciphertext, pt);
-        return;
+        AdjustLevelsInPlace(ciphertext, ctmorphed);
+    }
+    else {
+        AdjustLevelsAndDepthInPlace(ciphertext, ctmorphed);
     }
 
-    DCRTPoly pt = AdjustLevelsAndDepthInPlace(ciphertext, plaintext);
-    EvalSubCoreInPlace(ciphertext, pt);
+    EvalSubCoreInPlace(ciphertext, ctmorphed->GetElements()[0]);
 }
 
 /////////////////////////////////////////
@@ -393,24 +417,24 @@ void LeveledSHERNS::EvalMultInPlace(Ciphertext<DCRTPoly>& ciphertext, ConstPlain
         return;
     }
 
+    auto ctmorphed = MorphPlaintext(plaintext, ciphertext);
+
     if (cryptoParams->GetScalingTechnique() == FIXEDMANUAL) {
-        DCRTPoly pt = AdjustLevelsInPlace(ciphertext, plaintext);
-        EvalMultCoreInPlace(ciphertext, pt);
-        ciphertext->SetDepth(ciphertext->GetDepth() + plaintext->GetDepth());
-        ciphertext->SetScalingFactor(ciphertext->GetScalingFactor() * plaintext->GetScalingFactor());
-        return;
+        AdjustLevelsInPlace(ciphertext, ctmorphed);
+    }
+    else {
+        AdjustLevelsAndDepthToOneInPlace(ciphertext, ctmorphed);
     }
 
-    DCRTPoly pt = AdjustLevelsAndDepthToOneInPlace(ciphertext, plaintext);
-    EvalMultCoreInPlace(ciphertext, pt);
-    ciphertext->SetDepth(ciphertext->GetDepth() + 1);
-    ciphertext->SetScalingFactor(ciphertext->GetScalingFactor() * ciphertext->GetScalingFactor());
+    EvalMultCoreInPlace(ciphertext, ctmorphed->GetElements()[0]);
+
+    ciphertext->SetDepth(ciphertext->GetDepth() + ctmorphed->GetDepth());
+    ciphertext->SetScalingFactor(ciphertext->GetScalingFactor() * ctmorphed->GetScalingFactor());
     if (cryptoParams->GetScalingTechnique() == FLEXIBLEAUTO || cryptoParams->GetScalingTechnique() == FLEXIBLEAUTOEXT) {
         const auto plainMod = ciphertext->GetCryptoParameters()->GetPlaintextModulus();
-        ciphertext->SetScalingFactorInt(
-            ciphertext->GetScalingFactorInt().ModMul(ciphertext->GetScalingFactorInt(), plainMod));
+        ciphertext->SetScalingFactorInt(ciphertext->GetScalingFactorInt().ModMul(
+            ctmorphed->GetScalingFactorInt(), plainMod));
     }
-    return;
 }
 
 Ciphertext<DCRTPoly> LeveledSHERNS::EvalMultMutable(Ciphertext<DCRTPoly>& ciphertext, Plaintext plaintext) const {
@@ -422,25 +446,25 @@ Ciphertext<DCRTPoly> LeveledSHERNS::EvalMultMutable(Ciphertext<DCRTPoly>& cipher
         return EvalMultCore(ciphertext, pt);
     }
 
+    auto ctmorphed = MorphPlaintext(plaintext, ciphertext);
+
     if (cryptoParams->GetScalingTechnique() == FIXEDMANUAL) {
-        Ciphertext<DCRTPoly> c = ciphertext->Clone();
-        DCRTPoly pt            = AdjustLevelsInPlace(c, plaintext);
-        auto result            = EvalMultCore(c, pt);
-        result->SetScalingFactor(c->GetScalingFactor() * plaintext->GetScalingFactor());
-        result->SetDepth(c->GetDepth() + plaintext->GetDepth());
+        Ciphertext<DCRTPoly> ct = ciphertext->Clone();
+        AdjustLevelsInPlace(ct, ctmorphed);
+        auto result = EvalMultCore(ct, ctmorphed->GetElements()[0]);
+        result->SetDepth(ct->GetDepth() + ctmorphed->GetDepth());
+        result->SetScalingFactor(ct->GetScalingFactor() * ctmorphed->GetScalingFactor());
         return result;
     }
 
-    DCRTPoly pt = AdjustLevelsAndDepthToOneInPlace(ciphertext, plaintext);
-
-    auto result = EvalMultCore(ciphertext, pt);
-    result->SetDepth(ciphertext->GetDepth() + 1);
-    result->SetScalingFactor(ciphertext->GetScalingFactor() *
-                             cryptoParams->GetScalingFactorReal(ciphertext->GetLevel()));
+    AdjustLevelsAndDepthToOneInPlace(ciphertext, ctmorphed);
+    auto result = EvalMultCore(ciphertext, ctmorphed->GetElements()[0]);
+    result->SetDepth(ciphertext->GetDepth() + ctmorphed->GetDepth());
+    result->SetScalingFactor(ciphertext->GetScalingFactor() * ctmorphed->GetScalingFactor());
     if (cryptoParams->GetScalingTechnique() == FLEXIBLEAUTO || cryptoParams->GetScalingTechnique() == FLEXIBLEAUTOEXT) {
         const auto plainMod = ciphertext->GetCryptoParameters()->GetPlaintextModulus();
         result->SetScalingFactorInt(ciphertext->GetScalingFactorInt().ModMul(
-            cryptoParams->GetScalingFactorInt(ciphertext->GetLevel()), plainMod));
+            ctmorphed->GetScalingFactorInt(), plainMod));
     }
     return result;
 }
@@ -455,25 +479,23 @@ void LeveledSHERNS::EvalMultMutableInPlace(Ciphertext<DCRTPoly>& ciphertext, Pla
         return;
     }
 
+    Ciphertext<DCRTPoly> ctmorphed = MorphPlaintext(plaintext, ciphertext);
+
     if (cryptoParams->GetScalingTechnique() == FIXEDMANUAL) {
-        DCRTPoly pt = AdjustLevelsInPlace(ciphertext, plaintext);
-        EvalMultCoreInPlace(ciphertext, pt);
-        ciphertext->SetDepth(ciphertext->GetDepth() + plaintext->GetDepth());
-        ciphertext->SetScalingFactor(ciphertext->GetScalingFactor() * plaintext->GetScalingFactor());
-        return;
+        AdjustLevelsInPlace(ciphertext, ctmorphed);
+    }
+    else {
+        AdjustLevelsAndDepthToOneInPlace(ciphertext, ctmorphed);
     }
 
-    DCRTPoly pt = AdjustLevelsAndDepthToOneInPlace(ciphertext, plaintext);
-    EvalMultCoreInPlace(ciphertext, pt);
-    ciphertext->SetDepth(ciphertext->GetDepth() + 1);
-    ciphertext->SetScalingFactor(ciphertext->GetScalingFactor() *
-                                 cryptoParams->GetScalingFactorReal(ciphertext->GetLevel()));
+    EvalMultCoreInPlace(ciphertext, ctmorphed->GetElements()[0]);
+    ciphertext->SetDepth(ciphertext->GetDepth() + ctmorphed->GetDepth());
+    ciphertext->SetScalingFactor(ciphertext->GetScalingFactor() * ctmorphed->GetScalingFactor());
     if (cryptoParams->GetScalingTechnique() == FLEXIBLEAUTO || cryptoParams->GetScalingTechnique() == FLEXIBLEAUTOEXT) {
         const auto plainMod = ciphertext->GetCryptoParameters()->GetPlaintextModulus();
         ciphertext->SetScalingFactorInt(ciphertext->GetScalingFactorInt().ModMul(
-            cryptoParams->GetScalingFactorInt(ciphertext->GetLevel()), plainMod));
+            ctmorphed->GetScalingFactorInt(), plainMod));
     }
-    return;
 }
 
 Ciphertext<DCRTPoly> LeveledSHERNS::MultByMonomial(ConstCiphertext<DCRTPoly> ciphertext, usint power) const {
@@ -567,13 +589,6 @@ Ciphertext<DCRTPoly> LeveledSHERNS::Compress(ConstCiphertext<DCRTPoly> ciphertex
         return result;
     }
 
-    //  if (cryptoParams->GetScalingTechnique() == FLEXIBLEAUTO) {
-    //    const std::shared_ptr<ParmType> paramsQ = cryptoParams->GetElementParams();
-    //    usint sizeQ = paramsQ->GetParams().size();
-    //    AdjustLevelWithRescaleInPlace(result, sizeQ - towersLeft);
-    //    return result;
-    //  }
-
     LevelReduceInternalInPlace(result, sizeQl - towersLeft);
     return result;
 }
@@ -604,21 +619,6 @@ void LeveledSHERNS::AdjustLevelsInPlace(Ciphertext<DCRTPoly>& ciphertext1, Ciphe
     else if (sizeQl1 > sizeQl2) {
         LevelReduceInternalInPlace(ciphertext1, sizeQl1 - sizeQl2);
     }
-}
-
-DCRTPoly LeveledSHERNS::AdjustLevelsInPlace(Ciphertext<DCRTPoly>& ciphertext, ConstPlaintext plaintext) const {
-    auto sizeQlc = ciphertext->GetElements()[0].GetNumOfElements();
-    DCRTPoly pt  = plaintext->GetElement<DCRTPoly>();
-    auto sizeQlp = pt.GetNumOfElements();
-
-    if (sizeQlc < sizeQlp) {
-        pt.DropLastElements(sizeQlp - sizeQlc);
-    }
-    else if (sizeQlc > sizeQlp) {
-        LevelReduceInternalInPlace(ciphertext, sizeQlc - sizeQlp);
-    }
-    pt.SetFormat(Format::EVALUATION);
-    return pt;
 }
 
 }  // namespace lbcrypto

--- a/src/pke/lib/schemerns/rns-leveledshe.cpp
+++ b/src/pke/lib/schemerns/rns-leveledshe.cpp
@@ -52,56 +52,23 @@ void LeveledSHERNS::EvalAddInPlace(Ciphertext<DCRTPoly>& ciphertext1, ConstCiphe
 
     if (cryptoParams->GetScalingTechnique() == NORESCALE) {
         EvalAddCoreInPlace(ciphertext1, ciphertext2);
-        return;
-    }
-
-    Ciphertext<DCRTPoly> c2 = ciphertext2->Clone();
-
-    if (cryptoParams->GetScalingTechnique() == FIXEDMANUAL) {
-        AdjustLevelsInPlace(ciphertext1, c2);
     }
     else {
-        AdjustLevelsAndDepthInPlace(ciphertext1, c2);
-    }
+        auto c2 = ciphertext2->Clone();
+        AdjustForAddOrSubInPlace(ciphertext1, c2);
 
-    EvalAddCoreInPlace(ciphertext1, c2);
+        EvalAddCoreInPlace(ciphertext1, c2);
+    }
 }
 
 Ciphertext<DCRTPoly> LeveledSHERNS::EvalAddMutable(Ciphertext<DCRTPoly>& ciphertext1,
                                                    Ciphertext<DCRTPoly>& ciphertext2) const {
-    const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersRNS>(ciphertext1->GetCryptoParameters());
-
-    if (cryptoParams->GetScalingTechnique() == NORESCALE) {
-        return EvalAddCore(ciphertext1, ciphertext2);
-    }
-
-    if (cryptoParams->GetScalingTechnique() == FIXEDMANUAL) {
-        Ciphertext<DCRTPoly> c1 = ciphertext1->Clone();
-        Ciphertext<DCRTPoly> c2 = ciphertext2->Clone();
-        AdjustLevelsInPlace(c1, c2);
-        return EvalAddCore(c1, c2);
-    }
-
-    AdjustLevelsAndDepthInPlace(ciphertext1, ciphertext2);
+    AdjustForAddOrSubInPlace(ciphertext1, ciphertext2);
     return EvalAddCore(ciphertext1, ciphertext2);
 }
 
 void LeveledSHERNS::EvalAddMutableInPlace(Ciphertext<DCRTPoly>& ciphertext1, Ciphertext<DCRTPoly>& ciphertext2) const {
-    const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersRNS>(ciphertext1->GetCryptoParameters());
-
-    if (cryptoParams->GetScalingTechnique() == NORESCALE) {
-        EvalAddCoreInPlace(ciphertext1, ciphertext2);
-        return;
-    }
-
-    if (cryptoParams->GetScalingTechnique() == FIXEDMANUAL) {
-        Ciphertext<DCRTPoly> c2 = ciphertext2->Clone();
-        AdjustLevelsInPlace(ciphertext1, c2);
-        EvalAddCoreInPlace(ciphertext1, c2);
-        return;
-    }
-
-    AdjustLevelsAndDepthInPlace(ciphertext1, ciphertext2);
+    AdjustForAddOrSubInPlace(ciphertext1, ciphertext2);
     EvalAddCoreInPlace(ciphertext1, ciphertext2);
 }
 
@@ -116,67 +83,20 @@ Ciphertext<DCRTPoly> LeveledSHERNS::EvalAdd(ConstCiphertext<DCRTPoly> ciphertext
 }
 
 void LeveledSHERNS::EvalAddInPlace(Ciphertext<DCRTPoly>& ciphertext, ConstPlaintext plaintext) const {
-    const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersRNS>(ciphertext->GetCryptoParameters());
-
-    if (cryptoParams->GetScalingTechnique() == NORESCALE) {
-        DCRTPoly pt = plaintext->GetElement<DCRTPoly>();
-        pt.SetFormat(EVALUATION);
-        EvalAddCoreInPlace(ciphertext, pt);
-        return;
-    }
-
     auto ctmorphed = MorphPlaintext(plaintext, ciphertext);
-
-    if (cryptoParams->GetScalingTechnique() == FIXEDMANUAL) {
-        AdjustLevelsInPlace(ciphertext, ctmorphed);
-    }
-    else {
-        AdjustLevelsAndDepthInPlace(ciphertext, ctmorphed);
-    }
-
+    AdjustForAddOrSubInPlace(ciphertext, ctmorphed);
     EvalAddCoreInPlace(ciphertext, ctmorphed->GetElements()[0]);
 }
 
 Ciphertext<DCRTPoly> LeveledSHERNS::EvalAddMutable(Ciphertext<DCRTPoly>& ciphertext, Plaintext plaintext) const {
-    const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersRNS>(ciphertext->GetCryptoParameters());
-
-    if (cryptoParams->GetScalingTechnique() == NORESCALE) {
-        DCRTPoly pt = plaintext->GetElement<DCRTPoly>();
-        pt.SetFormat(EVALUATION);
-        return EvalAddCore(ciphertext, pt);
-    }
-
     auto ctmorphed = MorphPlaintext(plaintext, ciphertext);
-
-    if (cryptoParams->GetScalingTechnique() == FIXEDMANUAL) {
-        AdjustLevelsInPlace(ciphertext, ctmorphed);
-    }
-    else {
-        AdjustLevelsAndDepthInPlace(ciphertext, ctmorphed);
-    }
-
+    AdjustForAddOrSubInPlace(ciphertext, ctmorphed);
     return EvalAddCore(ciphertext, ctmorphed->GetElements()[0]);
 }
 
 void LeveledSHERNS::EvalAddMutableInPlace(Ciphertext<DCRTPoly>& ciphertext, Plaintext plaintext) const {
-    const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersRNS>(ciphertext->GetCryptoParameters());
-
-    if (cryptoParams->GetScalingTechnique() == NORESCALE) {
-        DCRTPoly pt = plaintext->GetElement<DCRTPoly>();
-        pt.SetFormat(EVALUATION);
-        EvalAddCoreInPlace(ciphertext, pt);
-        return;
-    }
-
     auto ctmorphed = MorphPlaintext(plaintext, ciphertext);
-
-    if (cryptoParams->GetScalingTechnique() == FIXEDMANUAL) {
-        AdjustLevelsInPlace(ciphertext, ctmorphed);
-    }
-    else {
-        AdjustLevelsAndDepthInPlace(ciphertext, ctmorphed);
-    }
-
+    AdjustForAddOrSubInPlace(ciphertext, ctmorphed);
     EvalAddCoreInPlace(ciphertext, ctmorphed->GetElements()[0]);
 }
 
@@ -196,56 +116,23 @@ void LeveledSHERNS::EvalSubInPlace(Ciphertext<DCRTPoly>& ciphertext1, ConstCiphe
 
     if (cryptoParams->GetScalingTechnique() == NORESCALE) {
         EvalSubCoreInPlace(ciphertext1, ciphertext2);
-        return;
-    }
-
-    Ciphertext<DCRTPoly> c2 = ciphertext2->Clone();
-
-    if (cryptoParams->GetScalingTechnique() == FIXEDMANUAL) {
-        AdjustLevelsInPlace(ciphertext1, c2);
     }
     else {
-        AdjustLevelsAndDepthInPlace(ciphertext1, c2);
-    }
+        auto c2 = ciphertext2->Clone();
+        AdjustForAddOrSubInPlace(ciphertext1, c2);
 
-    EvalSubCoreInPlace(ciphertext1, c2);
+        EvalSubCoreInPlace(ciphertext1, c2);
+    }
 }
 
 Ciphertext<DCRTPoly> LeveledSHERNS::EvalSubMutable(Ciphertext<DCRTPoly>& ciphertext1,
                                                    Ciphertext<DCRTPoly>& ciphertext2) const {
-    const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersRNS>(ciphertext1->GetCryptoParameters());
-
-    if (cryptoParams->GetScalingTechnique() == NORESCALE) {
-        return EvalSubCore(ciphertext1, ciphertext2);
-    }
-
-    if (cryptoParams->GetScalingTechnique() == FIXEDMANUAL) {
-        Ciphertext<DCRTPoly> c1 = ciphertext1->Clone();
-        Ciphertext<DCRTPoly> c2 = ciphertext2->Clone();
-        AdjustLevelsInPlace(c1, c2);
-        return EvalSubCore(c1, c2);
-    }
-
-    AdjustLevelsAndDepthInPlace(ciphertext1, ciphertext2);
+    AdjustForAddOrSubInPlace(ciphertext1, ciphertext2);
     return EvalSubCore(ciphertext1, ciphertext2);
 }
 
 void LeveledSHERNS::EvalSubMutableInPlace(Ciphertext<DCRTPoly>& ciphertext1, Ciphertext<DCRTPoly>& ciphertext2) const {
-    const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersRNS>(ciphertext1->GetCryptoParameters());
-
-    if (cryptoParams->GetScalingTechnique() == NORESCALE) {
-        EvalSubCoreInPlace(ciphertext1, ciphertext2);
-        return;
-    }
-
-    if (cryptoParams->GetScalingTechnique() == FIXEDMANUAL) {
-        Ciphertext<DCRTPoly> c2 = ciphertext2->Clone();
-        AdjustLevelsInPlace(ciphertext1, c2);
-        EvalSubCoreInPlace(ciphertext1, c2);
-        return;
-    }
-
-    AdjustLevelsAndDepthInPlace(ciphertext1, ciphertext2);
+    AdjustForAddOrSubInPlace(ciphertext1, ciphertext2);
     EvalSubCoreInPlace(ciphertext1, ciphertext2);
 }
 
@@ -260,67 +147,20 @@ Ciphertext<DCRTPoly> LeveledSHERNS::EvalSub(ConstCiphertext<DCRTPoly> ciphertext
 }
 
 void LeveledSHERNS::EvalSubInPlace(Ciphertext<DCRTPoly>& ciphertext, ConstPlaintext plaintext) const {
-    const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersRNS>(ciphertext->GetCryptoParameters());
-
-    if (cryptoParams->GetScalingTechnique() == NORESCALE) {
-        DCRTPoly pt = plaintext->GetElement<DCRTPoly>();
-        pt.SetFormat(EVALUATION);
-        EvalSubCoreInPlace(ciphertext, pt);
-        return;
-    }
-
     auto ctmorphed = MorphPlaintext(plaintext, ciphertext);
-
-    if (cryptoParams->GetScalingTechnique() == FIXEDMANUAL) {
-        AdjustLevelsInPlace(ciphertext, ctmorphed);
-    }
-    else {
-        AdjustLevelsAndDepthInPlace(ciphertext, ctmorphed);
-    }
-
+    AdjustForAddOrSubInPlace(ciphertext, ctmorphed);
     EvalSubCoreInPlace(ciphertext, ctmorphed->GetElements()[0]);
 }
 
 Ciphertext<DCRTPoly> LeveledSHERNS::EvalSubMutable(Ciphertext<DCRTPoly>& ciphertext, Plaintext plaintext) const {
-    const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersRNS>(ciphertext->GetCryptoParameters());
-
-    if (cryptoParams->GetScalingTechnique() == NORESCALE) {
-        DCRTPoly pt = plaintext->GetElement<DCRTPoly>();
-        pt.SetFormat(EVALUATION);
-        return EvalSubCore(ciphertext, pt);
-    }
-
     auto ctmorphed = MorphPlaintext(plaintext, ciphertext);
-
-    if (cryptoParams->GetScalingTechnique() == FIXEDMANUAL) {
-        AdjustLevelsInPlace(ciphertext, ctmorphed);
-    }
-    else {
-        AdjustLevelsAndDepthInPlace(ciphertext, ctmorphed);
-    }
-
+    AdjustForAddOrSubInPlace(ciphertext, ctmorphed);
     return EvalSubCore(ciphertext, ctmorphed->GetElements()[0]);
 }
 
 void LeveledSHERNS::EvalSubMutableInPlace(Ciphertext<DCRTPoly>& ciphertext, Plaintext plaintext) const {
-    const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersRNS>(ciphertext->GetCryptoParameters());
-
-    if (cryptoParams->GetScalingTechnique() == NORESCALE) {
-        DCRTPoly pt = plaintext->GetElement<DCRTPoly>();
-        pt.SetFormat(EVALUATION);
-        EvalSubCoreInPlace(ciphertext, pt);
-        return;
-    }
-
     auto ctmorphed = MorphPlaintext(plaintext, ciphertext);
-
-    if (cryptoParams->GetScalingTechnique() == FIXEDMANUAL) {
-        AdjustLevelsInPlace(ciphertext, ctmorphed);
-    }
-    else {
-        AdjustLevelsAndDepthInPlace(ciphertext, ctmorphed);
-    }
-
+    AdjustForAddOrSubInPlace(ciphertext, ctmorphed);
     EvalSubCoreInPlace(ciphertext, ctmorphed->GetElements()[0]);
 }
 
@@ -336,50 +176,29 @@ Ciphertext<DCRTPoly> LeveledSHERNS::EvalMult(ConstCiphertext<DCRTPoly> ciphertex
         return EvalMultCore(ciphertext1, ciphertext2);
     }
 
-    Ciphertext<DCRTPoly> c1 = ciphertext1->Clone();
-    Ciphertext<DCRTPoly> c2 = ciphertext2->Clone();
-
-    if (cryptoParams->GetScalingTechnique() == FIXEDMANUAL) {
-        AdjustLevelsInPlace(c1, c2);
-    }
-    else {
-        AdjustLevelsAndDepthToOneInPlace(c1, c2);
-    }
+    auto c1 = ciphertext1->Clone();
+    auto c2 = ciphertext2->Clone();
+    AdjustForMultInPlace(c1, c2);
 
     return EvalMultCore(c1, c2);
 }
 
 Ciphertext<DCRTPoly> LeveledSHERNS::EvalMultMutable(Ciphertext<DCRTPoly>& ciphertext1,
                                                     Ciphertext<DCRTPoly>& ciphertext2) const {
-    const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersRNS>(ciphertext1->GetCryptoParameters());
-
-    if (cryptoParams->GetScalingTechnique() == NORESCALE) {
-        return EvalMultCore(ciphertext1, ciphertext2);
-    }
-
-    if (cryptoParams->GetScalingTechnique() == FIXEDMANUAL) {
-        Ciphertext<DCRTPoly> c1 = ciphertext1->Clone();
-        Ciphertext<DCRTPoly> c2 = ciphertext2->Clone();
-        AdjustLevelsInPlace(c1, c2);
-        return EvalMultCore(c1, c2);
-    }
-
-    AdjustLevelsAndDepthToOneInPlace(ciphertext1, ciphertext2);
+    AdjustForMultInPlace(ciphertext1, ciphertext2);
     return EvalMultCore(ciphertext1, ciphertext2);
 }
 
 Ciphertext<DCRTPoly> LeveledSHERNS::EvalSquare(ConstCiphertext<DCRTPoly> ciphertext) const {
     const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersRNS>(ciphertext->GetCryptoParameters());
 
-    if (cryptoParams->GetScalingTechnique() == NORESCALE) {
+    if (cryptoParams->GetScalingTechnique() == NORESCALE || cryptoParams->GetScalingTechnique() == FIXEDMANUAL ||
+        ciphertext->GetDepth() == 1) {
         return EvalSquareCore(ciphertext);
     }
 
-    Ciphertext<DCRTPoly> c = ciphertext->Clone();
-
-    if ((cryptoParams->GetScalingTechnique() != FIXEDMANUAL) && (c->GetDepth() == 2)) {
-        ModReduceInternalInPlace(c, 1);
-    }
+    auto c = ciphertext->Clone();
+    ModReduceInternalInPlace(c, BASE_NUM_LEVELS_TO_DROP);
 
     return EvalSquareCore(c);
 }
@@ -387,17 +206,11 @@ Ciphertext<DCRTPoly> LeveledSHERNS::EvalSquare(ConstCiphertext<DCRTPoly> ciphert
 Ciphertext<DCRTPoly> LeveledSHERNS::EvalSquareMutable(Ciphertext<DCRTPoly>& ciphertext) const {
     const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersRNS>(ciphertext->GetCryptoParameters());
 
-    if (cryptoParams->GetScalingTechnique() == NORESCALE) {
-        return EvalSquareCore(ciphertext);
+    if (cryptoParams->GetScalingTechnique() != NORESCALE && cryptoParams->GetScalingTechnique() != FIXEDMANUAL &&
+        ciphertext->GetDepth() == 2) {
+        ModReduceInternalInPlace(ciphertext, BASE_NUM_LEVELS_TO_DROP);
     }
 
-    if (cryptoParams->GetScalingTechnique() == FIXEDMANUAL) {
-        Ciphertext<DCRTPoly> c = ciphertext->Clone();
-        return EvalSquareCore(c);
-    }
-    if (ciphertext->GetDepth() == 2) {
-        ModReduceInternalInPlace(ciphertext, 1);
-    }
     return EvalSquareCore(ciphertext);
 }
 
@@ -408,93 +221,56 @@ Ciphertext<DCRTPoly> LeveledSHERNS::EvalMult(ConstCiphertext<DCRTPoly> ciphertex
 }
 
 void LeveledSHERNS::EvalMultInPlace(Ciphertext<DCRTPoly>& ciphertext, ConstPlaintext plaintext) const {
-    const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersRNS>(ciphertext->GetCryptoParameters());
-
-    if (cryptoParams->GetScalingTechnique() == NORESCALE) {
-        DCRTPoly pt = plaintext->GetElement<DCRTPoly>();
-        pt.SetFormat(EVALUATION);
-        EvalMultCoreInPlace(ciphertext, pt);
-        return;
-    }
-
     auto ctmorphed = MorphPlaintext(plaintext, ciphertext);
-
-    if (cryptoParams->GetScalingTechnique() == FIXEDMANUAL) {
-        AdjustLevelsInPlace(ciphertext, ctmorphed);
-    }
-    else {
-        AdjustLevelsAndDepthToOneInPlace(ciphertext, ctmorphed);
-    }
-
+    AdjustForMultInPlace(ciphertext, ctmorphed);
     EvalMultCoreInPlace(ciphertext, ctmorphed->GetElements()[0]);
 
+    const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersRNS>(ciphertext->GetCryptoParameters());
     ciphertext->SetDepth(ciphertext->GetDepth() + ctmorphed->GetDepth());
+    // TODO (Andrey) : This part is only used in CKKS scheme
     ciphertext->SetScalingFactor(ciphertext->GetScalingFactor() * ctmorphed->GetScalingFactor());
+    // TODO (Andrey) : This part is only used in BGV scheme
     if (cryptoParams->GetScalingTechnique() == FLEXIBLEAUTO || cryptoParams->GetScalingTechnique() == FLEXIBLEAUTOEXT) {
         const auto plainMod = ciphertext->GetCryptoParameters()->GetPlaintextModulus();
-        ciphertext->SetScalingFactorInt(ciphertext->GetScalingFactorInt().ModMul(
-            ctmorphed->GetScalingFactorInt(), plainMod));
+        ciphertext->SetScalingFactorInt(
+            ciphertext->GetScalingFactorInt().ModMul(ctmorphed->GetScalingFactorInt(), plainMod));
     }
 }
 
 Ciphertext<DCRTPoly> LeveledSHERNS::EvalMultMutable(Ciphertext<DCRTPoly>& ciphertext, Plaintext plaintext) const {
-    const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersRNS>(ciphertext->GetCryptoParameters());
-
-    if (cryptoParams->GetScalingTechnique() == NORESCALE) {
-        DCRTPoly pt = plaintext->GetElement<DCRTPoly>();
-        pt.SetFormat(EVALUATION);
-        return EvalMultCore(ciphertext, pt);
-    }
-
     auto ctmorphed = MorphPlaintext(plaintext, ciphertext);
-
-    if (cryptoParams->GetScalingTechnique() == FIXEDMANUAL) {
-        Ciphertext<DCRTPoly> ct = ciphertext->Clone();
-        AdjustLevelsInPlace(ct, ctmorphed);
-        auto result = EvalMultCore(ct, ctmorphed->GetElements()[0]);
-        result->SetDepth(ct->GetDepth() + ctmorphed->GetDepth());
-        result->SetScalingFactor(ct->GetScalingFactor() * ctmorphed->GetScalingFactor());
-        return result;
-    }
-
-    AdjustLevelsAndDepthToOneInPlace(ciphertext, ctmorphed);
+    AdjustForMultInPlace(ciphertext, ctmorphed);
     auto result = EvalMultCore(ciphertext, ctmorphed->GetElements()[0]);
+
+    const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersRNS>(ciphertext->GetCryptoParameters());
     result->SetDepth(ciphertext->GetDepth() + ctmorphed->GetDepth());
+    // TODO (Andrey) : This part is only used in CKKS scheme
     result->SetScalingFactor(ciphertext->GetScalingFactor() * ctmorphed->GetScalingFactor());
+    // TODO (Andrey) : This part is only used in BGV scheme
     if (cryptoParams->GetScalingTechnique() == FLEXIBLEAUTO || cryptoParams->GetScalingTechnique() == FLEXIBLEAUTOEXT) {
         const auto plainMod = ciphertext->GetCryptoParameters()->GetPlaintextModulus();
-        result->SetScalingFactorInt(ciphertext->GetScalingFactorInt().ModMul(
-            ctmorphed->GetScalingFactorInt(), plainMod));
+        result->SetScalingFactorInt(
+            ciphertext->GetScalingFactorInt().ModMul(ctmorphed->GetScalingFactorInt(), plainMod));
     }
+
     return result;
 }
 
+// TODO (Andrey) : currently do same as EvalMultInPlace, as Plaintext element is immutable
 void LeveledSHERNS::EvalMultMutableInPlace(Ciphertext<DCRTPoly>& ciphertext, Plaintext plaintext) const {
-    const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersRNS>(ciphertext->GetCryptoParameters());
-
-    if (cryptoParams->GetScalingTechnique() == NORESCALE) {
-        DCRTPoly pt = plaintext->GetElement<DCRTPoly>();
-        pt.SetFormat(EVALUATION);
-        EvalMultCoreInPlace(ciphertext, pt);
-        return;
-    }
-
-    Ciphertext<DCRTPoly> ctmorphed = MorphPlaintext(plaintext, ciphertext);
-
-    if (cryptoParams->GetScalingTechnique() == FIXEDMANUAL) {
-        AdjustLevelsInPlace(ciphertext, ctmorphed);
-    }
-    else {
-        AdjustLevelsAndDepthToOneInPlace(ciphertext, ctmorphed);
-    }
-
+    auto ctmorphed = MorphPlaintext(plaintext, ciphertext);
+    AdjustForMultInPlace(ciphertext, ctmorphed);
     EvalMultCoreInPlace(ciphertext, ctmorphed->GetElements()[0]);
+
+    const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersRNS>(ciphertext->GetCryptoParameters());
     ciphertext->SetDepth(ciphertext->GetDepth() + ctmorphed->GetDepth());
+    // TODO (Andrey) : This part is only used in CKKS scheme
     ciphertext->SetScalingFactor(ciphertext->GetScalingFactor() * ctmorphed->GetScalingFactor());
+    // TODO (Andrey) : This part is only used in BGV scheme
     if (cryptoParams->GetScalingTechnique() == FLEXIBLEAUTO || cryptoParams->GetScalingTechnique() == FLEXIBLEAUTOEXT) {
         const auto plainMod = ciphertext->GetCryptoParameters()->GetPlaintextModulus();
-        ciphertext->SetScalingFactorInt(ciphertext->GetScalingFactorInt().ModMul(
-            ctmorphed->GetScalingFactorInt(), plainMod));
+        ciphertext->SetScalingFactorInt(
+            ciphertext->GetScalingFactorInt().ModMul(ctmorphed->GetScalingFactorInt(), plainMod));
     }
 }
 
@@ -552,6 +328,7 @@ void LeveledSHERNS::ModReduceInPlace(Ciphertext<DCRTPoly>& ciphertext, size_t le
 // SHE LEVELED Level Reduce
 /////////////////////////////////////
 
+// TODO (Andrey) : remove evalKey as unused
 Ciphertext<DCRTPoly> LeveledSHERNS::LevelReduce(ConstCiphertext<DCRTPoly> ciphertext, const EvalKey<DCRTPoly> evalKey,
                                                 size_t levels) const {
     Ciphertext<DCRTPoly> result = ciphertext->Clone();
@@ -559,6 +336,7 @@ Ciphertext<DCRTPoly> LeveledSHERNS::LevelReduce(ConstCiphertext<DCRTPoly> cipher
     return result;
 }
 
+// TODO (Andrey) : remove evalKey as unused
 void LeveledSHERNS::LevelReduceInPlace(Ciphertext<DCRTPoly>& ciphertext, const EvalKey<DCRTPoly> evalKey,
                                        size_t levels) const {
     const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersRNS>(ciphertext->GetCryptoParameters());
@@ -585,11 +363,10 @@ Ciphertext<DCRTPoly> LeveledSHERNS::Compress(ConstCiphertext<DCRTPoly> ciphertex
     const std::vector<DCRTPoly>& cv = result->GetElements();
     usint sizeQl                    = cv[0].GetNumOfElements();
 
-    if (towersLeft >= sizeQl) {
-        return result;
+    if (towersLeft < sizeQl) {
+        LevelReduceInternalInPlace(result, sizeQl - towersLeft);
     }
 
-    LevelReduceInternalInPlace(result, sizeQl - towersLeft);
     return result;
 }
 
@@ -618,6 +395,29 @@ void LeveledSHERNS::AdjustLevelsInPlace(Ciphertext<DCRTPoly>& ciphertext1, Ciphe
     }
     else if (sizeQl1 > sizeQl2) {
         LevelReduceInternalInPlace(ciphertext1, sizeQl1 - sizeQl2);
+    }
+}
+
+void LeveledSHERNS::AdjustForAddOrSubInPlace(Ciphertext<DCRTPoly>& ciphertext1,
+                                             Ciphertext<DCRTPoly>& ciphertext2) const {
+    const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersRNS>(ciphertext1->GetCryptoParameters());
+
+    if (cryptoParams->GetScalingTechnique() == FIXEDMANUAL) {
+        AdjustLevelsInPlace(ciphertext1, ciphertext2);
+    }
+    else if (cryptoParams->GetScalingTechnique() != NORESCALE) {
+        AdjustLevelsAndDepthInPlace(ciphertext1, ciphertext2);
+    }
+}
+
+void LeveledSHERNS::AdjustForMultInPlace(Ciphertext<DCRTPoly>& ciphertext1, Ciphertext<DCRTPoly>& ciphertext2) const {
+    const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersRNS>(ciphertext1->GetCryptoParameters());
+
+    if (cryptoParams->GetScalingTechnique() == FIXEDMANUAL) {
+        AdjustLevelsInPlace(ciphertext1, ciphertext2);
+    }
+    else if (cryptoParams->GetScalingTechnique() != NORESCALE) {
+        AdjustLevelsAndDepthToOneInPlace(ciphertext1, ciphertext2);
     }
 }
 

--- a/src/pke/unittest/utckksrns/UnitTestCKKSrns.cpp
+++ b/src/pke/unittest/utckksrns/UnitTestCKKSrns.cpp
@@ -950,12 +950,12 @@ protected:
             std::vector<std::complex<double>> constantInts(
                 std::vector<std::complex<double>>(VECTOR_SIZE, 11));  // vector of 11s
             Plaintext plaintextConst     = cc->MakeCKKSPackedPlaintext(constantInts);
-            Plaintext plaintextConstDeep = cc->MakeCKKSPackedPlaintext(constantInts, 3);
+            Plaintext plaintextConstDeep = cc->MakeCKKSPackedPlaintext(constantInts, 2);
 
             std::vector<std::complex<double>> constantInts2(
                 std::vector<std::complex<double>>(VECTOR_SIZE, -11));  // vector of "-11"s
             Plaintext plaintextConst2     = cc->MakeCKKSPackedPlaintext(constantInts2);
-            Plaintext plaintextConst2Deep = cc->MakeCKKSPackedPlaintext(constantInts2, 3);
+            Plaintext plaintextConst2Deep = cc->MakeCKKSPackedPlaintext(constantInts2, 2);
 
             Plaintext plaintext2 = cc->MakeCKKSPackedPlaintext(vectorOfInts7_0);
             Plaintext plaintext3 = cc->MakeCKKSPackedPlaintext(vectorOfInts0_7neg);
@@ -1318,14 +1318,14 @@ protected:
             auto ct_5 = cc->EvalAdd(ct_4, plaintext2);
             cc->Decrypt(kp.secretKey, ct_5, &results);
             results->SetLength(plaintextCt_5->GetLength());
-            checkEquality(plaintextCt_5->GetCKKSPackedValue(), results->GetCKKSPackedValue(), eps,
+            checkEquality(plaintextCt_5->GetCKKSPackedValue(), results->GetCKKSPackedValue(), epsHigh,
                           failmsg + " addition with plaintext and tower diff = 1 fails");
 
             // Subtraction with plaintext and tower diff = 1
             auto ct_6 = cc->EvalSub(ct_4, plaintext2);
             cc->Decrypt(kp.secretKey, ct_6, &results);
             results->SetLength(plaintextCt_6->GetLength());
-            checkEquality(plaintextCt_6->GetCKKSPackedValue(), results->GetCKKSPackedValue(), eps,
+            checkEquality(plaintextCt_6->GetCKKSPackedValue(), results->GetCKKSPackedValue(), epsHigh,
                           failmsg + " subtraction with plaintext and tower diff = 1 fails");
 
             // Multiplication with plaintext and tower diff = 1


### PR DESCRIPTION
closes #59 
Added MorphPlaintext method that creates a ciphertext with a single element from a plaintext.
In UnitTests changed MakeCKKSPackedPlaintext depth from 3 to 2 (to be compatible with AUTO logic, where depth <= 2)
In UnitTests changed eps -> epsHigh where FIXEDAUTO mode precision become worse.