### PR TITLE
113 bfv keyswitch

### DIFF
--- a/benchmark/src/mult-vs-square.cpp
+++ b/benchmark/src/mult-vs-square.cpp
@@ -34,8 +34,6 @@
  * using EvalMult and EvalSquare operations.
  */
 
-#define PROFILE
-#define _USE_MATH_DEFINES
 #include "scheme/bfvrns/cryptocontext-bfvrns.h"
 #include "scheme/bgvrns/cryptocontext-bgvrns.h"
 #include "scheme/ckksrns/cryptocontext-ckksrns.h"
@@ -137,6 +135,7 @@ void BGVrns_EvalPo2WithMult_P2(benchmark::State& state) {
     plaintextDec->SetLength(plaintext->GetLength());
 
     if (plaintext != plaintextDec) {
+        std::cout << "Error: Original plaintext should be equal to evaluated plaintext" << std::endl;
         std::cout << "Original plaintext: " << plaintext << std::endl;
         std::cout << "Evaluated plaintext: " << plaintextDec << std::endl;
     }
@@ -174,6 +173,7 @@ void BGVrns_EvalPo2WithSquare_P2(benchmark::State& state) {
     plaintextDec->SetLength(plaintext->GetLength());
 
     if (plaintext != plaintextDec) {
+        std::cout << "Error: Original plaintext should be equal to evaluated plaintext" << std::endl;
         std::cout << "Original plaintext: " << plaintext << std::endl;
         std::cout << "Evaluated plaintext: " << plaintextDec << std::endl;
     }
@@ -211,6 +211,7 @@ void BFVrns_EvalPo2WithMult_P2(benchmark::State& state) {
     plaintextDec->SetLength(plaintext->GetLength());
 
     if (plaintext != plaintextDec) {
+        std::cout << "Error: Original plaintext should be equal to evaluated plaintext" << std::endl;
         std::cout << "Original plaintext: " << plaintext << std::endl;
         std::cout << "Evaluated plaintext: " << plaintextDec << std::endl;
     }
@@ -248,6 +249,7 @@ void BFVrns_EvalPo2WithSquare_P2(benchmark::State& state) {
     plaintextDec->SetLength(plaintext->GetLength());
 
     if (plaintext != plaintextDec) {
+        std::cout << "Error: Original plaintext should be equal to evaluated plaintext" << std::endl;
         std::cout << "Original plaintext: " << plaintext << std::endl;
         std::cout << "Evaluated plaintext: " << plaintextDec << std::endl;
     }
@@ -285,6 +287,7 @@ void BGVrns_EvalPo2WithMult_P65537(benchmark::State& state) {
     plaintextDec->SetLength(plaintext->GetLength());
 
     if (plaintext != plaintextDec) {
+        std::cout << "Error: Original plaintext should be equal to evaluated plaintext" << std::endl;
         std::cout << "Original plaintext: " << plaintext << std::endl;
         std::cout << "Evaluated plaintext: " << plaintextDec << std::endl;
     }
@@ -322,6 +325,7 @@ void BGVrns_EvalPo2WithSquare_P65537(benchmark::State& state) {
     plaintextDec->SetLength(plaintext->GetLength());
 
     if (plaintext != plaintextDec) {
+        std::cout << "Error: Original plaintext should be equal to evaluated plaintext" << std::endl;
         std::cout << "Original plaintext: " << plaintext << std::endl;
         std::cout << "Evaluated plaintext: " << plaintextDec << std::endl;
     }
@@ -359,6 +363,7 @@ void BFVrns_EvalPo2WithMult_P65537(benchmark::State& state) {
     plaintextDec->SetLength(plaintext->GetLength());
 
     if (plaintext != plaintextDec) {
+        std::cout << "Error: Original plaintext should be equal to evaluated plaintext" << std::endl;
         std::cout << "Original plaintext: " << plaintext << std::endl;
         std::cout << "Evaluated plaintext: " << plaintextDec << std::endl;
     }
@@ -396,6 +401,7 @@ void BFVrns_EvalPo2WithSquare_P65537(benchmark::State& state) {
     plaintextDec->SetLength(plaintext->GetLength());
 
     if (plaintext != plaintextDec) {
+        std::cout << "Error: Original plaintext should be equal to evaluated plaintext" << std::endl;
         std::cout << "Original plaintext: " << plaintext << std::endl;
         std::cout << "Evaluated plaintext: " << plaintextDec << std::endl;
     }
@@ -437,6 +443,7 @@ void CKKSrns_EvalPo2WithMult(benchmark::State& state) {
                                 return std::fabs(value1.real() - value2.real()) < epsilon;
                             });
     if (!equal) {
+        std::cout << "Error: Original plaintext should be equal to evaluated plaintext" << std::endl;
         std::cout << "Original plaintext: " << plaintext << std::endl;
         std::cout << "Evaluated plaintext: " << plaintextDec << std::endl;
     }
@@ -478,6 +485,7 @@ void CKKSrns_EvalPo2WithSquare(benchmark::State& state) {
                                 return std::fabs(value1.real() - value2.real()) < epsilon;
                             });
     if (!equal) {
+        std::cout << "Error: Original plaintext should be equal to evaluated plaintext" << std::endl;
         std::cout << "Original plaintext: " << plaintext << std::endl;
         std::cout << "Evaluated plaintext: " << plaintextDec << std::endl;
     }

--- a/benchmark/src/mult-vs-square.cpp
+++ b/benchmark/src/mult-vs-square.cpp
@@ -1,0 +1,391 @@
+//==================================================================================
+// BSD 2-Clause License
+//
+// Copyright (c) 2014-2022, NJIT, Duality Technologies Inc. and other contributors
+//
+// All rights reserved.
+//
+// Author TPOC: contact@openfhe.org
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//==================================================================================
+
+/*
+ * Compares the performance of Mult and Square for BGV, BFV and CKKS
+ * using EvalMult and EvalSquare operations.
+ */
+
+#define PROFILE
+#define _USE_MATH_DEFINES
+#include "scheme/bfvrns/cryptocontext-bfvrns.h"
+#include "scheme/bgvrns/cryptocontext-bgvrns.h"
+#include "gen-cryptocontext.h"
+
+#include "benchmark/benchmark.h"
+
+#include <iostream>
+#include <fstream>
+#include <limits>
+#include <iterator>
+#include <random>
+
+using namespace lbcrypto;
+
+static std::vector<usint> depths({1, 2, 4, 8, 12});
+
+/*
+ * Context setup utility methods
+ */
+CryptoContext<DCRTPoly> GenerateBGVrnsContext(usint ptm, usint multDepth) {
+    CCParams<CryptoContextBGVRNS> parameters;
+    parameters.SetPlaintextModulus(ptm);
+    parameters.SetMultiplicativeDepth(multDepth);
+    parameters.SetKeySwitchTechnique(HYBRID);
+    parameters.SetScalingTechnique(FIXEDAUTO);
+
+    CryptoContext<DCRTPoly> cc = GenCryptoContext(parameters);
+    cc->Enable(PKE);
+    cc->Enable(KEYSWITCH);
+    cc->Enable(LEVELEDSHE);
+
+    return cc;
+}
+
+CryptoContext<DCRTPoly> GenerateBFVrnsContext(usint ptm, usint multDepth) {
+    CCParams<CryptoContextBFVRNS> parameters;
+    parameters.SetPlaintextModulus(ptm);
+    parameters.SetMultiplicativeDepth(multDepth);
+    parameters.SetScalingModSize(60);
+    parameters.SetKeySwitchTechnique(HYBRID);
+    parameters.SetMultiplicationTechnique(HPS);
+
+    CryptoContext<DCRTPoly> cc = GenCryptoContext(parameters);
+    cc->Enable(PKE);
+    cc->Enable(KEYSWITCH);
+    cc->Enable(LEVELEDSHE);
+
+    return cc;
+}
+
+static void DepthArguments(benchmark::internal::Benchmark* b) {
+    for (usint t : depths) {
+        b->ArgName("depths")->Arg(t);
+    }
+}
+
+/*
+ * EvalMult benchmarks for Power of 2
+ */
+void BGVrns_EvalPo2WithMult_P2(benchmark::State& state) {
+    usint ptm                  = 2;
+    usint depth                = state.range(0);
+    CryptoContext<DCRTPoly> cc = GenerateBGVrnsContext(ptm, depth);
+
+    // KeyGen
+    KeyPair<DCRTPoly> keyPair = cc->KeyGen();
+    cc->EvalMultKeyGen(keyPair.secretKey);
+
+    std::vector<int64_t> vectorOfInts = {1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    Plaintext plaintext               = cc->MakeCoefPackedPlaintext(vectorOfInts);
+    Ciphertext<DCRTPoly> ciphertext   = cc->Encrypt(keyPair.publicKey, plaintext);
+
+    Ciphertext<DCRTPoly> ciphertextPo2;
+
+    while (state.KeepRunning()) {
+        ciphertextPo2 = cc->EvalMult(ciphertext, ciphertext);
+        for (usint i = 2; i < depth; ++i) {
+            ciphertextPo2 = cc->EvalMult(ciphertextPo2, ciphertextPo2);
+        }
+    }
+
+    Plaintext plaintextDec;
+    cc->Decrypt(keyPair.secretKey, ciphertextPo2, &plaintextDec);
+    plaintextDec->SetLength(plaintext->GetLength());
+
+    if (plaintext != plaintextDec) {
+        std::cout << "Original plaintext: " << plaintext << std::endl;
+        std::cout << "Evaluated plaintext: " << plaintextDec << std::endl;
+    }
+}
+
+BENCHMARK(BGVrns_EvalPo2WithMult_P2)->Unit(benchmark::kMicrosecond)->Apply(DepthArguments)->MinTime(10.0);
+
+/*
+ * EvalSquare benchmarks for Power of 2
+ */
+void BGVrns_EvalPo2WithSquare_P2(benchmark::State& state) {
+    usint ptm                  = 2;
+    usint depth                = state.range(0);
+    CryptoContext<DCRTPoly> cc = GenerateBGVrnsContext(ptm, depth);
+
+    // KeyGen
+    KeyPair<DCRTPoly> keyPair = cc->KeyGen();
+    cc->EvalMultKeyGen(keyPair.secretKey);
+
+    std::vector<int64_t> vectorOfInts = {1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    Plaintext plaintext               = cc->MakeCoefPackedPlaintext(vectorOfInts);
+    Ciphertext<DCRTPoly> ciphertext   = cc->Encrypt(keyPair.publicKey, plaintext);
+
+    Ciphertext<DCRTPoly> ciphertextPo2;
+
+    while (state.KeepRunning()) {
+        ciphertextPo2 = cc->EvalSquare(ciphertext);
+        for (usint i = 2; i < depth; ++i) {
+            ciphertextPo2 = cc->EvalSquare(ciphertextPo2);
+        }
+    }
+
+    Plaintext plaintextDec;
+    cc->Decrypt(keyPair.secretKey, ciphertextPo2, &plaintextDec);
+    plaintextDec->SetLength(plaintext->GetLength());
+
+    if (plaintext != plaintextDec) {
+        std::cout << "Original plaintext: " << plaintext << std::endl;
+        std::cout << "Evaluated plaintext: " << plaintextDec << std::endl;
+    }
+}
+
+BENCHMARK(BGVrns_EvalPo2WithSquare_P2)->Unit(benchmark::kMicrosecond)->Apply(DepthArguments)->MinTime(10.0);
+
+/*
+ * EvalMult benchmarks for Power of 2
+ */
+void BFVrns_EvalPo2WithMult_P2(benchmark::State& state) {
+    usint ptm                  = 2;
+    usint depth                = state.range(0);
+    CryptoContext<DCRTPoly> cc = GenerateBFVrnsContext(ptm, depth);
+
+    // KeyGen
+    KeyPair<DCRTPoly> keyPair = cc->KeyGen();
+    cc->EvalMultKeyGen(keyPair.secretKey);
+
+    std::vector<int64_t> vectorOfInts = {1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    Plaintext plaintext               = cc->MakeCoefPackedPlaintext(vectorOfInts);
+    Ciphertext<DCRTPoly> ciphertext   = cc->Encrypt(keyPair.publicKey, plaintext);
+
+    Ciphertext<DCRTPoly> ciphertextPo2;
+
+    while (state.KeepRunning()) {
+        ciphertextPo2 = cc->EvalMult(ciphertext, ciphertext);
+        for (usint i = 2; i < depth; ++i) {
+            ciphertextPo2 = cc->EvalMult(ciphertextPo2, ciphertextPo2);
+        }
+    }
+
+    Plaintext plaintextDec;
+    cc->Decrypt(keyPair.secretKey, ciphertextPo2, &plaintextDec);
+    plaintextDec->SetLength(plaintext->GetLength());
+
+    if (plaintext != plaintextDec) {
+        std::cout << "Original plaintext: " << plaintext << std::endl;
+        std::cout << "Evaluated plaintext: " << plaintextDec << std::endl;
+    }
+}
+
+BENCHMARK(BFVrns_EvalPo2WithMult_P2)->Unit(benchmark::kMicrosecond)->Apply(DepthArguments)->MinTime(10.0);
+
+/*
+ * EvalSquare benchmarks for Power of 2
+ */
+void BFVrns_EvalPo2WithSquare_P2(benchmark::State& state) {
+    usint ptm                  = 2;
+    usint depth                = state.range(0);
+    CryptoContext<DCRTPoly> cc = GenerateBFVrnsContext(ptm, depth);
+
+    // KeyGen
+    KeyPair<DCRTPoly> keyPair = cc->KeyGen();
+    cc->EvalMultKeyGen(keyPair.secretKey);
+
+    std::vector<int64_t> vectorOfInts = {1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    Plaintext plaintext               = cc->MakeCoefPackedPlaintext(vectorOfInts);
+    Ciphertext<DCRTPoly> ciphertext   = cc->Encrypt(keyPair.publicKey, plaintext);
+
+    Ciphertext<DCRTPoly> ciphertextPo2;
+
+    while (state.KeepRunning()) {
+        ciphertextPo2 = cc->EvalSquare(ciphertext);
+        for (usint i = 2; i < depth; ++i) {
+            ciphertextPo2 = cc->EvalSquare(ciphertextPo2);
+        }
+    }
+
+    Plaintext plaintextDec;
+    cc->Decrypt(keyPair.secretKey, ciphertextPo2, &plaintextDec);
+    plaintextDec->SetLength(plaintext->GetLength());
+
+    if (plaintext != plaintextDec) {
+        std::cout << "Original plaintext: " << plaintext << std::endl;
+        std::cout << "Evaluated plaintext: " << plaintextDec << std::endl;
+    }
+}
+
+BENCHMARK(BFVrns_EvalPo2WithSquare_P2)->Unit(benchmark::kMicrosecond)->Apply(DepthArguments)->MinTime(10.0);
+
+/*
+ * EvalMult benchmarks for Power of 2
+ */
+void BGVrns_EvalPo2WithMult_P65537(benchmark::State& state) {
+    usint ptm                  = 65537;
+    usint depth                = state.range(0);
+    CryptoContext<DCRTPoly> cc = GenerateBGVrnsContext(ptm, depth);
+
+    // KeyGen
+    KeyPair<DCRTPoly> keyPair = cc->KeyGen();
+    cc->EvalMultKeyGen(keyPair.secretKey);
+
+    std::vector<int64_t> vectorOfInts = {1, 0, 0, 1, 0, 0, 1, 1};
+    Plaintext plaintext               = cc->MakePackedPlaintext(vectorOfInts);
+    Ciphertext<DCRTPoly> ciphertext   = cc->Encrypt(keyPair.publicKey, plaintext);
+
+    Ciphertext<DCRTPoly> ciphertextPo2;
+
+    while (state.KeepRunning()) {
+        ciphertextPo2 = cc->EvalMult(ciphertext, ciphertext);
+        for (usint i = 2; i < depth; ++i) {
+            ciphertextPo2 = cc->EvalMult(ciphertextPo2, ciphertextPo2);
+        }
+    }
+
+    Plaintext plaintextDec;
+    cc->Decrypt(keyPair.secretKey, ciphertextPo2, &plaintextDec);
+    plaintextDec->SetLength(plaintext->GetLength());
+
+    if (plaintext != plaintextDec) {
+        std::cout << "Original plaintext: " << plaintext << std::endl;
+        std::cout << "Evaluated plaintext: " << plaintextDec << std::endl;
+    }
+}
+
+BENCHMARK(BGVrns_EvalPo2WithMult_P65537)->Unit(benchmark::kMicrosecond)->Apply(DepthArguments)->MinTime(10.0);
+
+/*
+ * EvalSquare benchmarks for Power of 2
+ */
+void BGVrns_EvalPo2WithSquare_P65537(benchmark::State& state) {
+    usint ptm                  = 65537;
+    usint depth                = state.range(0);
+    CryptoContext<DCRTPoly> cc = GenerateBGVrnsContext(ptm, depth);
+
+    // KeyGen
+    KeyPair<DCRTPoly> keyPair = cc->KeyGen();
+    cc->EvalMultKeyGen(keyPair.secretKey);
+
+    std::vector<int64_t> vectorOfInts = {1, 0, 0, 1, 0, 0, 1, 1};
+    Plaintext plaintext               = cc->MakePackedPlaintext(vectorOfInts);
+    Ciphertext<DCRTPoly> ciphertext   = cc->Encrypt(keyPair.publicKey, plaintext);
+
+    Ciphertext<DCRTPoly> ciphertextPo2;
+
+    while (state.KeepRunning()) {
+        ciphertextPo2 = cc->EvalSquare(ciphertext);
+        for (usint i = 2; i < depth; ++i) {
+            cc->EvalSquareInPlace(ciphertextPo2);
+        }
+    }
+
+    Plaintext plaintextDec;
+    cc->Decrypt(keyPair.secretKey, ciphertextPo2, &plaintextDec);
+    plaintextDec->SetLength(plaintext->GetLength());
+
+    if (plaintext != plaintextDec) {
+        std::cout << "Original plaintext: " << plaintext << std::endl;
+        std::cout << "Evaluated plaintext: " << plaintextDec << std::endl;
+    }
+}
+
+BENCHMARK(BGVrns_EvalPo2WithSquare_P65537)->Unit(benchmark::kMicrosecond)->Apply(DepthArguments)->MinTime(10.0);
+
+/*
+ * EvalMult benchmarks for Power of 2
+ */
+void BFVrns_EvalPo2WithMult_P65537(benchmark::State& state) {
+    usint ptm                  = 65537;
+    usint depth                = state.range(0);
+    CryptoContext<DCRTPoly> cc = GenerateBFVrnsContext(ptm, depth);
+
+    // KeyGen
+    KeyPair<DCRTPoly> keyPair = cc->KeyGen();
+    cc->EvalMultKeyGen(keyPair.secretKey);
+
+    std::vector<int64_t> vectorOfInts = {1, 0, 0, 1, 0, 0, 1, 1, 0, 0, 0, 0};
+    Plaintext plaintext               = cc->MakePackedPlaintext(vectorOfInts);
+    Ciphertext<DCRTPoly> ciphertext   = cc->Encrypt(keyPair.publicKey, plaintext);
+
+    Ciphertext<DCRTPoly> ciphertextPo2;
+
+    while (state.KeepRunning()) {
+        ciphertextPo2 = cc->EvalMult(ciphertext, ciphertext);
+        for (usint i = 2; i < depth; ++i) {
+            ciphertextPo2 = cc->EvalMult(ciphertextPo2, ciphertextPo2);
+        }
+    }
+
+    Plaintext plaintextDec;
+    cc->Decrypt(keyPair.secretKey, ciphertextPo2, &plaintextDec);
+    plaintextDec->SetLength(plaintext->GetLength());
+
+    if (plaintext != plaintextDec) {
+        std::cout << "Original plaintext: " << plaintext << std::endl;
+        std::cout << "Evaluated plaintext: " << plaintextDec << std::endl;
+    }
+}
+
+BENCHMARK(BFVrns_EvalPo2WithMult_P65537)->Unit(benchmark::kMicrosecond)->Apply(DepthArguments)->MinTime(10.0);
+
+/*
+ * EvalSquare benchmarks for Power of 2
+ */
+void BFVrns_EvalPo2WithSquare_P65537(benchmark::State& state) {
+    usint ptm                  = 65537;
+    usint depth                = state.range(0);
+    CryptoContext<DCRTPoly> cc = GenerateBFVrnsContext(ptm, depth);
+
+    // KeyGen
+    KeyPair<DCRTPoly> keyPair = cc->KeyGen();
+    cc->EvalMultKeyGen(keyPair.secretKey);
+
+    std::vector<int64_t> vectorOfInts = {1, 0, 0, 1, 0, 0, 1, 1, 0, 0, 0, 0};
+    Plaintext plaintext               = cc->MakePackedPlaintext(vectorOfInts);
+    Ciphertext<DCRTPoly> ciphertext   = cc->Encrypt(keyPair.publicKey, plaintext);
+
+    Ciphertext<DCRTPoly> ciphertextPo2;
+
+    while (state.KeepRunning()) {
+        ciphertextPo2 = cc->EvalSquare(ciphertext);
+        for (usint i = 2; i < depth; ++i) {
+            ciphertextPo2 = cc->EvalSquare(ciphertextPo2);
+        }
+    }
+
+    Plaintext plaintextDec;
+    cc->Decrypt(keyPair.secretKey, ciphertextPo2, &plaintextDec);
+    plaintextDec->SetLength(plaintext->GetLength());
+
+    if (plaintext != plaintextDec) {
+        std::cout << "Original plaintext: " << plaintext << std::endl;
+        std::cout << "Evaluated plaintext: " << plaintextDec << std::endl;
+    }
+}
+
+BENCHMARK(BFVrns_EvalPo2WithSquare_P65537)->Unit(benchmark::kMicrosecond)->Apply(DepthArguments)->MinTime(10.0);
+
+BENCHMARK_MAIN();

--- a/src/pke/include/cryptocontext.h
+++ b/src/pke/include/cryptocontext.h
@@ -1740,10 +1740,7 @@ public:
         const auto cryptoParams  = GetCryptoParameters();
         const auto elementParams = cryptoParams->GetElementParams();
         uint32_t m               = elementParams->GetCyclotomicOrder();
-        if (this->getSchemeId() == "CKKSRNS")
-            return FindAutomorphismIndex2nComplex(idx, m);
-        else
-            return FindAutomorphismIndex2n(idx, m);
+        return GetScheme()->FindAutomorphismIndex(idx, m);
     }
 
     std::vector<usint> FindAutomorphismIndices(const std::vector<usint> idxList) const {

--- a/src/pke/include/scheme/bfvrns/bfvrns-leveledshe.h
+++ b/src/pke/include/scheme/bfvrns/bfvrns-leveledshe.h
@@ -35,6 +35,9 @@
 #include "schemerns/rns-leveledshe.h"
 
 #include <string>
+#include <map>
+#include <memory>
+#include <vector>
 
 /**
  * @namespace lbcrypto
@@ -69,9 +72,10 @@ public:
     void EvalSubInPlace(Ciphertext<DCRTPoly>& ciphertext, ConstPlaintext plaintext) const override;
 
     using LeveledSHERNS::EvalMult;
-    //  using LeveledSHERNS::EvalMultInPlace;
-    //  using LeveledSHERNS::EvalMultMutable;
-    //  using LeveledSHERNS::EvalMultMutableInPlace;
+    using LeveledSHERNS::EvalMultInPlace;
+
+    using LeveledSHERNS::EvalSquare;
+    using LeveledSHERNS::EvalSquareInPlace;
 
     /**
    * Virtual function to define the interface for multiplicative homomorphic
@@ -84,7 +88,36 @@ public:
     Ciphertext<DCRTPoly> EvalMult(ConstCiphertext<DCRTPoly> ciphertext1,
                                   ConstCiphertext<DCRTPoly> ciphertext2) const override;
 
+    Ciphertext<DCRTPoly> EvalSquare(ConstCiphertext<DCRTPoly> ciphertext) const override;
+
+    Ciphertext<DCRTPoly> EvalMult(ConstCiphertext<DCRTPoly> ciphertext1, ConstCiphertext<DCRTPoly> ciphertext2,
+                                  const EvalKey<DCRTPoly> evalKey) const override;
+
+    void EvalMultInPlace(Ciphertext<DCRTPoly>& ciphertext1, ConstCiphertext<DCRTPoly> ciphertext2,
+                         const EvalKey<DCRTPoly> evalKey) const override;
+
+    Ciphertext<DCRTPoly> EvalSquare(ConstCiphertext<DCRTPoly> ciphertext,
+                                    const EvalKey<DCRTPoly> evalKey) const override;
+
+    void EvalSquareInPlace(Ciphertext<DCRTPoly>& ciphertext1, const EvalKey<DCRTPoly> evalKey) const override;
+
     void EvalMultCoreInPlace(Ciphertext<DCRTPoly>& ciphertext, const NativeInteger& constant) const;
+
+    /////////////////////////////////////
+    // AUTOMORPHISM
+    /////////////////////////////////////
+
+    Ciphertext<DCRTPoly> EvalAutomorphism(ConstCiphertext<DCRTPoly> ciphertext, usint i,
+                                          const std::map<usint, EvalKey<DCRTPoly>>& evalKeyMap,
+                                          CALLER_INFO_ARGS_HDR) const override;
+
+    Ciphertext<DCRTPoly> EvalFastRotation(ConstCiphertext<DCRTPoly> ciphertext, const usint index, const usint m,
+                                          const std::shared_ptr<std::vector<DCRTPoly>> digits) const override;
+
+    std::shared_ptr<std::vector<DCRTPoly>> EvalFastRotationPrecompute(
+        ConstCiphertext<DCRTPoly> ciphertext) const override;
+
+    usint FindAutomorphismIndex(usint index, usint m) const override;
 
     /////////////////////////////////////
     // SERIALIZATION
@@ -103,6 +136,9 @@ public:
     std::string SerializedObjectName() const {
         return "LeveledSHEBFVRNS";
     }
+
+private:
+    void RelinearizeCore(Ciphertext<DCRTPoly>& ciphertext, const EvalKey<DCRTPoly> evalKey) const;
 };
 }  // namespace lbcrypto
 

--- a/src/pke/include/scheme/bgvrns/bgvrns-leveledshe.h
+++ b/src/pke/include/scheme/bgvrns/bgvrns-leveledshe.h
@@ -46,6 +46,16 @@ class LeveledSHEBGVRNS : public LeveledSHERNS {
 public:
     virtual ~LeveledSHEBGVRNS() {}
 
+    /////////////////////////////////////
+    // AUTOMORPHISM
+    /////////////////////////////////////
+
+    usint FindAutomorphismIndex(usint index, usint m) const override;
+
+    /////////////////////////////////////
+    // Mod Reduce
+    /////////////////////////////////////
+
     /**
    * Method for scaling in-place.
    *

--- a/src/pke/include/scheme/ckksrns/ckksrns-leveledshe.h
+++ b/src/pke/include/scheme/ckksrns/ckksrns-leveledshe.h
@@ -118,6 +118,8 @@ public:
                                              const std::shared_ptr<std::vector<DCRTPoly>> digits, bool addFirst,
                                              const std::map<usint, EvalKey<DCRTPoly>>& evalKeys) const override;
 
+    usint FindAutomorphismIndex(usint index, usint m) const override;
+
     /////////////////////////////////////
     // Mod Reduce
     /////////////////////////////////////

--- a/src/pke/include/schemebase/base-leveledshe.h
+++ b/src/pke/include/schemebase/base-leveledshe.h
@@ -633,6 +633,10 @@ public:
     virtual Ciphertext<Element> EvalAtIndex(ConstCiphertext<Element> ciphertext, int32_t index,
                                             const std::map<usint, EvalKey<Element>>& evalKeyMap) const;
 
+    virtual usint FindAutomorphismIndex(usint index, usint m) const {
+        OPENFHE_THROW(config_error, "FindAutomorphismIndex is not supported for this scheme");
+    }
+
     /////////////////////////////////////////
     // SHE LEVELED Mod Reduce
     /////////////////////////////////////////

--- a/src/pke/include/schemebase/base-scheme.h
+++ b/src/pke/include/schemebase/base-scheme.h
@@ -1216,6 +1216,13 @@ public:
         OPENFHE_THROW(config_error, "EvalAtIndex operation has not been enabled");
     }
 
+    virtual usint FindAutomorphismIndex(usint index, usint m) {
+        if (m_LeveledSHE) {
+            return m_LeveledSHE->FindAutomorphismIndex(index, m);
+        }
+        OPENFHE_THROW(config_error, "FindAutomorphismIndex operation has not been enabled");
+    }
+
     /////////////////////////////////////////
     // SHE Leveled Methods Wrapper
     /////////////////////////////////////////

--- a/src/pke/lib/scheme/bfvrns/bfvrns-leveledshe.cpp
+++ b/src/pke/lib/scheme/bfvrns/bfvrns-leveledshe.cpp
@@ -255,6 +255,7 @@ Ciphertext<DCRTPoly> LeveledSHEBFVRNS::EvalMult(ConstCiphertext<DCRTPoly> cipher
             cryptoParams->GetqInvModr(), cryptoParams->GetModrBarrettMu(), cryptoParams->GetRlHatInvModr(l),
             cryptoParams->GetRlHatInvModrPrecon(l), cryptoParams->GetRlHatModq(l), cryptoParams->GetalphaRlModq(l),
             cryptoParams->GetModqBarrettMu(), cryptoParams->GetrInv());
+
         for (size_t i = 0; i < cv2Size; i++) {
             cv2[i].SetFormat(Format::COEFFICIENT);
             // Switch ciphertext2 from basis Q to P to PQ.
@@ -451,8 +452,6 @@ Ciphertext<DCRTPoly> LeveledSHEBFVRNS::EvalSquare(ConstCiphertext<DCRTPoly> ciph
         }
     }
     else if (cryptoParams->GetMultiplicationTechnique() == HPSPOVERQLEVELED) {
-        cvPoverQ = cv;
-
         size_t cdepth   = ciphertext->GetDepth();
         size_t levels   = cdepth - 1;
         double dcrtBits = cv[0].GetElementAtIndex(0).GetModulus().GetMSB();
@@ -463,6 +462,11 @@ Ciphertext<DCRTPoly> LeveledSHEBFVRNS::EvalSquare(ConstCiphertext<DCRTPoly> ciph
 
         for (size_t i = 0; i < cvSize; i++) {
             cv[i].SetFormat(Format::COEFFICIENT);
+        }
+
+        cvPoverQ = cv;
+
+        for (size_t i = 0; i < cvSize; i++) {
             if (l < sizeQ - 1) {
                 // Drop from basis Q to Q_l.
                 cv[i] =
@@ -484,8 +488,6 @@ Ciphertext<DCRTPoly> LeveledSHEBFVRNS::EvalSquare(ConstCiphertext<DCRTPoly> ciph
             cryptoParams->GetModqBarrettMu(), cryptoParams->GetrInv());
 
         for (size_t i = 0; i < cvSize; i++) {
-            cvPoverQ[i].SetFormat(Format::COEFFICIENT);
-            // Switch ciphertext2 from basis Q to P to PQ.
             cvPoverQ[i].FastExpandCRTBasisPloverQ(basisPQ);
             cvPoverQ[i].SetFormat(Format::EVALUATION);
         }

--- a/src/pke/lib/scheme/bfvrns/bfvrns-leveledshe.cpp
+++ b/src/pke/lib/scheme/bfvrns/bfvrns-leveledshe.cpp
@@ -402,6 +402,318 @@ Ciphertext<DCRTPoly> LeveledSHEBFVRNS::EvalMult(ConstCiphertext<DCRTPoly> cipher
     return ciphertextMult;
 }
 
+Ciphertext<DCRTPoly> LeveledSHEBFVRNS::EvalSquare(ConstCiphertext<DCRTPoly> ciphertext) const {
+    Ciphertext<DCRTPoly> ciphertextSq = ciphertext->CloneEmpty();
+
+    const auto cryptoParams =
+        std::dynamic_pointer_cast<CryptoParametersBFVRNS>(ciphertext->GetCryptoContext()->GetCryptoParameters());
+
+    std::vector<DCRTPoly> cv = ciphertext->GetElements();
+
+    size_t cvSize   = cv.size();
+    size_t cvSqSize = 2 * cvSize - 1;
+    size_t sizeQ    = cv[0].GetNumOfElements();
+    size_t l        = 0;
+
+    std::vector<DCRTPoly> cvPoverQ;
+    if (cryptoParams->GetMultiplicationTechnique() == HPS) {
+        for (size_t i = 0; i < cvSize; i++) {
+            cv[i].ExpandCRTBasis(cryptoParams->GetParamsQlRl(), cryptoParams->GetParamsRl(),
+                                 cryptoParams->GetQlHatInvModq(), cryptoParams->GetQlHatInvModqPrecon(),
+                                 cryptoParams->GetQlHatModr(), cryptoParams->GetalphaQlModr(),
+                                 cryptoParams->GetModrBarrettMu(), cryptoParams->GetqInv(), Format::EVALUATION);
+        }
+    }
+    else if (cryptoParams->GetMultiplicationTechnique() == HPSPOVERQ) {
+        cvPoverQ = cv;
+        for (size_t i = 0; i < cvSize; i++) {
+            // Expand ciphertext1 from basis Q to PQ.
+            cv[i].ExpandCRTBasis(cryptoParams->GetParamsQlRl(sizeQ - 1), cryptoParams->GetParamsRl(sizeQ - 1),
+                                 cryptoParams->GetQlHatInvModq(sizeQ - 1),
+                                 cryptoParams->GetQlHatInvModqPrecon(sizeQ - 1), cryptoParams->GetQlHatModr(sizeQ - 1),
+                                 cryptoParams->GetalphaQlModr(sizeQ - 1), cryptoParams->GetModrBarrettMu(),
+                                 cryptoParams->GetqInv(), Format::EVALUATION);
+        }
+
+        DCRTPoly::CRTBasisExtensionPrecomputations basisPQ(
+            cryptoParams->GetParamsQlRl(sizeQ - 1), cryptoParams->GetParamsRl(sizeQ - 1),
+            cryptoParams->GetParamsQl(sizeQ - 1), cryptoParams->GetmNegRlQHatInvModq(sizeQ - 1),
+            cryptoParams->GetmNegRlQHatInvModqPrecon(sizeQ - 1), cryptoParams->GetqInvModr(),
+            cryptoParams->GetModrBarrettMu(), cryptoParams->GetRlHatInvModr(sizeQ - 1),
+            cryptoParams->GetRlHatInvModrPrecon(sizeQ - 1), cryptoParams->GetRlHatModq(sizeQ - 1),
+            cryptoParams->GetalphaRlModq(sizeQ - 1), cryptoParams->GetModqBarrettMu(), cryptoParams->GetrInv());
+
+        for (size_t i = 0; i < cvSize; i++) {
+            cvPoverQ[i].SetFormat(Format::COEFFICIENT);
+            // Switch ciphertext2 from basis Q to P to PQ.
+            cvPoverQ[i].FastExpandCRTBasisPloverQ(basisPQ);
+            cvPoverQ[i].SetFormat(Format::EVALUATION);
+        }
+    }
+    else if (cryptoParams->GetMultiplicationTechnique() == HPSPOVERQLEVELED) {
+        cvPoverQ = cv;
+
+        size_t cdepth   = ciphertext->GetDepth();
+        size_t levels   = cdepth - 1;
+        double dcrtBits = cv[0].GetElementAtIndex(0).GetModulus().GetMSB();
+
+        // how many levels to drop
+        uint32_t levelsDropped = FindLevelsToDrop(levels, cryptoParams, dcrtBits, false);
+        l                      = levelsDropped > 0 ? sizeQ - 1 - levelsDropped : sizeQ - 1;
+
+        for (size_t i = 0; i < cvSize; i++) {
+            cv[i].SetFormat(Format::COEFFICIENT);
+            if (l < sizeQ - 1) {
+                // Drop from basis Q to Q_l.
+                cv[i] =
+                    cv[i].ScaleAndRound(cryptoParams->GetParamsQl(l), cryptoParams->GetQlQHatInvModqDivqModq(l),
+                                        cryptoParams->GetQlQHatInvModqDivqFrac(l), cryptoParams->GetModqBarrettMu());
+            }
+            // Expand ciphertext1 from basis Q_l to PQ_l.
+            cv[i].ExpandCRTBasis(cryptoParams->GetParamsQlRl(l), cryptoParams->GetParamsRl(l),
+                                 cryptoParams->GetQlHatInvModq(l), cryptoParams->GetQlHatInvModqPrecon(l),
+                                 cryptoParams->GetQlHatModr(l), cryptoParams->GetalphaQlModr(l),
+                                 cryptoParams->GetModrBarrettMu(), cryptoParams->GetqInv(), Format::EVALUATION);
+        }
+
+        DCRTPoly::CRTBasisExtensionPrecomputations basisPQ(
+            cryptoParams->GetParamsQlRl(l), cryptoParams->GetParamsRl(l), cryptoParams->GetParamsQl(l),
+            cryptoParams->GetmNegRlQHatInvModq(l), cryptoParams->GetmNegRlQHatInvModqPrecon(l),
+            cryptoParams->GetqInvModr(), cryptoParams->GetModrBarrettMu(), cryptoParams->GetRlHatInvModr(l),
+            cryptoParams->GetRlHatInvModrPrecon(l), cryptoParams->GetRlHatModq(l), cryptoParams->GetalphaRlModq(l),
+            cryptoParams->GetModqBarrettMu(), cryptoParams->GetrInv());
+
+        for (size_t i = 0; i < cvSize; i++) {
+            cvPoverQ[i].SetFormat(Format::COEFFICIENT);
+            // Switch ciphertext2 from basis Q to P to PQ.
+            cvPoverQ[i].FastExpandCRTBasisPloverQ(basisPQ);
+            cvPoverQ[i].SetFormat(Format::EVALUATION);
+        }
+    }
+    else {
+        for (size_t i = 0; i < cvSize; i++) {
+            cv[i].FastBaseConvqToBskMontgomery(
+                cryptoParams->GetParamsBsk(), cryptoParams->GetModuliQ(), cryptoParams->GetModuliBsk(),
+                cryptoParams->GetModbskBarrettMu(), cryptoParams->GetmtildeQHatInvModq(),
+                cryptoParams->GetmtildeQHatInvModqPrecon(), cryptoParams->GetQHatModbsk(),
+                cryptoParams->GetQHatModmtilde(), cryptoParams->GetQModbsk(), cryptoParams->GetQModbskPrecon(),
+                cryptoParams->GetNegQInvModmtilde(), cryptoParams->GetmtildeInvModbsk(),
+                cryptoParams->GetmtildeInvModbskPrecon());
+
+            cv[i].SetFormat(Format::EVALUATION);
+        }
+    }
+
+    std::vector<DCRTPoly> cvSquare(cvSqSize);
+#ifdef USE_KARATSUBA
+    if (cvSize == 2) {
+        if (cryptoParams->GetMultiplicationTechnique() == HPS || cryptoParams->GetMultiplicationTechnique() == BEHZ) {
+            // size of each ciphertxt = 2, use Karatsuba
+            cvSquare[0] = cv[0] * cv[0];  // a
+            cvSquare[2] = cv[1] * cv[1];  // b
+
+            cvSquare[1] = cv1[0] * cv1[1];
+            cvSquare[1] += cvSquare[1];
+        }
+        else {
+            // size of each ciphertxt = 2, use Karatsuba
+            cvSquare[0] = cv[0] * cvPoverQ[0];  // a
+            cvSquare[2] = cv[1] * cvPoverQ[1];  // b
+
+            cvSquare[1] = cv[0] + cv[1];
+            cvSquare[1] *= (cvPoverQ[0] + cvPoverQ[1]);
+            cvSquare[1] -= cvSquare[2];
+            cvSquare[1] -= cvSquare[0];
+        }
+    }
+    else {
+        std::vector<bool> isFirstAdd(cvSqSize, true);
+        DCRTPoly cvtemp;
+
+        if (cryptoParams->GetMultiplicationTechnique() == HPS || cryptoParams->GetMultiplicationTechnique() == BEHZ) {
+            for (size_t i = 0; i < cv.size(); i++) {
+                for (size_t j = i; j < cv.size(); j++) {
+                    if (isFirstAdd[i + j] == true) {
+                        if (j == i) {
+                            cvSquare[i + j] = cv[i] * cv[j];
+                        }
+                        else {
+                            cvtemp          = cv[i] * cv[j];
+                            cvSquare[i + j] = cvtemp;
+                            cvSquare[i + j] += cvtemp;
+                        }
+                        isFirstAdd[i + j] = false;
+                    }
+                    else {
+                        if (j == i) {
+                            cvSquare[i + j] += cv[i] * cv[j];
+                        }
+                        else {
+                            cvtemp = cv[i] * cv[j];
+                            cvSquare[i + j] += cvtemp;
+                            cvSquare[i + j] += cvtemp;
+                        }
+                    }
+                }
+            }
+        }
+        else {
+            for (size_t i = 0; i < cvSize; i++) {
+                for (size_t j = 0; j < cvSize; j++) {
+                    if (isFirstAdd[i + j] == true) {
+                        cvSquare[i + j]   = cv[i] * cvPoverQ[j];
+                        isFirstAdd[i + j] = false;
+                    }
+                    else {
+                        cvSquare[i + j] += cv[i] * cvPoverQ[j];
+                    }
+                }
+            }
+        }
+    }
+#else
+    std::vector<bool> isFirstAdd(cvSqSize, true);
+    DCRTPoly cvtemp;
+
+    if (cryptoParams->GetMultiplicationTechnique() == HPS || cryptoParams->GetMultiplicationTechnique() == BEHZ) {
+        for (size_t i = 0; i < cv.size(); i++) {
+            for (size_t j = i; j < cv.size(); j++) {
+                if (isFirstAdd[i + j] == true) {
+                    if (j == i) {
+                        cvSquare[i + j] = cv[i] * cv[j];
+                    }
+                    else {
+                        cvtemp          = cv[i] * cv[j];
+                        cvSquare[i + j] = cvtemp;
+                        cvSquare[i + j] += cvtemp;
+                    }
+                    isFirstAdd[i + j] = false;
+                }
+                else {
+                    if (j == i) {
+                        cvSquare[i + j] += cv[i] * cv[j];
+                    }
+                    else {
+                        cvtemp = cv[i] * cv[j];
+                        cvSquare[i + j] += cvtemp;
+                        cvSquare[i + j] += cvtemp;
+                    }
+                }
+            }
+        }
+    }
+    else {
+        for (size_t i = 0; i < cvSize; i++) {
+            for (size_t j = 0; j < cvSize; j++) {
+                if (isFirstAdd[i + j] == true) {
+                    cvSquare[i + j]   = cv[i] * cvPoverQ[j];
+                    isFirstAdd[i + j] = false;
+                }
+                else {
+                    cvSquare[i + j] += cv[i] * cvPoverQ[j];
+                }
+            }
+        }
+    }
+#endif
+
+    if (cryptoParams->GetMultiplicationTechnique() == HPS) {
+        for (size_t i = 0; i < cvSqSize; i++) {
+            // converts to coefficient representation before rounding
+            cvSquare[i].SetFormat(Format::COEFFICIENT);
+            // Performs the scaling by t/Q followed by rounding; the result is in the
+            // CRT basis P
+            cvSquare[i] =
+                cvSquare[i].ScaleAndRound(cryptoParams->GetParamsRl(), cryptoParams->GettRSHatInvModsDivsModr(),
+                                          cryptoParams->GettRSHatInvModsDivsFrac(), cryptoParams->GetModrBarrettMu());
+
+            // Converts from the CRT basis P to Q
+            cvSquare[i] = cvSquare[i].SwitchCRTBasis(cryptoParams->GetElementParams(), cryptoParams->GetRlHatInvModr(),
+                                                     cryptoParams->GetRlHatInvModrPrecon(),
+                                                     cryptoParams->GetRlHatModq(), cryptoParams->GetalphaRlModq(),
+                                                     cryptoParams->GetModqBarrettMu(), cryptoParams->GetrInv());
+        }
+    }
+    else if (cryptoParams->GetMultiplicationTechnique() == HPSPOVERQ) {
+        for (size_t i = 0; i < cvSqSize; i++) {
+            cvSquare[i].SetFormat(COEFFICIENT);
+            // Performs the scaling by t/P followed by rounding; the result is in the
+            // CRT basis Q
+            cvSquare[i] = cvSquare[i].ScaleAndRound(
+                cryptoParams->GetElementParams(), cryptoParams->GettQlSlHatInvModsDivsModq(0),
+                cryptoParams->GettQlSlHatInvModsDivsFrac(0), cryptoParams->GetModqBarrettMu());
+        }
+    }
+    else if (cryptoParams->GetMultiplicationTechnique() == HPSPOVERQLEVELED) {
+        for (size_t i = 0; i < cvSqSize; i++) {
+            cvSquare[i].SetFormat(COEFFICIENT);
+            // Performs the scaling by t/P followed by rounding; the result is in the
+            // CRT basis Q
+            cvSquare[i] = cvSquare[i].ScaleAndRound(
+                cryptoParams->GetParamsQl(l), cryptoParams->GettQlSlHatInvModsDivsModq(l),
+                cryptoParams->GettQlSlHatInvModsDivsFrac(l), cryptoParams->GetModqBarrettMu());
+
+            if (l < sizeQ - 1) {
+                // Expand back to basis Q.
+                cvSquare[i].ExpandCRTBasisQlHat(cryptoParams->GetElementParams(), cryptoParams->GetQlHatModq(l),
+                                                cryptoParams->GetQlHatModqPrecon(l), sizeQ);
+            }
+        }
+    }
+    else {
+        const NativeInteger& t = cryptoParams->GetPlaintextModulus();
+        for (size_t i = 0; i < cvSqSize; i++) {
+            // converts to Format::COEFFICIENT representation before rounding
+            cvSquare[i].SetFormat(Format::COEFFICIENT);
+            // Performs the scaling by t/Q followed by rounding; the result is in the
+            // CRT basis {Bsk}
+            cvSquare[i].FastRNSFloorq(
+                t, cryptoParams->GetModuliQ(), cryptoParams->GetModuliBsk(), cryptoParams->GetModbskBarrettMu(),
+                cryptoParams->GettQHatInvModq(), cryptoParams->GettQHatInvModqPrecon(), cryptoParams->GetQHatModbsk(),
+                cryptoParams->GetqInvModbsk(), cryptoParams->GettQInvModbsk(), cryptoParams->GettQInvModbskPrecon());
+
+            // Converts from the CRT basis {Bsk} to {Q}
+            cvSquare[i].FastBaseConvSK(cryptoParams->GetElementParams(), cryptoParams->GetModqBarrettMu(),
+                                       cryptoParams->GetModuliBsk(), cryptoParams->GetModbskBarrettMu(),
+                                       cryptoParams->GetBHatInvModb(), cryptoParams->GetBHatInvModbPrecon(),
+                                       cryptoParams->GetBHatModmsk(), cryptoParams->GetBInvModmsk(),
+                                       cryptoParams->GetBInvModmskPrecon(), cryptoParams->GetBHatModq(),
+                                       cryptoParams->GetBModq(), cryptoParams->GetBModqPrecon());
+        }
+    }
+
+    ciphertextSq->SetElements(std::move(cvSquare));
+    ciphertextSq->SetDepth(ciphertext->GetDepth() + 1);
+
+    return ciphertextSq;
+}
+
+Ciphertext<DCRTPoly> LeveledSHEBFVRNS::EvalMult(ConstCiphertext<DCRTPoly> ciphertext1,
+                                                ConstCiphertext<DCRTPoly> ciphertext2,
+                                                const EvalKey<DCRTPoly> evalKey) const {
+    Ciphertext<DCRTPoly> ciphertext = EvalMult(ciphertext1, ciphertext2);
+    RelinearizeCore(ciphertext, evalKey);
+    return ciphertext;
+}
+
+void LeveledSHEBFVRNS::EvalMultInPlace(Ciphertext<DCRTPoly>& ciphertext1, ConstCiphertext<DCRTPoly> ciphertext2,
+                                       const EvalKey<DCRTPoly> evalKey) const {
+    ciphertext1 = EvalMult(ciphertext1, ciphertext2);
+    RelinearizeCore(ciphertext1, evalKey);
+}
+
+Ciphertext<DCRTPoly> LeveledSHEBFVRNS::EvalSquare(ConstCiphertext<DCRTPoly> ciphertext,
+                                                  const EvalKey<DCRTPoly> evalKey) const {
+    Ciphertext<DCRTPoly> csquare = EvalSquare(ciphertext);
+    RelinearizeCore(csquare, evalKey);
+    return csquare;
+}
+
+void LeveledSHEBFVRNS::EvalSquareInPlace(Ciphertext<DCRTPoly>& ciphertext, const EvalKey<DCRTPoly> evalKey) const {
+    ciphertext = EvalSquare(ciphertext);
+    RelinearizeCore(ciphertext, evalKey);
+}
+
 void LeveledSHEBFVRNS::EvalMultCoreInPlace(Ciphertext<DCRTPoly>& ciphertext, const NativeInteger& constant) const {
     const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersBFVRNS>(ciphertext->GetCryptoParameters());
 
@@ -412,6 +724,166 @@ void LeveledSHEBFVRNS::EvalMultCoreInPlace(Ciphertext<DCRTPoly>& ciphertext, con
     const NativeInteger t(cryptoParams->GetPlaintextModulus());
 
     ciphertext->SetDepth(ciphertext->GetDepth() + 1);
+}
+
+Ciphertext<DCRTPoly> LeveledSHEBFVRNS::EvalAutomorphism(ConstCiphertext<DCRTPoly> ciphertext, usint i,
+                                                        const std::map<usint, EvalKey<DCRTPoly>>& evalKeyMap,
+                                                        CALLER_INFO_ARGS_CPP) const {
+    const std::vector<DCRTPoly>& cv = ciphertext->GetElements();
+
+    usint N = cv[0].GetRingDimension();
+
+    std::vector<usint> vec(N);
+    PrecomputeAutoMap(N, i, &vec);
+
+    auto algo = ciphertext->GetCryptoContext()->GetScheme();
+
+    Ciphertext<DCRTPoly> result = ciphertext->Clone();
+
+    RelinearizeCore(result, evalKeyMap.at(i));
+
+    std::vector<DCRTPoly>& rcv = result->GetElements();
+
+    rcv[0] = rcv[0].AutomorphismTransform(i, vec);
+    rcv[1] = rcv[1].AutomorphismTransform(i, vec);
+
+    return result;
+}
+
+std::shared_ptr<std::vector<DCRTPoly>> LeveledSHEBFVRNS::EvalFastRotationPrecompute(
+    ConstCiphertext<DCRTPoly> ciphertext) const {
+    const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersBFVRNS>(ciphertext->GetCryptoParameters());
+    auto algo               = ciphertext->GetCryptoContext()->GetScheme();
+    std::shared_ptr<std::vector<DCRTPoly>> digits;
+
+    if (cryptoParams->GetMultiplicationTechnique() == HPSPOVERQLEVELED) {
+        digits = algo->EvalKeySwitchPrecomputeCore(ciphertext->GetElements()[1], ciphertext->GetCryptoParameters());
+    }
+    else {
+        DCRTPoly c1     = ciphertext->GetElements()[1];
+        size_t levels   = ciphertext->GetDepth() - 1;
+        size_t sizeQ    = c1.GetNumOfElements();
+        double dcrtBits = c1.GetElementAtIndex(0).GetModulus().GetMSB();
+        // how many levels to drop
+        uint32_t levelsDropped = FindLevelsToDrop(levels, cryptoParams, dcrtBits, false);
+        uint32_t l             = levelsDropped > 0 ? sizeQ - 1 - levelsDropped : sizeQ - 1;
+        c1.SetFormat(COEFFICIENT);
+        c1 = c1.ScaleAndRound(cryptoParams->GetParamsQl(l), cryptoParams->GetQlQHatInvModqDivqModq(l),
+                              cryptoParams->GetQlQHatInvModqDivqFrac(l), cryptoParams->GetModqBarrettMu());
+
+        digits = algo->EvalKeySwitchPrecomputeCore(c1, ciphertext->GetCryptoParameters());
+    }
+
+    return digits;
+}
+
+Ciphertext<DCRTPoly> LeveledSHEBFVRNS::EvalFastRotation(ConstCiphertext<DCRTPoly> ciphertext, const usint index,
+                                                        const usint m,
+                                                        const std::shared_ptr<std::vector<DCRTPoly>> digits) const {
+    if (index == 0) {
+        Ciphertext<DCRTPoly> result = ciphertext->Clone();
+        return result;
+    }
+
+    const auto cc = ciphertext->GetCryptoContext();
+
+    usint autoIndex = FindAutomorphismIndex(index, m);
+
+    auto evalKey = cc->GetEvalAutomorphismKeyMap(ciphertext->GetKeyTag()).find(autoIndex)->second;
+
+    auto algo                       = cc->GetScheme();
+    const std::vector<DCRTPoly>& cv = ciphertext->GetElements();
+
+    std::shared_ptr<std::vector<DCRTPoly>> ba = algo->EvalFastKeySwitchCore(digits, evalKey, cv[0].GetParams());
+
+    const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersBFVRNS>(ciphertext->GetCryptoParameters());
+
+    if (cryptoParams->GetMultiplicationTechnique() == HPSPOVERQLEVELED) {
+        size_t levels   = ciphertext->GetDepth() - 1;
+        size_t sizeQ    = cv[0].GetNumOfElements();
+        double dcrtBits = cv[0].GetElementAtIndex(0).GetModulus().GetMSB();
+        // how many levels to drop
+        uint32_t levelsDropped = FindLevelsToDrop(levels, cryptoParams, dcrtBits, false);
+        uint32_t l             = levelsDropped > 0 ? sizeQ - 1 - levelsDropped : sizeQ - 1;
+
+        (*ba)[0].ExpandCRTBasisQlHat(cryptoParams->GetElementParams(), cryptoParams->GetQlHatModq(l),
+                                     cryptoParams->GetQlHatModqPrecon(l), sizeQ);
+        (*ba)[1].ExpandCRTBasisQlHat(cryptoParams->GetElementParams(), cryptoParams->GetQlHatModq(l),
+                                     cryptoParams->GetQlHatModqPrecon(l), sizeQ);
+    }
+
+    usint N = cryptoParams->GetElementParams()->GetRingDimension();
+    std::vector<usint> vec(N);
+    PrecomputeAutoMap(N, autoIndex, &vec);
+
+    (*ba)[0] += cv[0];
+
+    (*ba)[0] = (*ba)[0].AutomorphismTransform(autoIndex, vec);
+    (*ba)[1] = (*ba)[1].AutomorphismTransform(autoIndex, vec);
+
+    Ciphertext<DCRTPoly> result = ciphertext->Clone();
+
+    result->SetElements({std::move((*ba)[0]), std::move((*ba)[1])});
+
+    return result;
+}
+
+usint LeveledSHEBFVRNS::FindAutomorphismIndex(usint index, usint m) const {
+    return FindAutomorphismIndex2n(index, m);
+}
+
+void LeveledSHEBFVRNS::RelinearizeCore(Ciphertext<DCRTPoly>& ciphertext, const EvalKey<DCRTPoly> evalKey) const {
+    const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersBFVRNS>(ciphertext->GetCryptoParameters());
+    uint32_t l              = 0;
+
+    std::vector<DCRTPoly>& cv = ciphertext->GetElements();
+
+    auto algo = ciphertext->GetCryptoContext()->GetScheme();
+
+    if (cryptoParams->GetMultiplicationTechnique() == HPSPOVERQLEVELED) {
+        size_t levels   = ciphertext->GetDepth() - 1;
+        size_t sizeQ    = cv[0].GetNumOfElements();
+        double dcrtBits = cv[0].GetElementAtIndex(0).GetModulus().GetMSB();
+
+        // how many levels to drop
+        uint32_t levelsDropped = FindLevelsToDrop(levels, cryptoParams, dcrtBits, false);
+        l                      = levelsDropped > 0 ? sizeQ - 1 - levelsDropped : sizeQ - 1;
+        if (cv.size() == 2) {
+            cv[1].SetFormat(COEFFICIENT);
+            cv[1] = cv[1].ScaleAndRound(cryptoParams->GetParamsQl(l), cryptoParams->GetQlQHatInvModqDivqModq(l),
+                                        cryptoParams->GetQlQHatInvModqDivqFrac(l), cryptoParams->GetModqBarrettMu());
+        }
+        else {
+            cv[2].SetFormat(COEFFICIENT);
+            cv[2] = cv[2].ScaleAndRound(cryptoParams->GetParamsQl(l), cryptoParams->GetQlQHatInvModqDivqModq(l),
+                                        cryptoParams->GetQlQHatInvModqDivqFrac(l), cryptoParams->GetModqBarrettMu());
+        }
+    }
+
+    for (auto& c : cv)
+        c.SetFormat(Format::EVALUATION);
+
+    std::shared_ptr<std::vector<DCRTPoly>> ab =
+        (cv.size() == 2) ? algo->KeySwitchCore(cv[1], evalKey) : algo->KeySwitchCore(cv[2], evalKey);
+
+    if (cryptoParams->GetMultiplicationTechnique() == HPSPOVERQLEVELED) {
+        size_t sizeQ = cv[0].GetNumOfElements();
+        (*ab)[0].ExpandCRTBasisQlHat(cryptoParams->GetElementParams(), cryptoParams->GetQlHatModq(l),
+                                     cryptoParams->GetQlHatModqPrecon(l), sizeQ);
+        (*ab)[1].ExpandCRTBasisQlHat(cryptoParams->GetElementParams(), cryptoParams->GetQlHatModq(l),
+                                     cryptoParams->GetQlHatModqPrecon(l), sizeQ);
+    }
+
+    cv[0] += (*ab)[0];
+
+    if (cv.size() > 2) {
+        cv[1] += (*ab)[1];
+    }
+    else {
+        cv[1] = (*ab)[1];
+    }
+
+    cv.resize(2);
 }
 
 }  // namespace lbcrypto

--- a/src/pke/lib/scheme/bfvrns/bfvrns-leveledshe.cpp
+++ b/src/pke/lib/scheme/bfvrns/bfvrns-leveledshe.cpp
@@ -38,6 +38,7 @@ BFV implementation. See https://eprint.iacr.org/2021/204 for details.
 #include "scheme/bfvrns/bfvrns-leveledshe.h"
 
 #include "scheme/bfvrns/bfvrns-cryptoparameters.h"
+#include "schemebase/base-scheme.h"
 #include "cryptocontext.h"
 #include "ciphertext.h"
 

--- a/src/pke/lib/scheme/bfvrns/bfvrns-leveledshe.cpp
+++ b/src/pke/lib/scheme/bfvrns/bfvrns-leveledshe.cpp
@@ -177,7 +177,8 @@ Ciphertext<DCRTPoly> LeveledSHEBFVRNS::EvalMult(ConstCiphertext<DCRTPoly> cipher
     size_t cv2Size    = cv2.size();
     size_t cvMultSize = cv1Size + cv2Size - 1;
     size_t sizeQ      = cv1[0].GetNumOfElements();
-    size_t l          = 0;
+    // l is index correspinding to leveled parameters in cryptoParameters precomputations in HPSPOVERQLEVELED
+    size_t l = 0;
 
     std::vector<DCRTPoly> cvMult(cvMultSize);
 
@@ -414,7 +415,8 @@ Ciphertext<DCRTPoly> LeveledSHEBFVRNS::EvalSquare(ConstCiphertext<DCRTPoly> ciph
     size_t cvSize   = cv.size();
     size_t cvSqSize = 2 * cvSize - 1;
     size_t sizeQ    = cv[0].GetNumOfElements();
-    size_t l        = 0;
+    // l is index correspinding to leveled parameters in cryptoParameters precomputations in HPSPOVERQLEVELED
+    size_t l = 0;
 
     std::vector<DCRTPoly> cvPoverQ;
     if (cryptoParams->GetMultiplicationTechnique() == HPS) {
@@ -767,7 +769,8 @@ std::shared_ptr<std::vector<DCRTPoly>> LeveledSHEBFVRNS::EvalFastRotationPrecomp
     double dcrtBits = c1.GetElementAtIndex(0).GetModulus().GetMSB();
     // how many levels to drop
     uint32_t levelsDropped = FindLevelsToDrop(levels, cryptoParams, dcrtBits, true);
-    uint32_t l             = levelsDropped > 0 ? sizeQ - 1 - levelsDropped : sizeQ - 1;
+    // l is index correspinding to leveled parameters in cryptoParameters precomputations in HPSPOVERQLEVELED
+    uint32_t l = levelsDropped > 0 ? sizeQ - 1 - levelsDropped : sizeQ - 1;
     c1.SetFormat(COEFFICIENT);
     c1 = c1.ScaleAndRound(cryptoParams->GetParamsQl(l), cryptoParams->GetQlQHatInvModqDivqModq(l),
                           cryptoParams->GetQlQHatInvModqDivqFrac(l), cryptoParams->GetModqBarrettMu());
@@ -801,7 +804,8 @@ Ciphertext<DCRTPoly> LeveledSHEBFVRNS::EvalFastRotation(ConstCiphertext<DCRTPoly
         double dcrtBits = cv[0].GetElementAtIndex(0).GetModulus().GetMSB();
         // how many levels to drop
         uint32_t levelsDropped = FindLevelsToDrop(levels, cryptoParams, dcrtBits, true);
-        uint32_t l             = levelsDropped > 0 ? sizeQ - 1 - levelsDropped : sizeQ - 1;
+        // l is index correspinding to leveled parameters in cryptoParameters precomputations in HPSPOVERQLEVELED
+        uint32_t l = levelsDropped > 0 ? sizeQ - 1 - levelsDropped : sizeQ - 1;
 
         (*ba)[0].ExpandCRTBasisQlHat(cryptoParams->GetElementParams(), cryptoParams->GetQlHatModq(l),
                                      cryptoParams->GetQlHatModqPrecon(l), sizeQ);
@@ -831,7 +835,8 @@ usint LeveledSHEBFVRNS::FindAutomorphismIndex(usint index, usint m) const {
 
 void LeveledSHEBFVRNS::RelinearizeCore(Ciphertext<DCRTPoly>& ciphertext, const EvalKey<DCRTPoly> evalKey) const {
     const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersBFVRNS>(ciphertext->GetCryptoParameters());
-    uint32_t l              = 0;
+    // l is index correspinding to leveled parameters in cryptoParameters precomputations in HPSPOVERQLEVELED
+    uint32_t l = 0;
 
     std::vector<DCRTPoly>& cv = ciphertext->GetElements();
     bool isKeySwitch          = (cv.size() == 2);

--- a/src/pke/lib/scheme/bgvrns/bgvrns-leveledshe.cpp
+++ b/src/pke/lib/scheme/bgvrns/bgvrns-leveledshe.cpp
@@ -248,4 +248,8 @@ void LeveledSHEBGVRNS::EvalMultCoreInPlace(Ciphertext<DCRTPoly>& ciphertext, con
     }
 }
 
+usint LeveledSHEBGVRNS::FindAutomorphismIndex(usint index, usint m) const {
+    return FindAutomorphismIndex2n(index, m);
+}
+
 }  // namespace lbcrypto

--- a/src/pke/lib/scheme/ckksrns/ckksrns-leveledshe.cpp
+++ b/src/pke/lib/scheme/ckksrns/ckksrns-leveledshe.cpp
@@ -224,10 +224,10 @@ std::vector<DCRTPoly::Integer> LeveledSHECKKSRNS::GetElementForEvalAddOrSub(Cons
     }
 
     // Compute approxFactor, a value to scale down by, in case the value exceeds a 64-bit integer.
-    int32_t logSF    = static_cast<int32_t>(ceil(log2(fabs(scFactor))));
-    int32_t logValid = (logSF <= LargeScalingFactorConstants::MAX_BITS_IN_WORD) ?
-                           logSF :
-                           LargeScalingFactorConstants::MAX_BITS_IN_WORD;
+    int32_t logSF       = static_cast<int32_t>(ceil(log2(fabs(scFactor))));
+    int32_t logValid    = (logSF <= LargeScalingFactorConstants::MAX_BITS_IN_WORD) ?
+                              logSF :
+                              LargeScalingFactorConstants::MAX_BITS_IN_WORD;
     int32_t logApprox   = logSF - logValid;
     double approxFactor = pow(2, logApprox);
 
@@ -236,17 +236,17 @@ std::vector<DCRTPoly::Integer> LeveledSHECKKSRNS::GetElementForEvalAddOrSub(Cons
 
     // Scale back up by approxFactor within the CRT multiplications.
     if (logApprox > 0) {
-        int32_t logStep = (logApprox <= LargeScalingFactorConstants::MAX_LOG_STEP) ?
-                              logApprox :
-                              LargeScalingFactorConstants::MAX_LOG_STEP;
+        int32_t logStep           = (logApprox <= LargeScalingFactorConstants::MAX_LOG_STEP) ?
+                                        logApprox :
+                                        LargeScalingFactorConstants::MAX_LOG_STEP;
         DCRTPoly::Integer intStep = uint64_t(1) << logStep;
         std::vector<DCRTPoly::Integer> crtApprox(sizeQl, intStep);
         logApprox -= logStep;
 
         while (logApprox > 0) {
-            int32_t logStep = (logApprox <= LargeScalingFactorConstants::MAX_LOG_STEP) ?
-                                  logApprox :
-                                  LargeScalingFactorConstants::MAX_LOG_STEP;
+            int32_t logStep           = (logApprox <= LargeScalingFactorConstants::MAX_LOG_STEP) ?
+                                            logApprox :
+                                            LargeScalingFactorConstants::MAX_LOG_STEP;
             DCRTPoly::Integer intStep = uint64_t(1) << logStep;
             std::vector<DCRTPoly::Integer> crtSF(sizeQl, intStep);
             crtApprox = CKKSPackedEncoding::CRTMult(crtApprox, crtSF, moduli);
@@ -372,17 +372,17 @@ std::vector<DCRTPoly::Integer> LeveledSHECKKSRNS::GetElementForEvalMult(ConstCip
 
     // Scale back up by approxFactor within the CRT multiplications.
     if (logApprox > 0) {
-        int32_t logStep = (logApprox <= LargeScalingFactorConstants::MAX_LOG_STEP) ?
-                              logApprox :
-                              LargeScalingFactorConstants::MAX_LOG_STEP;
+        int32_t logStep           = (logApprox <= LargeScalingFactorConstants::MAX_LOG_STEP) ?
+                                        logApprox :
+                                        LargeScalingFactorConstants::MAX_LOG_STEP;
         DCRTPoly::Integer intStep = uint64_t(1) << logStep;
         std::vector<DCRTPoly::Integer> crtApprox(numTowers, intStep);
         logApprox -= logStep;
 
         while (logApprox > 0) {
-            int32_t logStep = (logApprox <= LargeScalingFactorConstants::MAX_LOG_STEP) ?
-                                  logApprox :
-                                  LargeScalingFactorConstants::MAX_LOG_STEP;
+            int32_t logStep           = (logApprox <= LargeScalingFactorConstants::MAX_LOG_STEP) ?
+                                            logApprox :
+                                            LargeScalingFactorConstants::MAX_LOG_STEP;
             DCRTPoly::Integer intStep = uint64_t(1) << logStep;
             std::vector<DCRTPoly::Integer> crtSF(numTowers, intStep);
             crtApprox = CKKSPackedEncoding::CRTMult(crtApprox, crtSF, moduli);
@@ -620,6 +620,10 @@ void LeveledSHECKKSRNS::EvalMultCoreInPlace(Ciphertext<DCRTPoly>& ciphertext, do
 
     double scFactor = cryptoParams->GetScalingFactorReal(ciphertext->GetLevel());
     ciphertext->SetScalingFactor(ciphertext->GetScalingFactor() * scFactor);
+}
+
+usint LeveledSHECKKSRNS::FindAutomorphismIndex(usint index, usint m) const {
+    return FindAutomorphismIndex2nComplex(index, m);
 }
 
 }  // namespace lbcrypto

--- a/src/pke/lib/schemebase/base-leveledshe.cpp
+++ b/src/pke/lib/schemebase/base-leveledshe.cpp
@@ -473,8 +473,7 @@ Ciphertext<Element> LeveledSHEBase<Element>::EvalFastRotation(
 
     const auto cc = ciphertext->GetCryptoContext();
 
-    usint autoIndex =
-        (cc->getSchemeId() == "CKKSRNS") ? FindAutomorphismIndex2nComplex(index, m) : FindAutomorphismIndex2n(index, m);
+    usint autoIndex = FindAutomorphismIndex(index, m);
 
     auto evalKey = cc->GetEvalAutomorphismKeyMap(ciphertext->GetKeyTag()).find(autoIndex)->second;
 
@@ -511,8 +510,7 @@ std::shared_ptr<std::map<usint, EvalKey<Element>>> LeveledSHEBase<Element>::Eval
 
     std::vector<uint32_t> autoIndices(indexList.size());
     for (size_t i = 0; i < indexList.size(); i++) {
-        autoIndices[i] = (cc->getSchemeId() == "CKKSRNS") ? FindAutomorphismIndex2nComplex(indexList[i], M) :
-                                                            FindAutomorphismIndex2n(indexList[i], M);
+        autoIndices[i] = FindAutomorphismIndex(indexList[i], M);
     }
 
     return EvalAutomorphismKeyGen(privateKey, autoIndices);
@@ -525,8 +523,7 @@ Ciphertext<Element> LeveledSHEBase<Element>::EvalAtIndex(ConstCiphertext<Element
 
     usint M = ciphertext->GetCryptoParameters()->GetElementParams()->GetCyclotomicOrder();
 
-    uint32_t autoIndex =
-        (cc->getSchemeId() == "CKKSRNS") ? FindAutomorphismIndex2nComplex(index, M) : FindAutomorphismIndex2n(index, M);
+    uint32_t autoIndex = FindAutomorphismIndex(index, M);
 
     return EvalAutomorphism(ciphertext, autoIndex, evalKeyMap);
 }


### PR DESCRIPTION
1) Added Leveled Hybrid Key Switching:
Now in HPSPOVERQLEVELED we also drop levels at KeySwitch step. 

2) Added EvalSquare
Added implementation of EvalSquare for BFV scheme. Previously EvalSquare was working only for CKKS and BGV scheme
Added benchmark mult-vs-square which evaluates Enc(x^{2^k}) using EvalMult and EvalSquare. 
EvalSquare is 10-20% faster.

3) Refactored Rotation indexes
change check (cc->getSchemeId() == "CKKSRNS") from base-leveledshe.cpp in Automorphism methods and instead added FindAutomorphismIndex method for each scheme.
