### PR TITLE
PRE changes for noise flooding

### DIFF
--- a/src/pke/include/constants.h
+++ b/src/pke/include/constants.h
@@ -149,7 +149,7 @@ const double MP_SD = 1048576;
 // noise flooding distribution parameter for fixed 20 bits noise multihop PRE
 const double PRE_SD = 1048576;
 // statistical security parameter for noise flooding in PRE
-const double STAT_SECURITY = 30;
+const double STAT_SECURITY = 32;
 // number of additional moduli in NOISE_FLOODING_MULTIPARTY mode
 const size_t NUM_MODULI_MULTIPARTY = 2;
 // modulus size for additional moduli in NOISE_FLOODING_MULTIPARTY mode

--- a/src/pke/include/scheme/bgvrns/bgvrns-cryptoparameters.h
+++ b/src/pke/include/scheme/bgvrns/bgvrns-cryptoparameters.h
@@ -66,10 +66,15 @@ public:
                            SecretKeyDist secretKeyDist, int maxRelinSkDeg = 2, KeySwitchTechnique ksTech = BV,
                            ScalingTechnique scalTech = FIXEDMANUAL, EncryptionTechnique encTech = STANDARD,
                            MultiplicationTechnique multTech = HPS, ProxyReEncryptionMode PREMode = NOT_SET,
-                           MultipartyMode multipartyMode = FIXED_NOISE_MULTIPARTY)
+                           MultipartyMode multipartyMode           = FIXED_NOISE_MULTIPARTY,
+                           ExecutionMode executionMode             = EXEC_EVALUATION,
+                           DecryptionNoiseMode decryptionNoiseMode = FIXED_NOISE_DECRYPT,
+                           PlaintextModulus noiseScale = 1, double statisticalSecurity = 30,
+                           double numAdversarialQueries = 1)
         : CryptoParametersRNS(params, encodingParams, distributionParameter, assuranceMeasure, securityLevel, digitSize,
                               secretKeyDist, maxRelinSkDeg, ksTech, scalTech, encTech, multTech, PREMode,
-                              multipartyMode) {}
+                              multipartyMode, executionMode, decryptionNoiseMode, noiseScale, statisticalSecurity,
+                              numAdversarialQueries) {}
 
     virtual ~CryptoParametersBGVRNS() {}
 

--- a/src/pke/include/scheme/bgvrns/gen-cryptocontext-bgvrns-internal.h
+++ b/src/pke/include/scheme/bgvrns/gen-cryptocontext-bgvrns-internal.h
@@ -74,7 +74,12 @@ typename ContextGeneratorType::ContextType genCryptoContextBGVRNSInternal(
         parameters.GetEncryptionTechnique(),
         parameters.GetMultiplicationTechnique(),
         parameters.GetPREMode(),
-        parameters.GetMultipartyMode());
+        parameters.GetMultipartyMode(),
+        parameters.GetExecutionMode(),
+        parameters.GetDecryptionNoiseMode(),
+        parameters.GetPlaintextModulus(),
+        parameters.GetStatisticalSecurity(),
+        parameters.GetNumAdversarialQueries());
 
     // for BGV scheme noise scale is always set to plaintext modulus
     params->SetNoiseScale(parameters.GetPlaintextModulus());

--- a/src/pke/include/schemebase/base-pke.h
+++ b/src/pke/include/schemebase/base-pke.h
@@ -136,8 +136,7 @@ public:
                                                                    const std::shared_ptr<ParmType> params) const;
 
     virtual std::shared_ptr<std::vector<Element> > EncryptZeroCore(const PublicKey<Element> publicKey,
-                                                                   const std::shared_ptr<ParmType> params,
-                                                                   const DggType& dgg) const;
+                                                                   const std::shared_ptr<ParmType> params) const;
 
     virtual Element DecryptCore(const std::vector<Element>& cv, const PrivateKey<Element> privateKey) const;
 };

--- a/src/pke/include/schemebase/base-scheme.h
+++ b/src/pke/include/schemebase/base-scheme.h
@@ -245,13 +245,12 @@ public:
         OPENFHE_THROW(config_error, "EncryptZeroCore operation has not been enabled");
     }
 
-    std::shared_ptr<std::vector<Element>> EncryptZeroCore(const PublicKey<Element> publicKey,
-                                                          const DggType& dgg) const {
+    std::shared_ptr<std::vector<Element>> EncryptZeroCore(const PublicKey<Element> publicKey) const {
         if (m_PKE) {
             if (!publicKey)
                 OPENFHE_THROW(config_error, "Input public key is nullptr");
 
-            return m_PKE->EncryptZeroCore(publicKey, nullptr, dgg);
+            return m_PKE->EncryptZeroCore(publicKey, nullptr);
         }
         OPENFHE_THROW(config_error, "EncryptZeroCore operation has not been enabled");
     }

--- a/src/pke/include/schemebase/rlwe-cryptoparameters.h
+++ b/src/pke/include/schemebase/rlwe-cryptoparameters.h
@@ -75,10 +75,12 @@ public:
         m_floodingDistributionParameter = rhs.m_floodingDistributionParameter;
         m_dgg.SetStd(m_distributionParameter);
         m_dggFlooding.SetStd(m_floodingDistributionParameter);
-        m_PREMode             = rhs.m_PREMode;
-        m_multipartyMode      = rhs.m_multipartyMode;
-        m_executionMode       = rhs.m_executionMode;
-        m_decryptionNoiseMode = rhs.m_decryptionNoiseMode;
+        m_PREMode               = rhs.m_PREMode;
+        m_multipartyMode        = rhs.m_multipartyMode;
+        m_executionMode         = rhs.m_executionMode;
+        m_decryptionNoiseMode   = rhs.m_decryptionNoiseMode;
+        m_statisticalSecurity   = rhs.m_statisticalSecurity;
+        m_numAdversarialQueries = rhs.m_numAdversarialQueries;
     }
 
     /**
@@ -101,20 +103,23 @@ public:
                          int maxRelinSkDeg = 2, SecretKeyDist secretKeyDist = GAUSSIAN,
                          ProxyReEncryptionMode PREMode = INDCPA, MultipartyMode multipartyMode = FIXED_NOISE_MULTIPARTY,
                          ExecutionMode executionMode             = EXEC_EVALUATION,
-                         DecryptionNoiseMode decryptionNoiseMode = FIXED_NOISE_DECRYPT, PlaintextModulus noiseScale = 1)
+                         DecryptionNoiseMode decryptionNoiseMode = FIXED_NOISE_DECRYPT, PlaintextModulus noiseScale = 1,
+                         double statisticalSecurity = 30, double numAdversarialQueries = 1)
         : CryptoParametersBase<Element>(params, encodingParams) {
         m_distributionParameter = distributionParameter;
         m_assuranceMeasure      = assuranceMeasure;
         m_noiseScale            = noiseScale;
         m_digitSize             = digitSize;
         m_dgg.SetStd(m_distributionParameter);
-        m_maxRelinSkDeg       = maxRelinSkDeg;
-        m_secretKeyDist       = secretKeyDist;
-        m_stdLevel            = stdLevel;
-        m_PREMode             = PREMode;
-        m_multipartyMode      = multipartyMode;
-        m_executionMode       = executionMode;
-        m_decryptionNoiseMode = decryptionNoiseMode;
+        m_maxRelinSkDeg         = maxRelinSkDeg;
+        m_secretKeyDist         = secretKeyDist;
+        m_stdLevel              = stdLevel;
+        m_PREMode               = PREMode;
+        m_multipartyMode        = multipartyMode;
+        m_executionMode         = executionMode;
+        m_decryptionNoiseMode   = decryptionNoiseMode;
+        m_statisticalSecurity   = statisticalSecurity;
+        m_numAdversarialQueries = numAdversarialQueries;
     }
 
     /**
@@ -253,6 +258,23 @@ public:
         return m_dggFlooding;
     }
 
+    /**
+   * Gets the statistical security level
+   *
+   * @return the statistical security level.
+   */
+    double GetStatisticalSecurity() const {
+        return m_statisticalSecurity;
+    }
+
+    /**
+   * Gets the number of adversarial queries
+   *
+   * @return the number of adversarial queries.
+   */
+    double GetNumAdversarialQueries() const {
+        return m_numAdversarialQueries;
+    }
     // @Set Properties
 
     /**
@@ -355,6 +377,22 @@ public:
     }
 
     /**
+   * Configures the decryption noise mode for CKKS noise flooding and PRE
+   * @param statisticalSecurity.
+   */
+    void SetStatisticalSecurity(double statisticalSecurity) {
+        m_statisticalSecurity = statisticalSecurity;
+    }
+
+    /**
+   * Configures the decryption noise mode for CKKS noise flooding and PRE
+   * @param numAdversarialQueries.
+   */
+    void SetNumAdversarialQueries(double numAdversarialQueries) {
+        m_numAdversarialQueries = numAdversarialQueries;
+    }
+
+    /**
    * == operator to compare to this instance of CryptoParametersRLWE object.
    *
    * @param &rhs CryptoParameters to check equality against.
@@ -375,7 +413,9 @@ public:
                m_stdLevel == el->GetStdLevel() && m_maxRelinSkDeg == el->GetMaxRelinSkDeg() &&
                m_PREMode == el->GetPREMode() && m_multipartyMode == el->GetMultipartyMode() &&
                m_executionMode == el->GetExecutionMode() &&
-               m_floodingDistributionParameter == el->GetFloodingDistributionParameter();
+               m_floodingDistributionParameter == el->GetFloodingDistributionParameter() &&
+               m_statisticalSecurity == el->GetStatisticalSecurity() &&
+               m_numAdversarialQueries == el->GetNumAdversarialQueries();
     }
 
     void PrintParameters(std::ostream& os) const {
@@ -401,6 +441,8 @@ public:
         ar(::cereal::make_nvp("dnm", m_decryptionNoiseMode));
         ar(::cereal::make_nvp("slv", m_stdLevel));
         ar(::cereal::make_nvp("fdp", m_floodingDistributionParameter));
+        ar(::cereal::make_nvp("ss", m_statisticalSecurity));
+        ar(::cereal::make_nvp("aq", m_numAdversarialQueries));
     }
 
     template <class Archive>
@@ -418,6 +460,8 @@ public:
         ar(::cereal::make_nvp("dnm", m_decryptionNoiseMode));
         ar(::cereal::make_nvp("slv", m_stdLevel));
         ar(::cereal::make_nvp("fdp", m_floodingDistributionParameter));
+        ar(::cereal::make_nvp("ss", m_statisticalSecurity));
+        ar(::cereal::make_nvp("aq", m_numAdversarialQueries));
 
         m_dgg.SetStd(m_distributionParameter);
         m_dggFlooding.SetStd(m_floodingDistributionParameter);
@@ -462,6 +506,14 @@ protected:
 
     // specifies the noise mode used for decryption in CKKS
     DecryptionNoiseMode m_decryptionNoiseMode = FIXED_NOISE_DECRYPT;
+
+    // Statistical security of CKKS in NOISE_FLOODING_DECRYPT mode. This is the bound on the probability of success
+    // that any adversary can have. Specifically, they a probability of success of at most 2^(-statisticalSecurity).
+    double m_statisticalSecurity = 30;
+
+    // This is the number of adversarial queries a user is expecting for their application, which we use to ensure
+    // security of CKKS in NOISE_FLOODING_DECRYPT mode.
+    double m_numAdversarialQueries = 1;
 };
 
 }  // namespace lbcrypto

--- a/src/pke/include/schemerns/rns-cryptoparameters.h
+++ b/src/pke/include/schemerns/rns-cryptoparameters.h
@@ -119,10 +119,12 @@ protected:
                         MultiplicationTechnique multTech = HPS, ProxyReEncryptionMode PREMode = INDCPA,
                         MultipartyMode multipartyMode           = FIXED_NOISE_MULTIPARTY,
                         ExecutionMode executionMode             = EXEC_EVALUATION,
-                        DecryptionNoiseMode decryptionNoiseMode = FIXED_NOISE_DECRYPT)
+                        DecryptionNoiseMode decryptionNoiseMode = FIXED_NOISE_DECRYPT, PlaintextModulus noiseScale = 1,
+                        double statisticalSecurity = 30, double numAdversarialQueries = 1)
         : CryptoParametersRLWE<DCRTPoly>(params, encodingParams, distributionParameter, assuranceMeasure, securityLevel,
                                          digitSize, maxRelinSkDeg, secretKeyDist, PREMode, multipartyMode,
-                                         executionMode, decryptionNoiseMode) {
+                                         executionMode, decryptionNoiseMode, noiseScale, statisticalSecurity,
+                                         numAdversarialQueries) {
         m_ksTechnique   = ksTech;
         m_scalTechnique = scalTech;
         m_encTechnique  = encTech;

--- a/src/pke/include/schemerns/rns-pke.h
+++ b/src/pke/include/schemerns/rns-pke.h
@@ -114,8 +114,7 @@ public:
                                                            const std::shared_ptr<ParmType> params) const override;
 
     std::shared_ptr<std::vector<DCRTPoly>> EncryptZeroCore(const PublicKey<DCRTPoly> publicKey,
-                                                           const std::shared_ptr<ParmType> params,
-                                                           const DggType& dgg) const override;
+                                                           const std::shared_ptr<ParmType> params) const override;
 
     DCRTPoly DecryptCore(const std::vector<DCRTPoly>& cv, const PrivateKey<DCRTPoly> privateKey) const override;
 

--- a/src/pke/lib/scheme/bfvrns/bfvrns-pke.cpp
+++ b/src/pke/lib/scheme/bfvrns/bfvrns-pke.cpp
@@ -168,7 +168,7 @@ Ciphertext<DCRTPoly> PKEBFVRNS::Encrypt(DCRTPoly ptxt, const PublicKey<DCRTPoly>
     }
     ptxt.SetFormat(Format::COEFFICIENT);
 
-    std::shared_ptr<std::vector<DCRTPoly>> ba = EncryptZeroCore(publicKey, encParams, DggType());
+    std::shared_ptr<std::vector<DCRTPoly>> ba = EncryptZeroCore(publicKey, encParams);
 
     NativeInteger NegQModt       = cryptoParams->GetNegQModt();
     NativeInteger NegQModtPrecon = cryptoParams->GetNegQModtPrecon();

--- a/src/pke/lib/schemebase/base-pke.cpp
+++ b/src/pke/lib/schemebase/base-pke.cpp
@@ -106,7 +106,7 @@ Ciphertext<Element> PKEBase<Element>::Encrypt(Element plaintext, const PrivateKe
 template <class Element>
 Ciphertext<Element> PKEBase<Element>::Encrypt(Element plaintext, const PublicKey<Element> publicKey) const {
     Ciphertext<Element> ciphertext           = std::make_shared<CiphertextImpl<Element>>(publicKey);
-    std::shared_ptr<std::vector<Element>> ba = EncryptZeroCore(publicKey, nullptr, DggType());
+    std::shared_ptr<std::vector<Element>> ba = EncryptZeroCore(publicKey, nullptr);
 
     (*ba)[0] += plaintext;
 
@@ -141,13 +141,12 @@ std::shared_ptr<std::vector<Element>> PKEBase<Element>::EncryptZeroCore(const Pr
 // makeSparse is not used by this scheme
 template <class Element>
 std::shared_ptr<std::vector<Element>> PKEBase<Element>::EncryptZeroCore(const PublicKey<Element> publicKey,
-                                                                        const std::shared_ptr<ParmType> params,
-                                                                        const DggType& dgg) const {
+                                                                        const std::shared_ptr<ParmType> params) const {
     const auto cryptoParams =
         std::dynamic_pointer_cast<CryptoParametersRLWE<Element>>(publicKey->GetCryptoParameters());
 
-    const auto ns            = cryptoParams->GetNoiseScale();
-    const DggType& dggsecret = cryptoParams->GetDiscreteGaussianGenerator();
+    const auto ns      = cryptoParams->GetNoiseScale();
+    const DggType& dgg = cryptoParams->GetDiscreteGaussianGenerator();
     TugType tug;
 
     const std::shared_ptr<ParmType> elementParams = (params == nullptr) ? cryptoParams->GetElementParams() : params;
@@ -165,13 +164,11 @@ std::shared_ptr<std::vector<Element>> PKEBase<Element>::EncryptZeroCore(const Pu
         p1.DropLastElements(sizePK - sizeQ);
     }
 
-    Element v = cryptoParams->GetSecretKeyDist() == GAUSSIAN ? Element(dggsecret, elementParams, Format::EVALUATION) :
+    Element v = cryptoParams->GetSecretKeyDist() == GAUSSIAN ? Element(dgg, elementParams, Format::EVALUATION) :
                                                                Element(tug, elementParams, Format::EVALUATION);
 
-    const DggType& dggGen = dgg.IsInitialized() ? dgg : cryptoParams->GetDiscreteGaussianGenerator();
-
-    Element e0(dggGen, elementParams, Format::EVALUATION);
-    Element e1(dggGen, elementParams, Format::EVALUATION);
+    Element e0(dgg, elementParams, Format::EVALUATION);
+    Element e1(dgg, elementParams, Format::EVALUATION);
 
     Element b(elementParams);
     Element a(elementParams);

--- a/src/pke/lib/schemebase/base-pre.cpp
+++ b/src/pke/lib/schemebase/base-pre.cpp
@@ -48,20 +48,28 @@ EvalKey<Element> PREBase<Element>::ReKeyGen(const PrivateKey<Element> oldPrivate
 template <class Element>
 Ciphertext<Element> PREBase<Element>::ReEncrypt(ConstCiphertext<Element> ciphertext, const EvalKey<Element> evalKey,
                                                 const PublicKey<Element> publicKey) const {
-    auto algo = ciphertext->GetCryptoContext()->GetScheme();
+    auto algo               = ciphertext->GetCryptoContext()->GetScheme();
+    const auto cryptoParams = std::static_pointer_cast<CryptoParametersRNS>(ciphertext->GetCryptoParameters());
 
     Ciphertext<Element> result = ciphertext->Clone();
+    std::vector<Element>& cv   = result->GetElements();
     if (publicKey != nullptr) {
-        const auto cryptoParams = std::static_pointer_cast<CryptoParametersRNS>(publicKey->GetCryptoParameters());
-
-        const DggType& floodingdist              = cryptoParams->GetFloodingDiscreteGaussianGenerator();
-        std::vector<Element>& cv                 = result->GetElements();
-        std::shared_ptr<std::vector<Element>> ba = algo->EncryptZeroCore(publicKey, floodingdist);
+        std::shared_ptr<std::vector<Element>> ba = algo->EncryptZeroCore(publicKey);
 
         cv[0] += (*ba)[0];
         cv[1] += (*ba)[1];
     }
 
+    if ((cryptoParams->GetPREMode() == FIXED_NOISE_HRA) || (cryptoParams->GetPREMode() == NOISE_FLOODING_HRA)) {
+        // noise flooding distribution
+        auto elementParams          = cryptoParams->GetElementParams();
+        const DggType& floodingdist = cryptoParams->GetFloodingDiscreteGaussianGenerator();
+
+        // noiseflooding
+        Element enf(floodingdist, elementParams, Format::EVALUATION);
+
+        cv[0] += enf;
+    }
     algo->KeySwitchInPlace(result, evalKey);
 
     return result;

--- a/src/pke/lib/schemerns/rns-pke.cpp
+++ b/src/pke/lib/schemerns/rns-pke.cpp
@@ -56,7 +56,7 @@ Ciphertext<DCRTPoly> PKERNS::Encrypt(DCRTPoly plaintext, const PublicKey<DCRTPol
     Ciphertext<DCRTPoly> ciphertext(std::make_shared<CiphertextImpl<DCRTPoly>>(publicKey));
 
     const std::shared_ptr<ParmType> ptxtParams = plaintext.GetParams();
-    std::shared_ptr<std::vector<DCRTPoly>> ba  = EncryptZeroCore(publicKey, ptxtParams, DggType());
+    std::shared_ptr<std::vector<DCRTPoly>> ba  = EncryptZeroCore(publicKey, ptxtParams);
 
     plaintext.SetFormat(EVALUATION);
 
@@ -146,13 +146,12 @@ std::shared_ptr<std::vector<DCRTPoly>> PKERNS::EncryptZeroCore(const PrivateKey<
 }
 
 std::shared_ptr<std::vector<DCRTPoly>> PKERNS::EncryptZeroCore(const PublicKey<DCRTPoly> publicKey,
-                                                               const std::shared_ptr<ParmType> params,
-                                                               const DggType& dgg) const {
+                                                               const std::shared_ptr<ParmType> params) const {
     const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersRNS>(publicKey->GetCryptoParameters());
 
     const std::vector<DCRTPoly>& pk = publicKey->GetPublicElements();
     const auto ns                   = cryptoParams->GetNoiseScale();
-    const DggType& dggsecret        = cryptoParams->GetDiscreteGaussianGenerator();
+    const DggType& dgg              = cryptoParams->GetDiscreteGaussianGenerator();
 
     TugType tug;
 
@@ -162,13 +161,11 @@ std::shared_ptr<std::vector<DCRTPoly>> PKERNS::EncryptZeroCore(const PublicKey<D
     // if (cryptoParams->GetSecretKeyDist() != GAUSSIAN) {
     //    OPENFHE_THROW(math_error, "TugType tug must be assigned");
     //}
-    DCRTPoly v = cryptoParams->GetSecretKeyDist() == GAUSSIAN ? DCRTPoly(dggsecret, elementParams, Format::EVALUATION) :
+    DCRTPoly v = cryptoParams->GetSecretKeyDist() == GAUSSIAN ? DCRTPoly(dgg, elementParams, Format::EVALUATION) :
                                                                 DCRTPoly(tug, elementParams, Format::EVALUATION);
 
-    const DggType& dggGen = dgg.IsInitialized() ? dgg : cryptoParams->GetDiscreteGaussianGenerator();
-
-    DCRTPoly e0(dggGen, elementParams, Format::EVALUATION);
-    DCRTPoly e1(dggGen, elementParams, Format::EVALUATION);
+    DCRTPoly e0(dgg, elementParams, Format::EVALUATION);
+    DCRTPoly e1(dgg, elementParams, Format::EVALUATION);
 
     uint32_t sizeQ  = pk[0].GetParams()->GetParams().size();
     uint32_t sizeQl = elementParams->GetParams().size();


### PR DESCRIPTION
*change noise flooding to be done in base-pre.cpp instead of the noise in encryptzerocore 
*include the statistical security and num of queries in computing noise flooding param in initializeflooding function in bgvrns-paramatersgeneration.cpp 
*included parameters statisticalSecurity and numAdversarialQueries used for ckks noise flooding in cryptocontextparams into internal rlwe-parameters to reuse the same parameters for PRE noise flooding