### PR TITLE
Switch mTilde related params to uint64_t

### DIFF
--- a/src/core/include/lattice/hal/dcrtpoly-interface.h
+++ b/src/core/include/lattice/hal/dcrtpoly-interface.h
@@ -1235,9 +1235,9 @@ public:
         const std::shared_ptr<Params> paramsBsk, const std::vector<NativeInteger>& moduliQ,
         const std::vector<NativeInteger>& moduliBsk, const std::vector<DoubleNativeInt>& modbskBarrettMu,
         const std::vector<NativeInteger>& mtildeQHatInvModq, const std::vector<NativeInteger>& mtildeQHatInvModqPrecon,
-        const std::vector<std::vector<NativeInteger>>& QHatModbsk, const std::vector<uint16_t>& QHatModmtilde,
+        const std::vector<std::vector<NativeInteger>>& QHatModbsk, const std::vector<uint64_t>& QHatModmtilde,
         const std::vector<NativeInteger>& QModbsk, const std::vector<NativeInteger>& QModbskPrecon,
-        const uint16_t& negQInvModmtilde, const std::vector<NativeInteger>& mtildeInvModbsk,
+        const uint64_t& negQInvModmtilde, const std::vector<NativeInteger>& mtildeInvModbsk,
         const std::vector<NativeInteger>& mtildeInvModbskPrecon) = 0;
 
     /**

--- a/src/core/include/lattice/hal/default/dcrtpoly.h
+++ b/src/core/include/lattice/hal/default/dcrtpoly.h
@@ -1212,9 +1212,9 @@ public:
         const std::shared_ptr<Params> paramsBsk, const std::vector<NativeInteger>& moduliQ,
         const std::vector<NativeInteger>& moduliBsk, const std::vector<DoubleNativeInt>& modbskBarrettMu,
         const std::vector<NativeInteger>& mtildeQHatInvModq, const std::vector<NativeInteger>& mtildeQHatInvModqPrecon,
-        const std::vector<std::vector<NativeInteger>>& QHatModbsk, const std::vector<uint16_t>& QHatModmtilde,
+        const std::vector<std::vector<NativeInteger>>& QHatModbsk, const std::vector<uint64_t>& QHatModmtilde,
         const std::vector<NativeInteger>& QModbsk, const std::vector<NativeInteger>& QModbskPrecon,
-        const uint16_t& negQInvModmtilde, const std::vector<NativeInteger>& mtildeInvModbsk,
+        const uint64_t& negQInvModmtilde, const std::vector<NativeInteger>& mtildeInvModbsk,
         const std::vector<NativeInteger>& mtildeInvModbskPrecon) override;
 
     /**

--- a/src/core/lib/lattice/hal/default/dcrtpoly.cpp
+++ b/src/core/lib/lattice/hal/default/dcrtpoly.cpp
@@ -2564,17 +2564,17 @@ void DCRTPolyImpl<VecType>::FastBaseConvqToBskMontgomery(
     }
 
     // mod mtilde = 2^16
-    uint64_t mtilde      = (uint64_t)1 << 16;
-    uint64_t mtilde_half = mtilde >> 1;
+    const uint64_t mtilde      = (uint64_t)1 << 16;
+    const uint64_t mtilde_half = mtilde >> 1;
+    const uint64_t mtilde_minus_1 = mtilde-1;
 
-    std::vector<uint64_t> result_mtilde(n);
+    std::vector<uint64_t> result_mtilde(n, 0);
     #pragma omp parallel for
     for (uint32_t k = 0; k < n; k++) {
-        result_mtilde[k] = 0;
         for (uint32_t i = 0; i < numQ; i++) {
             result_mtilde[k] += ximtildeQHatModqi[i * n + k].ConvertToInt() * QHatModmtilde[i];
         }
-        result_mtilde[k] &= (mtilde-1);
+        result_mtilde[k] &= mtilde_minus_1;
     }
 
     // now we have input in Basis (q U Bsk U mtilde)
@@ -2585,7 +2585,7 @@ void DCRTPolyImpl<VecType>::FastBaseConvqToBskMontgomery(
     #pragma omp parallel for
     for (uint32_t k = 0; k < n; k++) {
         result_mtilde[k] *= negQInvModmtilde;
-        result_mtilde[k] &= (mtilde-1);
+        result_mtilde[k] &= mtilde_minus_1;
     }
 
     for (uint32_t i = 0; i < numBsk; i++) {
@@ -2697,17 +2697,17 @@ void DCRTPolyImpl<VecType>::FastBaseConvqToBskMontgomery(
     }
 
     // mod mtilde = 2^16
-    uint64_t mtilde      = (uint64_t)1 << 16;
-    uint64_t mtilde_half = mtilde >> 1;
+    const uint64_t mtilde      = (uint64_t)1 << 16;
+    const uint64_t mtilde_half = mtilde >> 1;
+    const uint64_t mtilde_minus_1 = mtilde-1;
 
-    std::vector<uint64_t> result_mtilde(n);
+    std::vector<uint64_t> result_mtilde(n, 0);
     #pragma omp parallel for
     for (uint32_t k = 0; k < n; k++) {
-        result_mtilde[k] = 0;
         for (uint32_t i = 0; i < numQ; i++) {
             result_mtilde[k] += ximtildeQHatModqi[i * n + k].ConvertToInt() * QHatModmtilde[i];
         }
-        result_mtilde[k] &= (mtilde-1);
+        result_mtilde[k] &= mtilde_minus_1;
     }
 
     // now we have input in Basis (q U Bsk U mtilde)
@@ -2718,7 +2718,7 @@ void DCRTPolyImpl<VecType>::FastBaseConvqToBskMontgomery(
     #pragma omp parallel for
     for (uint32_t k = 0; k < n; k++) {
         result_mtilde[k] *= negQInvModmtilde;
-        result_mtilde[k] &= (mtilde-1);
+        result_mtilde[k] &= mtilde_minus_1;
     }
 
     for (uint32_t i = 0; i < numBsk; i++) {

--- a/src/core/lib/lattice/hal/default/dcrtpoly.cpp
+++ b/src/core/lib/lattice/hal/default/dcrtpoly.cpp
@@ -2571,9 +2571,10 @@ void DCRTPolyImpl<VecType>::FastBaseConvqToBskMontgomery(
     #pragma omp parallel for
     for (uint32_t k = 0; k < n; k++) {
         result_mtilde[k] = 0;
-        for (uint32_t i = 0; i < numQ; i++)
+        for (uint32_t i = 0; i < numQ; i++) {
             result_mtilde[k] += ximtildeQHatModqi[i * n + k].ConvertToInt() * QHatModmtilde[i];
-        result_mtilde[k] = result_mtilde[k] & (mtilde-1);
+        }
+        result_mtilde[k] &= (mtilde-1);
     }
 
     // now we have input in Basis (q U Bsk U mtilde)
@@ -2583,7 +2584,8 @@ void DCRTPolyImpl<VecType>::FastBaseConvqToBskMontgomery(
 
     #pragma omp parallel for
     for (uint32_t k = 0; k < n; k++) {
-        result_mtilde[k] = (result_mtilde[k]*negQInvModmtilde)& (mtilde-1);
+        result_mtilde[k] *= negQInvModmtilde;
+        result_mtilde[k] &= (mtilde-1);
     }
 
     for (uint32_t i = 0; i < numBsk; i++) {
@@ -2702,9 +2704,10 @@ void DCRTPolyImpl<VecType>::FastBaseConvqToBskMontgomery(
     #pragma omp parallel for
     for (uint32_t k = 0; k < n; k++) {
         result_mtilde[k] = 0;
-        for (uint32_t i = 0; i < numQ; i++)
+        for (uint32_t i = 0; i < numQ; i++) {
             result_mtilde[k] += ximtildeQHatModqi[i * n + k].ConvertToInt() * QHatModmtilde[i];
-        result_mtilde[k] = result_mtilde[k] & (mtilde-1);
+        }
+        result_mtilde[k] &= (mtilde-1);
     }
 
     // now we have input in Basis (q U Bsk U mtilde)
@@ -2714,7 +2717,8 @@ void DCRTPolyImpl<VecType>::FastBaseConvqToBskMontgomery(
 
     #pragma omp parallel for
     for (uint32_t k = 0; k < n; k++) {
-        result_mtilde[k] = (result_mtilde[k]*negQInvModmtilde)& (mtilde-1);
+        result_mtilde[k] *= negQInvModmtilde;
+        result_mtilde[k] &= (mtilde-1);
     }
 
     for (uint32_t i = 0; i < numBsk; i++) {

--- a/src/core/lib/lattice/hal/default/dcrtpoly.cpp
+++ b/src/core/lib/lattice/hal/default/dcrtpoly.cpp
@@ -2504,9 +2504,9 @@ void DCRTPolyImpl<VecType>::FastBaseConvqToBskMontgomery(
     const std::shared_ptr<DCRTPolyImpl::Params> paramsBsk, const std::vector<NativeInteger>& moduliQ,
     const std::vector<NativeInteger>& moduliBsk, const std::vector<DoubleNativeInt>& modbskBarrettMu,
     const std::vector<NativeInteger>& mtildeQHatInvModq, const std::vector<NativeInteger>& mtildeQHatInvModqPrecon,
-    const std::vector<std::vector<NativeInteger>>& QHatModbsk, const std::vector<uint16_t>& QHatModmtilde,
+    const std::vector<std::vector<NativeInteger>>& QHatModbsk, const std::vector<uint64_t>& QHatModmtilde,
     const std::vector<NativeInteger>& QModbsk, const std::vector<NativeInteger>& QModbskPrecon,
-    const uint16_t& negQInvModmtilde, const std::vector<NativeInteger>& mtildeInvModbsk,
+    const uint64_t& negQInvModmtilde, const std::vector<NativeInteger>& mtildeInvModbsk,
     const std::vector<NativeInteger>& mtildeInvModbskPrecon) {
     // Input: poly in basis q
     // Output: poly in base Bsk = {B U msk}
@@ -2564,12 +2564,16 @@ void DCRTPolyImpl<VecType>::FastBaseConvqToBskMontgomery(
     }
 
     // mod mtilde = 2^16
-    std::vector<uint16_t> result_mtilde(n);
+    uint64_t mtilde      = (uint64_t)1 << 16;
+    uint64_t mtilde_half = mtilde >> 1;
+
+    std::vector<uint64_t> result_mtilde(n);
     #pragma omp parallel for
     for (uint32_t k = 0; k < n; k++) {
         result_mtilde[k] = 0;
         for (uint32_t i = 0; i < numQ; i++)
             result_mtilde[k] += ximtildeQHatModqi[i * n + k].ConvertToInt() * QHatModmtilde[i];
+        result_mtilde[k] = result_mtilde[k] & (mtilde-1);
     }
 
     // now we have input in Basis (q U Bsk U mtilde)
@@ -2577,12 +2581,9 @@ void DCRTPolyImpl<VecType>::FastBaseConvqToBskMontgomery(
     // ----------------------- step 1 -----------------------
     // NativeInteger *r_m_tildes = new NativeInteger[n];
 
-    uint64_t mtilde      = (uint64_t)1 << 16;
-    uint64_t mtilde_half = mtilde >> 1;
-
     #pragma omp parallel for
     for (uint32_t k = 0; k < n; k++) {
-        result_mtilde[k] *= negQInvModmtilde;
+        result_mtilde[k] = (result_mtilde[k]*negQInvModmtilde)& (mtilde-1);
     }
 
     for (uint32_t i = 0; i < numBsk; i++) {
@@ -2631,9 +2632,9 @@ void DCRTPolyImpl<VecType>::FastBaseConvqToBskMontgomery(
     const std::shared_ptr<DCRTPolyImpl::Params> paramsBsk, const std::vector<NativeInteger>& moduliQ,
     const std::vector<NativeInteger>& moduliBsk, const std::vector<DoubleNativeInt>& modbskBarrettMu,
     const std::vector<NativeInteger>& mtildeQHatInvModq, const std::vector<NativeInteger>& mtildeQHatInvModqPrecon,
-    const std::vector<std::vector<NativeInteger>>& QHatModbsk, const std::vector<uint16_t>& QHatModmtilde,
+    const std::vector<std::vector<NativeInteger>>& QHatModbsk, const std::vector<uint64_t>& QHatModmtilde,
     const std::vector<NativeInteger>& QModbsk, const std::vector<NativeInteger>& QModbskPrecon,
-    const uint16_t& negQInvModmtilde, const std::vector<NativeInteger>& mtildeInvModbsk,
+    const uint64_t& negQInvModmtilde, const std::vector<NativeInteger>& mtildeInvModbsk,
     const std::vector<NativeInteger>& mtildeInvModbskPrecon) {
     // Input: poly in basis q
     // Output: poly in base Bsk = {B U msk}
@@ -2694,12 +2695,16 @@ void DCRTPolyImpl<VecType>::FastBaseConvqToBskMontgomery(
     }
 
     // mod mtilde = 2^16
-    std::vector<uint16_t> result_mtilde(n);
+    uint64_t mtilde      = (uint64_t)1 << 16;
+    uint64_t mtilde_half = mtilde >> 1;
+
+    std::vector<uint64_t> result_mtilde(n);
     #pragma omp parallel for
     for (uint32_t k = 0; k < n; k++) {
         result_mtilde[k] = 0;
         for (uint32_t i = 0; i < numQ; i++)
             result_mtilde[k] += ximtildeQHatModqi[i * n + k].ConvertToInt() * QHatModmtilde[i];
+        result_mtilde[k] = result_mtilde[k] & (mtilde-1);
     }
 
     // now we have input in Basis (q U Bsk U mtilde)
@@ -2707,12 +2712,9 @@ void DCRTPolyImpl<VecType>::FastBaseConvqToBskMontgomery(
     // ----------------------- step 1 -----------------------
     // NativeInteger *r_m_tildes = new NativeInteger[n];
 
-    uint64_t mtilde      = (uint64_t)1 << 16;
-    uint64_t mtilde_half = mtilde >> 1;
-
     #pragma omp parallel for
     for (uint32_t k = 0; k < n; k++) {
-        result_mtilde[k] *= negQInvModmtilde;
+        result_mtilde[k] = (result_mtilde[k]*negQInvModmtilde)& (mtilde-1);
     }
 
     for (uint32_t i = 0; i < numBsk; i++) {

--- a/src/pke/include/schemerns/rns-cryptoparameters.h
+++ b/src/pke/include/schemerns/rns-cryptoparameters.h
@@ -1050,7 +1050,7 @@ public:
    *
    * @return the precomputed table
    */
-    std::vector<uint16_t> const& GetQHatModmtilde() const {
+    std::vector<uint64_t> const& GetQHatModmtilde() const {
         return m_QHatModmtilde;
     }
 
@@ -1077,7 +1077,7 @@ public:
    *
    * @return the precomputed value
    */
-    uint16_t const& GetNegQInvModmtilde() const {
+    uint64_t const& GetNegQInvModmtilde() const {
         return m_negQInvModmtilde;
     }
 
@@ -1653,7 +1653,7 @@ protected:
     std::vector<std::vector<NativeInteger>> m_qInvModbsk;
 
     // Stores [Q/q_i]_{mtilde}
-    std::vector<uint16_t> m_QHatModmtilde;
+    std::vector<uint64_t> m_QHatModmtilde;
 
     // Stores [Q]_{bsk_j}
     std::vector<NativeInteger> m_QModbsk;
@@ -1661,7 +1661,7 @@ protected:
     std::vector<NativeInteger> m_QModbskPrecon;
 
     // Stores [-Q^{-1}]_{mtilde}
-    uint16_t m_negQInvModmtilde = 0;
+    uint64_t m_negQInvModmtilde = 0;
 
     // Stores [mtilde^{-1}]_{bsk_j}
     std::vector<NativeInteger> m_mtildeInvModbsk;


### PR DESCRIPTION
This branch fixes this [issue](https://github.com/openfheorg/openfhe-development/issues/250).
In short, it removes assumptions that mTilde and related params are of type uint16_t.