### PR TITLE
Fix eval-decomp example returning wrong output

### DIFF
--- a/src/binfhe/examples/eval-decomp.cpp
+++ b/src/binfhe/examples/eval-decomp.cpp
@@ -84,7 +84,7 @@ int main() {
         ct1 = decomp[i];
         LWEPlaintext result;
         if (i == decomp.size() - 1) {
-            p = 2;
+            p = 8;
         }
         cc.Decrypt(sk, ct1, &result, p);
         std::cout << "(" << result << " * " << cc.GetMaxPlaintextSpace() << "^" << i << ")";

--- a/src/binfhe/examples/eval-decomp.cpp
+++ b/src/binfhe/examples/eval-decomp.cpp
@@ -56,7 +56,7 @@ int main() {
 
     int q      = 4096;                                               // q
     int factor = 1 << int(logQ - log2(q));                           // Q/q
-    int P      = cc.GetMaxPlaintextSpace().ConvertToInt() * factor;  // Obtain the maximum plaintext space
+    uint64_t P = cc.GetMaxPlaintextSpace().ConvertToInt() * factor;  // Obtain the maximum plaintext space
 
     // Sample Program: Step 2: Key Generation
     // Generate the secret key
@@ -78,15 +78,15 @@ int main() {
     auto decomp = cc.EvalDecomp(ct1);
 
     // Sample Program: Step 5: Decryption
-    auto p = cc.GetMaxPlaintextSpace().ConvertToInt();
+    uint64_t p = cc.GetMaxPlaintextSpace().ConvertToInt();
     std::cout << "Decomposed value: ";
     for (size_t i = 0; i < decomp.size(); i++) {
         ct1 = decomp[i];
         LWEPlaintext result;
         if (i == decomp.size() - 1) {
             // after every evalfloor, the least significant digit is dropped so the last modulus is computed as log p = (log P) mod (log GetMaxPlaintextSpace)
-            int logp = static_cast<int>(log2(P)) % static_cast<int>(log2(p));
-            p        = 1 << logp;
+            auto logp = GetMSB(P - 1) % GetMSB(p - 1);
+            p         = 1 << logp;
         }
         cc.Decrypt(sk, ct1, &result, p);
         std::cout << "(" << result << " * " << cc.GetMaxPlaintextSpace() << "^" << i << ")";

--- a/src/binfhe/examples/eval-decomp.cpp
+++ b/src/binfhe/examples/eval-decomp.cpp
@@ -56,7 +56,7 @@ int main() {
 
     int q      = 4096;                                               // q
     int factor = 1 << int(logQ - log2(q));                           // Q/q
-    int p      = cc.GetMaxPlaintextSpace().ConvertToInt() * factor;  // Obtain the maximum plaintext space
+    int P      = cc.GetMaxPlaintextSpace().ConvertToInt() * factor;  // Obtain the maximum plaintext space
 
     // Sample Program: Step 2: Key Generation
     // Generate the secret key
@@ -70,21 +70,22 @@ int main() {
     std::cout << "Completed the key generation." << std::endl;
 
     // Sample Program: Step 3: Encryption
-    auto ct1 = cc.Encrypt(sk, p / 2 + 1, FRESH, p, Q);
-    std::cout << "Encrypted value: " << p / 2 + 1 << std::endl;
+    auto ct1 = cc.Encrypt(sk, P / 2 + 1, FRESH, P, Q);
+    std::cout << "Encrypted value: " << P / 2 + 1 << std::endl;
 
     // Sample Program: Step 4: Evaluation
     // Decompose the large ciphertext into small ciphertexts that fit in q
     auto decomp = cc.EvalDecomp(ct1);
 
     // Sample Program: Step 5: Decryption
-    p = cc.GetMaxPlaintextSpace().ConvertToInt();
+    auto p = cc.GetMaxPlaintextSpace().ConvertToInt();
     std::cout << "Decomposed value: ";
     for (size_t i = 0; i < decomp.size(); i++) {
         ct1 = decomp[i];
         LWEPlaintext result;
         if (i == decomp.size() - 1) {
-            p = 8;
+            // after every evalfloor, the least significant digit is dropped so the last modulus is computed as log p = (log P) mod (log GetMaxPlaintextSpace)
+            p = pow(2, static_cast<int>(log2(P)) % static_cast<int>(log2(p)));
         }
         cc.Decrypt(sk, ct1, &result, p);
         std::cout << "(" << result << " * " << cc.GetMaxPlaintextSpace() << "^" << i << ")";

--- a/src/binfhe/examples/eval-decomp.cpp
+++ b/src/binfhe/examples/eval-decomp.cpp
@@ -56,7 +56,11 @@ int main() {
 
     int q      = 4096;                                               // q
     int factor = 1 << int(logQ - log2(q));                           // Q/q
+<<<<<<< HEAD
     uint64_t P = cc.GetMaxPlaintextSpace().ConvertToInt() * factor;  // Obtain the maximum plaintext space
+=======
+    int P      = cc.GetMaxPlaintextSpace().ConvertToInt() * factor;  // Obtain the maximum plaintext space
+>>>>>>> change to example to compute modulus for last digit instead of hardcoding, change to unittest to check all the digits
 
     // Sample Program: Step 2: Key Generation
     // Generate the secret key

--- a/src/binfhe/examples/eval-decomp.cpp
+++ b/src/binfhe/examples/eval-decomp.cpp
@@ -56,11 +56,7 @@ int main() {
 
     int q      = 4096;                                               // q
     int factor = 1 << int(logQ - log2(q));                           // Q/q
-<<<<<<< HEAD
     uint64_t P = cc.GetMaxPlaintextSpace().ConvertToInt() * factor;  // Obtain the maximum plaintext space
-=======
-    int P      = cc.GetMaxPlaintextSpace().ConvertToInt() * factor;  // Obtain the maximum plaintext space
->>>>>>> change to example to compute modulus for last digit instead of hardcoding, change to unittest to check all the digits
 
     // Sample Program: Step 2: Key Generation
     // Generate the secret key

--- a/src/binfhe/examples/eval-decomp.cpp
+++ b/src/binfhe/examples/eval-decomp.cpp
@@ -85,7 +85,8 @@ int main() {
         LWEPlaintext result;
         if (i == decomp.size() - 1) {
             // after every evalfloor, the least significant digit is dropped so the last modulus is computed as log p = (log P) mod (log GetMaxPlaintextSpace)
-            p = pow(2, static_cast<int>(log2(P)) % static_cast<int>(log2(p)));
+            int logp = static_cast<int>(log2(P)) % static_cast<int>(log2(p));
+            p        = 1 << logp;
         }
         cc.Decrypt(sk, ct1, &result, p);
         std::cout << "(" << result << " * " << cc.GetMaxPlaintextSpace() << "^" << i << ")";

--- a/src/binfhe/lib/binfhe-base-scheme.cpp
+++ b/src/binfhe/lib/binfhe-base-scheme.cpp
@@ -440,14 +440,6 @@ std::vector<LWECiphertext> BinFHEScheme::EvalDecomp(const std::shared_ptr<BinFHE
             }
         }
     }
-    LWEscheme->EvalAddConstEq(cttmp, beta);
-
-    auto f3 = [](NativeInteger x, NativeInteger q, NativeInteger Q) -> NativeInteger {
-        return (x < q / 2) ? (Q / 4) : (Q - Q / 4);
-    };
-    cttmp = BootstrapFunc(params, curEK, cttmp, f3, q);  // this is 1/4q_small or -1/4q_small mod q
-    RGSWParams->Change_BaseG(curBase);
-    LWEscheme->EvalSubConstEq(cttmp, q >> 2);
     ret.push_back(std::move(cttmp));
     return ret;
 }

--- a/src/binfhe/lib/binfhe-base-scheme.cpp
+++ b/src/binfhe/lib/binfhe-base-scheme.cpp
@@ -440,6 +440,7 @@ std::vector<LWECiphertext> BinFHEScheme::EvalDecomp(const std::shared_ptr<BinFHE
             }
         }
     }
+    RGSWParams->Change_BaseG(curBase);
     ret.push_back(std::move(cttmp));
     return ret;
 }

--- a/src/binfhe/unittest/UnitTestFunc.cpp
+++ b/src/binfhe/unittest/UnitTestFunc.cpp
@@ -149,18 +149,18 @@ TEST(UnitTestFHEWGINX, EvalDigitDecompTime) {
     cc.GenerateBinFHEContext(TOY, false, 29, 0, GINX, true);
     uint32_t Q = 1 << 29;
 
-    int basic   = 4096;                             // q
-    int factor  = 1 << int(log2(Q) - log2(basic));  // Q/q
-    int p_basic = cc.GetMaxPlaintextSpace().ConvertToInt();
-    int P       = p_basic * factor;
-    auto st     = P / 2 - 3;
+    int basic        = 4096;                             // q
+    int factor       = 1 << int(log2(Q) - log2(basic));  // Q/q
+    uint64_t p_basic = cc.GetMaxPlaintextSpace().ConvertToInt();
+    uint64_t P       = p_basic * factor;
+    auto st          = P / 2 - 3;
     // Generate the secret key
     auto sk = cc.KeyGen();
     cc.BTKeyGen(sk);
     std::string failed = "Large Precision Ciphertext Decomposition failed";
 
     // digit decomposes values starting with st upto st + 7 and checks every digit of each decomposition
-    for (int i = st; i < st + 8; i++) {
+    for (uint64_t i = st; i < st + 8; i++) {
         auto ct1 = cc.Encrypt(sk, i, FRESH, p_basic * factor, Q);
 
         auto decomp = cc.EvalDecomp(ct1);
@@ -173,7 +173,7 @@ TEST(UnitTestFHEWGINX, EvalDigitDecompTime) {
 
             if (j == decomp.size() - 1) {
                 // after every evalfloor, the least significant digit is dropped so the last modulus is computed as log p = (log P) mod (log GetMaxPlaintextSpace)
-                int logp       = static_cast<int>(log2(P)) % static_cast<int>(log2(p_basic));
+                auto logp      = GetMSB(P - 1) % GetMSB(p_basic - 1);
                 p_basicdecrypt = 1 << logp;
             }
             cc.Decrypt(sk, ct1, &result, p_basicdecrypt);
@@ -210,17 +210,17 @@ TEST(UnitTestFHEWGINX, EvalDigitDecompSpace) {
     cc.GenerateBinFHEContext(TOY, false, 29, 0, GINX, false);
     uint32_t Q = 1 << 29;
 
-    int basic   = 4096;                             // q
-    int factor  = 1 << int(log2(Q) - log2(basic));  // Q/q
-    int p_basic = cc.GetMaxPlaintextSpace().ConvertToInt();
-    int P       = p_basic * factor;
-    auto st     = P / 2 - 3;
+    int basic        = 4096;                             // q
+    int factor       = 1 << int(log2(Q) - log2(basic));  // Q/q
+    uint64_t p_basic = cc.GetMaxPlaintextSpace().ConvertToInt();
+    uint64_t P       = p_basic * factor;
+    auto st          = P / 2 - 3;
     // Generate the secret key
     auto sk = cc.KeyGen();
     cc.BTKeyGen(sk);
     std::string failed = "Large Precision Ciphertext Decomposition failed";
 
-    for (int i = st; i < st + 8; i++) {
+    for (uint64_t i = st; i < st + 8; i++) {
         auto ct1 = cc.Encrypt(sk, i, FRESH, p_basic * factor, Q);
 
         auto decomp = cc.EvalDecomp(ct1);
@@ -233,7 +233,7 @@ TEST(UnitTestFHEWGINX, EvalDigitDecompSpace) {
 
             if (j == decomp.size() - 1) {
                 // after every evalfloor, the least significant digit is dropped so the last modulus is computed as log p = (log P) mod (log GetMaxPlaintextSpace)
-                int logp       = static_cast<int>(log2(P)) % static_cast<int>(log2(p_basic));
+                auto logp      = GetMSB(P - 1) % GetMSB(p_basic - 1);
                 p_basicdecrypt = 1 << logp;
             }
             cc.Decrypt(sk, ct1, &result, p_basicdecrypt);

--- a/src/binfhe/unittest/UnitTestFunc.cpp
+++ b/src/binfhe/unittest/UnitTestFunc.cpp
@@ -152,7 +152,8 @@ TEST(UnitTestFHEWGINX, EvalDigitDecompTime) {
     int basic   = 4096;                             // q
     int factor  = 1 << int(log2(Q) - log2(basic));  // Q/q
     int p_basic = cc.GetMaxPlaintextSpace().ConvertToInt();
-    auto st     = p_basic * factor / 2 - 3;
+    int P       = p_basic * factor;
+    auto st     = P / 2 - 3;
     // Generate the secret key
     auto sk = cc.KeyGen();
     cc.BTKeyGen(sk);
@@ -172,7 +173,8 @@ TEST(UnitTestFHEWGINX, EvalDigitDecompTime) {
 
             if (j == decomp.size() - 1) {
                 // after every evalfloor, the least significant digit is dropped so the last modulus is computed as log p = (log P) mod (log GetMaxPlaintextSpace)
-                p_basicdecrypt = pow(2, static_cast<int>(log2(p_basic * factor)) % static_cast<int>(log2(p_basic)));
+                int logp       = static_cast<int>(log2(P)) % static_cast<int>(log2(p_basic));
+                p_basicdecrypt = 1 << logp;
             }
             cc.Decrypt(sk, ct1, &result, p_basicdecrypt);
 
@@ -211,7 +213,8 @@ TEST(UnitTestFHEWGINX, EvalDigitDecompSpace) {
     int basic   = 4096;                             // q
     int factor  = 1 << int(log2(Q) - log2(basic));  // Q/q
     int p_basic = cc.GetMaxPlaintextSpace().ConvertToInt();
-    auto st     = p_basic * factor / 2 - 3;
+    int P       = p_basic * factor;
+    auto st     = P / 2 - 3;
     // Generate the secret key
     auto sk = cc.KeyGen();
     cc.BTKeyGen(sk);
@@ -230,7 +233,8 @@ TEST(UnitTestFHEWGINX, EvalDigitDecompSpace) {
 
             if (j == decomp.size() - 1) {
                 // after every evalfloor, the least significant digit is dropped so the last modulus is computed as log p = (log P) mod (log GetMaxPlaintextSpace)
-                p_basicdecrypt = pow(2, static_cast<int>(log2(p_basic * factor)) % static_cast<int>(log2(p_basic)));
+                int logp       = static_cast<int>(log2(P)) % static_cast<int>(log2(p_basic));
+                p_basicdecrypt = 1 << logp;
             }
             cc.Decrypt(sk, ct1, &result, p_basicdecrypt);
 

--- a/src/binfhe/unittest/UnitTestFunc.cpp
+++ b/src/binfhe/unittest/UnitTestFunc.cpp
@@ -143,14 +143,14 @@ TEST(UnitTestFHEWGINX, EvalSignFuncSpace) {
     }
 }
 
-// Checks the sign evaluation
+// Checks the digit decomposition evaluation
 TEST(UnitTestFHEWGINX, EvalDigitDecompTime) {
     auto cc = BinFHEContext();
     cc.GenerateBinFHEContext(TOY, false, 29, 0, GINX, true);
     uint32_t Q = 1 << 29;
 
-    int basic   = 4096;                        // q
-    int factor  = 1 << int(29 - log2(basic));  // Q/q
+    int basic   = 4096;                             // q
+    int factor  = 1 << int(log2(Q) - log2(basic));  // Q/q
     int p_basic = cc.GetMaxPlaintextSpace().ConvertToInt();
     auto st     = p_basic * factor / 2 - 3;
     // Generate the secret key
@@ -158,19 +158,47 @@ TEST(UnitTestFHEWGINX, EvalDigitDecompTime) {
     cc.BTKeyGen(sk);
     std::string failed = "Large Precision Ciphertext Decomposition failed";
 
+    // digit decomposes values starting with st upto st + 7 and checks every digit of each decomposition
     for (int i = st; i < st + 8; i++) {
         auto ct1 = cc.Encrypt(sk, i, FRESH, p_basic * factor, Q);
 
         auto decomp = cc.EvalDecomp(ct1);
-        ct1         = decomp[1];
-
-        LWEPlaintext result;
-        cc.Decrypt(sk, ct1, &result, p_basic);
-        if (i < st + 3)
-            EXPECT_EQ(usint(15), result) << failed;
-        else
-            EXPECT_EQ(usint(0), result) << failed;
         EXPECT_EQ(usint(ceil(log(factor) / log(p_basic)) + 1), decomp.size()) << failed;
+
+        auto p_basicdecrypt = p_basic;
+        LWEPlaintext result;
+        for (size_t j = 0; j < decomp.size(); j++) {
+            ct1 = decomp[j];
+
+            if (j == decomp.size() - 1) {
+                // after every evalfloor, the least significant digit is dropped so the last modulus is computed as log p = (log P) mod (log GetMaxPlaintextSpace)
+                p_basicdecrypt = pow(2, static_cast<int>(log2(p_basic * factor)) % static_cast<int>(log2(p_basic)));
+            }
+            cc.Decrypt(sk, ct1, &result, p_basicdecrypt);
+
+            if (i < st + 3) {
+                if (j == 0) {
+                    EXPECT_EQ(usint(13 + i - st), result) << failed;
+                }
+                else if (j == decomp.size() - 1) {
+                    EXPECT_EQ(usint(0), result) << failed;
+                }
+                else {
+                    EXPECT_EQ(usint(15), result) << failed;
+                }
+            }
+            else {
+                if (j == 0) {
+                    EXPECT_EQ(usint(0 + i - (st + 3)), result) << failed;
+                }
+                else if (j == decomp.size() - 1) {
+                    EXPECT_EQ(usint(1), result) << failed;
+                }
+                else {
+                    EXPECT_EQ(usint(0), result) << failed;
+                }
+            }
+        }
     }
 }
 
@@ -180,8 +208,8 @@ TEST(UnitTestFHEWGINX, EvalDigitDecompSpace) {
     cc.GenerateBinFHEContext(TOY, false, 29, 0, GINX, false);
     uint32_t Q = 1 << 29;
 
-    int basic   = 4096;                        // q
-    int factor  = 1 << int(29 - log2(basic));  // Q/q
+    int basic   = 4096;                             // q
+    int factor  = 1 << int(log2(Q) - log2(basic));  // Q/q
     int p_basic = cc.GetMaxPlaintextSpace().ConvertToInt();
     auto st     = p_basic * factor / 2 - 3;
     // Generate the secret key
@@ -193,15 +221,42 @@ TEST(UnitTestFHEWGINX, EvalDigitDecompSpace) {
         auto ct1 = cc.Encrypt(sk, i, FRESH, p_basic * factor, Q);
 
         auto decomp = cc.EvalDecomp(ct1);
-        ct1         = decomp[1];
-
-        LWEPlaintext result;
-        cc.Decrypt(sk, ct1, &result, p_basic);
-        if (i < st + 3)
-            EXPECT_EQ(usint(15), result) << failed;
-        else
-            EXPECT_EQ(usint(0), result) << failed;
         EXPECT_EQ(usint(ceil(log(factor) / log(p_basic)) + 1), decomp.size()) << failed;
+
+        auto p_basicdecrypt = p_basic;
+        LWEPlaintext result;
+        for (size_t j = 0; j < decomp.size(); j++) {
+            ct1 = decomp[j];
+
+            if (j == decomp.size() - 1) {
+                // after every evalfloor, the least significant digit is dropped so the last modulus is computed as log p = (log P) mod (log GetMaxPlaintextSpace)
+                p_basicdecrypt = pow(2, static_cast<int>(log2(p_basic * factor)) % static_cast<int>(log2(p_basic)));
+            }
+            cc.Decrypt(sk, ct1, &result, p_basicdecrypt);
+
+            if (i < st + 3) {
+                if (j == 0) {
+                    EXPECT_EQ(usint(13 + i - st), result) << failed;
+                }
+                else if (j == decomp.size() - 1) {
+                    EXPECT_EQ(usint(0), result) << failed;
+                }
+                else {
+                    EXPECT_EQ(usint(15), result) << failed;
+                }
+            }
+            else {
+                if (j == 0) {
+                    EXPECT_EQ(usint(0 + i - (st + 3)), result) << failed;
+                }
+                else if (j == decomp.size() - 1) {
+                    EXPECT_EQ(usint(1), result) << failed;
+                }
+                else {
+                    EXPECT_EQ(usint(0), result) << failed;
+                }
+            }
+        }
     }
 }
 #endif


### PR DESCRIPTION
@RaindropFamily: The eval-decomp example in binfhe was giving the wrong output (for the last digit). It doesn't look like the final bootstrapping in the eval-decomp function is needed (the algorithm in the paper doesn't have it either). Removing the final bootstrapping in evaldecomp function and changing p=8 from p =2 in decrypt for the last digit in the example fixes the issue. Can you review the changes? 