### PR TITLE
add check to prevent negative moduli

### DIFF
--- a/src/core/lib/math/nbtheory.cpp
+++ b/src/core/lib/math/nbtheory.cpp
@@ -565,6 +565,11 @@ IntType PreviousPrime(const IntType& q, uint64_t m) {
 
     while (!MillerRabinPrimalityTest(qNew)) {
         qNew -= M;
+        // we need to check if qNew becomes < 0 by checking for an overflow
+        // this might happen if q is too small
+        if (qNew > q) {
+            OPENFHE_THROW(config_error, "Moduli size is not sufficient! Must be increased.");
+        }
     }
 
     return qNew;


### PR DESCRIPTION
This change should resolve this [issue](https://openfhe.discourse.group/t/setting-security-parameters-according-to-128-bit-security-very-small-ckks-scaling-factor/396) on OpenFHE discourse. 
Tha main reason for this issue is that setting the moduli size to a small value might cause an overflow in the moduli generation logic.