### PR TITLE
280 andrey depth limitations hps

### DIFF
--- a/src/core/include/lattice/hal/dcrtpoly-interface.h
+++ b/src/core/include/lattice/hal/dcrtpoly-interface.h
@@ -1154,7 +1154,7 @@ public:
    */
     virtual DerivedType ScaleAndRound(const std::shared_ptr<Params> paramsOutput,
                                       const std::vector<std::vector<NativeInteger>>& tOSHatInvModsDivsModo,
-                                      const std::vector<double>& tOSHatInvModsDivsFrac,
+                                      const std::vector<NativeInteger>& tOSHatInvModsDivsFrac,
                                       const std::vector<DoubleNativeInt>& modoBarretMu) const = 0;
 
     /**

--- a/src/core/include/lattice/hal/dcrtpoly-interface.h
+++ b/src/core/include/lattice/hal/dcrtpoly-interface.h
@@ -1095,12 +1095,10 @@ public:
    * @return the result of computation as a polynomial with native 64-bit
    * coefficients
    */
-    virtual TowerType ScaleAndRound(const NativeInteger& t, const std::vector<NativeInteger>& tQHatInvModqDivqModt,
-                                    const std::vector<NativeInteger>& tQHatInvModqDivqModtPrecon,
-                                    const std::vector<NativeInteger>& tQHatInvModqBDivqModt,
-                                    const std::vector<NativeInteger>& tQHatInvModqBDivqModtPrecon,
-                                    const std::vector<double>& tQHatInvModqDivqFrac,
-                                    const std::vector<double>& tQHatInvModqBDivqFrac) const = 0;
+    virtual TowerType ScaleAndRound(const NativeInteger& t,
+                                    const std::vector<std::vector<NativeInteger>>& tQHatInvModqDivqModt,
+                                    const std::vector<std::vector<NativeInteger>>& tQHatInvModqDivqModtPrecon,
+                                    const std::vector<std::vector<double>>& tQHatInvModqDivqFrac) const = 0;
 
     /**
    * @brief Computes approximate scale and round:

--- a/src/core/include/lattice/hal/dcrtpoly-interface.h
+++ b/src/core/include/lattice/hal/dcrtpoly-interface.h
@@ -1101,6 +1101,31 @@ public:
                                     const std::vector<std::vector<double>>& tQHatInvModqDivqFrac) const = 0;
 
     /**
+   * @brief Performs scale and round:
+   * {X}_{Q} -> {\round(t/Q*X)}_t
+   * {Q} = {q_1,...,q_l}
+   * {P} = {p_1,...,p_k}
+   *
+   * Brief algorithm:
+   * [\sum_i x_i*[t*QHatInv_i/q_i]_t + Round(\sum_i x_i*{t*QHatInv_i/q_i})]_t
+   *
+   * Source: Halevi S., Polyakov Y., and Shoup V. An Improved RNS Variant of the
+   * BFV Homomorphic Encryption Scheme. Cryptology ePrint Archive, Report
+   * 2018/117. (https://eprint.iacr.org/2018/117)
+   *
+   * @param &t often corresponds to the plaintext modulus
+   * @param &tQHatInvModqDivqModt precomputed values for [Floor{t*QHatInv_i*B^d/q_i}]_t
+   * @param &tQHatInvModqDivqModtPrecon NTL-specific precomputations
+   * @param &tQHatInvModqDivqMantissa precomputed values for Frac{t*QHatInv_i*B^d/q_i} * 2^54
+   * @return the result of computation as a polynomial with native 64-bit
+   * coefficients
+   */
+    virtual TowerType ScaleAndRound(const NativeInteger& t, const NativeInteger& tInvMantissa,
+                                    const std::vector<std::vector<NativeInteger>>& tQHatInvModqDivqModt,
+                                    const std::vector<std::vector<NativeInteger>>& tQHatInvModqDivqModtPrecon,
+                                    const std::vector<std::vector<NativeInteger>>& tQHatInvModqDivqMantissa) const = 0;
+
+    /**
    * @brief Computes approximate scale and round:
    * {X}_{Q,P} -> {\approx{t/Q * X}}_{P}
    * {Q} = {q_1,...,q_l}

--- a/src/core/include/lattice/hal/default/dcrtpoly.h
+++ b/src/core/include/lattice/hal/default/dcrtpoly.h
@@ -1072,12 +1072,9 @@ public:
    * @return the result of computation as a polynomial with native 64-bit
    * coefficients
    */
-    PolyType ScaleAndRound(const NativeInteger& t, const std::vector<NativeInteger>& tQHatInvModqDivqModt,
-                           const std::vector<NativeInteger>& tQHatInvModqDivqModtPrecon,
-                           const std::vector<NativeInteger>& tQHatInvModqBDivqModt,
-                           const std::vector<NativeInteger>& tQHatInvModqBDivqModtPrecon,
-                           const std::vector<double>& tQHatInvModqDivqFrac,
-                           const std::vector<double>& tQHatInvModqBDivqFrac) const override;
+    PolyType ScaleAndRound(const NativeInteger& t, const std::vector<std::vector<NativeInteger>>& tQHatInvModqDivqModt,
+                           const std::vector<std::vector<NativeInteger>>& tQHatInvModqDivqModtPrecon,
+                           const std::vector<std::vector<double>>& tQHatInvModqDivqFrac) const override;
 
     /**
    * @brief Computes approximate scale and round:

--- a/src/core/include/lattice/hal/default/dcrtpoly.h
+++ b/src/core/include/lattice/hal/default/dcrtpoly.h
@@ -1080,6 +1080,31 @@ public:
                            const std::vector<std::vector<double>>& tQHatInvModqDivqFrac) const override;
 
     /**
+   * @brief Performs scale and round:
+   * {X}_{Q} -> {\round(t/Q*X)}_t
+   * {Q} = {q_1,...,q_l}
+   * {P} = {p_1,...,p_k}
+   *
+   * Brief algorithm:
+   * [\sum_i x_i*[t*QHatInv_i*B^i/q_i]_t + Round(\sum_i x_i*{t*QHatInv_i*B^d/q_i})]_t
+   *
+   * Source: Halevi S., Polyakov Y., and Shoup V. An Improved RNS Variant of the
+   * BFV Homomorphic Encryption Scheme. Cryptology ePrint Archive, Report
+   * 2018/117. (https://eprint.iacr.org/2018/117)
+   *
+   * @param &t often corresponds to the plaintext modulus
+   * @param &tQHatInvModqDivqModt precomputed values for [Floor{t*QHatInv_i*B^d/q_i}]_t
+   * @param &tQHatInvModqDivqModtPrecon NTL-specific precomputations
+   * @param &tQHatInvModqDivqMantissa precomputed values for Frac{t*QHatInv_i*B^d/q_i} * 2^54
+   * @return the result of computation as a polynomial with native 64-bit
+   * coefficients
+   */
+    PolyType ScaleAndRound(const NativeInteger& t, const NativeInteger& tInvMantissa,
+                           const std::vector<std::vector<NativeInteger>>& tQHatInvModqDivqModt,
+                           const std::vector<std::vector<NativeInteger>>& tQHatInvModqDivqModtPrecon,
+                           const std::vector<std::vector<NativeInteger>>& tQHatInvModqDivqMantissa) const override;
+
+    /**
    * @brief Computes approximate scale and round:
    * {X}_{Q,P} -> {\approx{t/Q * X}}_{P}
    * {Q} = {q_1,...,q_l}

--- a/src/core/include/lattice/hal/default/dcrtpoly.h
+++ b/src/core/include/lattice/hal/default/dcrtpoly.h
@@ -53,6 +53,9 @@
 
 namespace lbcrypto {
 
+// Double Precision
+const int32_t DOUBLE_PRECISION = 54;
+
 /**
  * @brief Ideal lattice for the double-CRT representation.
  * The implementation contains a vector of underlying native-integer lattices
@@ -1130,7 +1133,7 @@ public:
    */
     DCRTPolyType ScaleAndRound(const std::shared_ptr<Params> paramsOutput,
                                const std::vector<std::vector<NativeInteger>>& tOSHatInvModsDivsModo,
-                               const std::vector<double>& tOSHatInvModsDivsFrac,
+                               const std::vector<NativeInteger>& tOSHatInvModsDivsFrac,
                                const std::vector<DoubleNativeInt>& modoBarretMu) const override;
 
     /**

--- a/src/pke/examples/bfv-mult-bug.cpp
+++ b/src/pke/examples/bfv-mult-bug.cpp
@@ -1,0 +1,162 @@
+//==================================================================================
+// BSD 2-Clause License
+//
+// Copyright (c) 2014-2022, NJIT, Duality Technologies Inc. and other contributors
+//
+// All rights reserved.
+//
+// Author TPOC: contact@openfhe.org
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//==================================================================================
+
+/*
+  Simple example for BFVrns (integer arithmetic)
+ */
+
+#include "openfhe.h"
+
+using namespace lbcrypto;
+
+void EvalNoiseBFV(PrivateKey<DCRTPoly> privateKey, ConstCiphertext<DCRTPoly> ciphertext, Plaintext ptxt, usint ptm,
+                  double& noise, double& logQ);
+
+int main() {
+    CCParams<CryptoContextBFVRNS> parameters;
+    uint64_t ptm = 786433;
+    parameters.SetPlaintextModulus(ptm);
+    parameters.SetMultiplicationTechnique(HPSPOVERQ);
+    parameters.SetMultiplicativeDepth(67);
+
+    CryptoContext<DCRTPoly> cryptoContext = GenCryptoContext(parameters);
+    // Enable features that you wish to use
+    cryptoContext->Enable(PKE);
+    cryptoContext->Enable(KEYSWITCH);
+    cryptoContext->Enable(LEVELEDSHE);
+
+    // Initialize Public Key Containers
+    KeyPair<DCRTPoly> keyPair;
+
+    // Generate a public/private key pair
+    keyPair = cryptoContext->KeyGen();
+
+    // Generate the relinearization key
+    cryptoContext->EvalMultKeyGen(keyPair.secretKey);
+
+    // First plaintext vector is encoded
+    std::vector<int64_t> vectorOfInts1 = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+    Plaintext plaintext1               = cryptoContext->MakePackedPlaintext(vectorOfInts1);
+    // Second plaintext vector is encoded
+    std::vector<int64_t> vectorOfInts2 = {3, 2, 1, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+    Plaintext plaintext2               = cryptoContext->MakePackedPlaintext(vectorOfInts2);
+
+    // The encoded vectors are encrypted
+    auto ciphertext1 = cryptoContext->Encrypt(keyPair.publicKey, plaintext1);
+    auto ciphertext2 = cryptoContext->Encrypt(keyPair.publicKey, plaintext2);
+
+    // Homomorphic multiplications
+    auto ciphertextMul12 = cryptoContext->EvalMult(ciphertext1, ciphertext2);
+
+    // Decrypt the result of multiplications
+    Plaintext plaintextMultResult;
+    cryptoContext->Decrypt(keyPair.secretKey, ciphertextMul12, &plaintextMultResult);
+    plaintextMultResult->SetLength(vectorOfInts1.size());
+    std::vector<int64_t> decvec = plaintextMultResult->GetPackedValue();
+    Plaintext dRes              = cryptoContext->MakePackedPlaintext(decvec);
+
+    // Decrypt the result of 1 and 2
+    Plaintext plaintext1Result;
+    cryptoContext->Decrypt(keyPair.secretKey, ciphertext1, &plaintext1Result);
+    plaintext1Result->SetLength(vectorOfInts1.size());
+    std::vector<int64_t> decvec1 = plaintext1Result->GetPackedValue();
+    Plaintext dRes1              = cryptoContext->MakePackedPlaintext(decvec1);
+
+    std::cout << "Plaintext #1: " << plaintext1 << std::endl;
+    std::cout << "Plaintext #2: " << plaintext2 << std::endl;
+
+    // Output results
+    std::cout << "\nResults of homomorphic computations" << std::endl;
+    std::cout << "#1:      " << plaintext1Result << std::endl;
+    std::cout << "#1 * #2: " << plaintextMultResult << std::endl;
+
+    double noise = 0, logQ = 0;
+    EvalNoiseBFV(keyPair.secretKey, ciphertextMul12, dRes, ptm, noise, logQ);
+    EvalNoiseBFV(keyPair.secretKey, ciphertext1, dRes1, ptm, noise, logQ);
+    return 0;
+}
+
+void EvalNoiseBFV(PrivateKey<DCRTPoly> privateKey, ConstCiphertext<DCRTPoly> ciphertext, Plaintext ptxt, usint ptm,
+                  double& noise, double& logQ) {
+    const auto cryptoParams = std::static_pointer_cast<CryptoParametersBFVRNS>(privateKey->GetCryptoParameters());
+
+    const std::vector<DCRTPoly>& cv = ciphertext->GetElements();
+    DCRTPoly s                      = privateKey->GetPrivateElement();
+
+    size_t sizeQl = cv[0].GetParams()->GetParams().size();
+    size_t sizeQs = s.GetParams()->GetParams().size();
+
+    size_t diffQl = sizeQs - sizeQl;
+
+    auto scopy(s);
+    scopy.DropLastElements(diffQl);
+
+    DCRTPoly sPower(scopy);
+
+    DCRTPoly b = cv[0];
+    b.SetFormat(Format::EVALUATION);
+
+    DCRTPoly ci;
+    for (size_t i = 1; i < cv.size(); i++) {
+        ci = cv[i];
+        ci.SetFormat(Format::EVALUATION);
+
+        b += sPower * ci;
+        sPower *= scopy;
+    }
+
+    const auto encParams                = cryptoParams->GetElementParams();
+    NativeInteger NegQModt              = cryptoParams->GetNegQModt();
+    NativeInteger NegQModtPrecon        = cryptoParams->GetNegQModtPrecon();
+    const NativeInteger t               = cryptoParams->GetPlaintextModulus();
+    std::vector<NativeInteger> tInvModq = cryptoParams->GettInvModq();
+
+    DCRTPoly plain = ptxt->GetElement<DCRTPoly>();
+    plain.SetFormat(Format::COEFFICIENT);
+    plain.TimesQovert(encParams, tInvModq, t, NegQModt, NegQModtPrecon);
+    plain.SetFormat(Format::EVALUATION);
+    DCRTPoly res;
+    res = b - plain;
+
+    // Converts back to coefficient representation
+    res.SetFormat(Format::COEFFICIENT);
+    size_t sizeQ = cryptoParams->GetElementParams()->GetParams().size();
+    noise        = (log2(res.Norm()));
+
+    logQ = 0;
+    for (usint i = 0; i < sizeQ; i++) {
+        double logqi = log2(cryptoParams->GetElementParams()->GetParams()[i]->GetModulus().ConvertToInt());
+        logQ += logqi;
+    }
+
+    std::cout << "logQ: " << logQ << std::endl;
+    std::cout << "noise: " << noise << std::endl;
+}

--- a/src/pke/include/schemerns/rns-cryptoparameters.h
+++ b/src/pke/include/schemerns/rns-cryptoparameters.h
@@ -673,8 +673,8 @@ public:
         return m_paramsQl[l];
     }
 
-    const std::vector<double>& GetQlQHatInvModqDivqFrac(usint l) const {
-        return m_QlQHatInvModqDivqFrac[l];
+    const std::vector<NativeInteger>& GetQlQHatInvModqDivqMantissa(usint l) const {
+        return m_QlQHatInvModqDivqMantissa[l];
     }
 
     const std::vector<std::vector<NativeInteger>>& GetQlQHatInvModqDivqModq(usint l) const {
@@ -777,8 +777,8 @@ public:
    *
    * @return the precomputed table
    */
-    const std::vector<double>& GettRSHatInvModsDivsFrac() const {
-        return m_tRSHatInvModsDivsFrac;
+    const std::vector<NativeInteger>& GettRSHatInvModsDivsMantissa() const {
+        return m_tRSHatInvModsDivsMantissa;
     }
 
     /**
@@ -831,8 +831,8 @@ public:
         return m_alphaRlModq[l];
     }
 
-    const std::vector<double>& GettQlSlHatInvModsDivsFrac(usint l = 0) const {
-        return m_tQlSlHatInvModsDivsFrac[l];
+    const std::vector<NativeInteger>& GettQlSlHatInvModsDivsMantissa(usint l = 0) const {
+        return m_tQlSlHatInvModsDivsMantissa[l];
     }
 
     const std::vector<std::vector<NativeInteger>>& GettQlSlHatInvModsDivsModq(usint l = 0) const {
@@ -1479,7 +1479,7 @@ protected:
     // used in homomorphic multiplication
     std::vector<std::shared_ptr<ILDCRTParams<BigInteger>>> m_paramsQl;
 
-    std::vector<std::vector<double>> m_QlQHatInvModqDivqFrac;
+    std::vector<std::vector<NativeInteger>> m_QlQHatInvModqDivqMantissa;
     std::vector<std::vector<std::vector<NativeInteger>>> m_QlQHatInvModqDivqModq;
 
     // Auxiliary CRT basis {Rl} = {r_k}
@@ -1513,8 +1513,8 @@ protected:
     /////////////////////////////////////
 
     // S = QR
-    // Stores \frac{[t*R*(S/s_m)^{-1}]_{s_m}/s_m}
-    std::vector<double> m_tRSHatInvModsDivsFrac;
+    // Stores \round{\frac{[t*R*(S/s_m)^{-1}]_{s_m}/s_m} * 2^54}
+    std::vector<NativeInteger> m_tRSHatInvModsDivsMantissa;
 
     // S = QR
     // Stores [\floor{t*R*(S/s_m)^{-1}/s_m}]_{r_k}
@@ -1561,7 +1561,7 @@ protected:
     // BFVrns : Mult : ScaleAndRoundP
     /////////////////////////////////////
 
-    std::vector<std::vector<double>> m_tQlSlHatInvModsDivsFrac;
+    std::vector<std::vector<NativeInteger>> m_tQlSlHatInvModsDivsMantissa;
 
     std::vector<std::vector<std::vector<NativeInteger>>> m_tQlSlHatInvModsDivsModq;
 

--- a/src/pke/include/schemerns/rns-cryptoparameters.h
+++ b/src/pke/include/schemerns/rns-cryptoparameters.h
@@ -861,60 +861,30 @@ public:
     /////////////////////////////////////
 
     /**
-   * Gets the precomputed table of \frac{t*{Q/q_i}^{-1}/q_i}
+   * Gets the precomputed table of \frac{t*{Q/q_i}^{-1}B^l/q_i}
    *
    * @return the precomputed table
    */
-    const std::vector<double>& GettQHatInvModqDivqFrac() const {
+    const std::vector<std::vector<double>>& GettQHatInvModqDivqFrac() const {
         return m_tQHatInvModqDivqFrac;
     }
 
     /**
-   * When log2(q_i) >= 45 bits, B = \floor[2^{\ceil{log2(q_i)/2}}
-   * Gets the precomputed table of \frac{t*{Q/q_i}^{-1}*B/q_i}
+   * Gets the precomputed table of [\floor{t*{Q/q_i}^{-1}B^l/q_i}]_t
    *
    * @return the precomputed table
    */
-    const std::vector<double>& GettQHatInvModqBDivqFrac() const {
-        return m_tQHatInvModqBDivqFrac;
-    }
-
-    /**
-   * Gets the precomputed table of [\floor{t*{Q/q_i}^{-1}/q_i}]_t
-   *
-   * @return the precomputed table
-   */
-    const std::vector<NativeInteger>& GettQHatInvModqDivqModt() const {
+    const std::vector<std::vector<NativeInteger>>& GettQHatInvModqDivqModt() const {
         return m_tQHatInvModqDivqModt;
     }
 
     /**
-   * Gets the NTL precomputations for [\floor{t*{Q/q_i}^{-1}/q_i}]_t
+   * Gets the NTL precomputations for [\floor{t*{Q/q_i}^{-1}B^l/q_i}]_t
    *
    * @return the precomputed table
    */
-    const std::vector<NativeInteger>& GettQHatInvModqDivqModtPrecon() const {
+    const std::vector<std::vector<NativeInteger>>& GettQHatInvModqDivqModtPrecon() const {
         return m_tQHatInvModqDivqModtPrecon;
-    }
-
-    /**
-   * When log2(q_i) >= 45 bits, B = \floor[2^{\ceil{log2(q_i)/2}}
-   * Gets the precomputed table of [\floor{t*{Q/q_i}^{-1}*B/q_i}]_t
-   *
-   * @return the precomputed table
-   */
-    const std::vector<NativeInteger>& GettQHatInvModqBDivqModt() const {
-        return m_tQHatInvModqBDivqModt;
-    }
-
-    /**
-   * When log2(q_i) >= 45 bits, B = \floor[2^{\ceil{log2(q_i)/2}}
-   * Gets the NTL precomputations for [\floor{t*{Q/q_i}^{-1}*B/q_i}]_t
-   *
-   * @return the precomputed table
-   */
-    const std::vector<NativeInteger>& GettQHatInvModqBDivqModtPrecon() const {
-        return m_tQHatInvModqBDivqModtPrecon;
     }
 
     const NativeInteger& GetScalingFactorInt(usint l) const {
@@ -1493,25 +1463,13 @@ protected:
     /////////////////////////////////////
 
     // Stores \frac{t*{Q/q_i}^{-1}/q_i}
-    std::vector<double> m_tQHatInvModqDivqFrac;
-
-    // when log2(q_i) >= 45 bits, B = \floor[2^{\ceil{log2(q_i)/2}}
-    // Stores \frac{t*{Q/q_i}^{-1}*B/q_i}
-    std::vector<double> m_tQHatInvModqBDivqFrac;
+    std::vector<std::vector<double>> m_tQHatInvModqDivqFrac;
 
     // Stores [\floor{t*{Q/q_i}^{-1}/q_i}]_t
-    std::vector<NativeInteger> m_tQHatInvModqDivqModt;
+    std::vector<std::vector<NativeInteger>> m_tQHatInvModqDivqModt;
 
     // Stores NTL precomputations for [\floor{t*{Q/q_i}^{-1}/q_i}]_t
-    std::vector<NativeInteger> m_tQHatInvModqDivqModtPrecon;
-
-    // when log2(q_i) >= 45 bits, B = \floor[2^{\ceil{log2(q_i)/2}}
-    // Stores [\floor{t*{Q/q_i}^{-1}*B/q_i}]_t
-    std::vector<NativeInteger> m_tQHatInvModqBDivqModt;
-
-    // when log2 q_i >= 45 bits, B = \floor[2^{\ceil{log2(q_i)/2}}
-    // Stores NTL precomputations for [\floor{t*{Q/q_i}^{-1}*B/q_i}]_t
-    std::vector<NativeInteger> m_tQHatInvModqBDivqModtPrecon;
+    std::vector<std::vector<NativeInteger>> m_tQHatInvModqDivqModtPrecon;
 
     /////////////////////////////////////
     // BFVrns : Mult : ExpandCRTBasis

--- a/src/pke/include/schemerns/rns-cryptoparameters.h
+++ b/src/pke/include/schemerns/rns-cryptoparameters.h
@@ -861,12 +861,16 @@ public:
     /////////////////////////////////////
 
     /**
-   * Gets the precomputed table of \frac{t*{Q/q_i}^{-1}B^l/q_i}
+   * Gets the precomputed table of \round{\frac{t*{Q/q_i}^{-1}B^d/q_i} * 2^54}
    *
    * @return the precomputed table
    */
-    const std::vector<std::vector<double>>& GettQHatInvModqDivqFrac() const {
-        return m_tQHatInvModqDivqFrac;
+    const std::vector<std::vector<NativeInteger>>& GettQHatInvModqDivqMantissa() const {
+        return m_tQHatInvModqDivqMantissa;
+    }
+
+    const NativeInteger& GettInvMantissa() const {
+        return m_tInvMantissa;
     }
 
     /**
@@ -1462,14 +1466,17 @@ protected:
     // BFVrns : Decrypt : ScaleAndRound
     /////////////////////////////////////
 
-    // Stores \frac{t*{Q/q_i}^{-1}/q_i}
-    std::vector<std::vector<double>> m_tQHatInvModqDivqFrac;
+    // Stores \round{\frac{t*{Q/q_i}^{-1} * B^d/q_i} * 2^54}
+    std::vector<std::vector<NativeInteger>> m_tQHatInvModqDivqMantissa;
 
-    // Stores [\floor{t*{Q/q_i}^{-1}/q_i}]_t
+    // Stores [\floor{t*{Q/q_i}^{-1} * B^d/q_i}]_t
     std::vector<std::vector<NativeInteger>> m_tQHatInvModqDivqModt;
 
-    // Stores NTL precomputations for [\floor{t*{Q/q_i}^{-1}/q_i}]_t
+    // Stores NTL precomputations for [\floor{t*{Q/q_i}^{-1} * B^d/q_i}]_t
     std::vector<std::vector<NativeInteger>> m_tQHatInvModqDivqModtPrecon;
+
+    // Stores \round{1/t * 2^54}
+    NativeInteger m_tInvMantissa;
 
     /////////////////////////////////////
     // BFVrns : Mult : ExpandCRTBasis

--- a/src/pke/include/schemerns/rns-cryptoparameters.h
+++ b/src/pke/include/schemerns/rns-cryptoparameters.h
@@ -120,7 +120,8 @@ protected:
                         MultipartyMode multipartyMode           = FIXED_NOISE_MULTIPARTY,
                         ExecutionMode executionMode             = EXEC_EVALUATION,
                         DecryptionNoiseMode decryptionNoiseMode = FIXED_NOISE_DECRYPT, PlaintextModulus noiseScale = 1,
-                        uint32_t statisticalSecurity = 30, uint32_t numAdversarialQueries = 1, uint32_t thresholdNumOfParties = 1)
+                        uint32_t statisticalSecurity = 30, uint32_t numAdversarialQueries = 1,
+                        uint32_t thresholdNumOfParties = 1)
         : CryptoParametersRLWE<DCRTPoly>(params, encodingParams, distributionParameter, assuranceMeasure, securityLevel,
                                          digitSize, maxRelinSkDeg, secretKeyDist, PREMode, multipartyMode,
                                          executionMode, decryptionNoiseMode, noiseScale, statisticalSecurity,
@@ -830,11 +831,11 @@ public:
         return m_alphaRlModq[l];
     }
 
-    const std::vector<double>& GettQlSlHatInvModsDivsFrac(usint l) const {
+    const std::vector<double>& GettQlSlHatInvModsDivsFrac(usint l = 0) const {
         return m_tQlSlHatInvModsDivsFrac[l];
     }
 
-    const std::vector<std::vector<NativeInteger>>& GettQlSlHatInvModsDivsModq(usint l) const {
+    const std::vector<std::vector<NativeInteger>>& GettQlSlHatInvModsDivsModq(usint l = 0) const {
         return m_tQlSlHatInvModsDivsModq[l];
     }
 

--- a/src/pke/lib/scheme/bfvrns/bfvrns-cryptoparameters.cpp
+++ b/src/pke/lib/scheme/bfvrns/bfvrns-cryptoparameters.cpp
@@ -155,7 +155,7 @@ void CryptoParametersBFVRNS::PrecomputeCRTTables(KeySwitchTechnique ksTech, Scal
 
         BigInteger tmpModulusQ = modulusQ;
 
-        if (multTech == HPSPOVERQLEVELED || multTech == HPSPOVERQ) {
+        if (multTech == HPSPOVERQLEVELED) {
             m_QlHatInvModq.resize(sizeQ);
             m_QlHatInvModqPrecon.resize(sizeQ);
             m_QlHatModr.resize(sizeQ);
@@ -212,25 +212,7 @@ void CryptoParametersBFVRNS::PrecomputeCRTTables(KeySwitchTechnique ksTech, Scal
         }
 
         // BFVrns : Mult : ExpandCRTBasis
-        if (multTech == HPS) {
-            m_paramsQl.resize(1);
-            m_paramsRl.resize(1);
-            m_paramsQlRl.resize(1);
-            m_paramsQl[0] = std::make_shared<ILDCRTParams<BigInteger>>(2 * n, moduliQ, rootsQ);
-            m_paramsRl[0] = std::make_shared<ILDCRTParams<BigInteger>>(2 * n, moduliR, rootsR);
-            std::vector<NativeInteger> moduliQR(sizeQ + sizeR);
-            std::vector<NativeInteger> rootsQR(sizeQ + sizeR);
-            for (size_t i = 0; i < sizeQ; i++) {
-                moduliQR[i] = moduliQ[i];
-                rootsQR[i]  = rootsQ[i];
-            }
-            for (size_t j = 0; j < sizeR; j++) {
-                moduliQR[sizeQ + j] = moduliR[j];
-                rootsQR[sizeQ + j]  = rootsR[j];
-            }
-            m_paramsQlRl[0] = std::make_shared<ILDCRTParams<BigInteger>>(2 * n, moduliQR, rootsQR);
-        }
-        else if (multTech == HPSPOVERQLEVELED || multTech == HPSPOVERQ) {
+        if (multTech == HPSPOVERQLEVELED) {
             m_paramsQl.resize(sizeQ);
             m_paramsRl.resize(sizeQ);
             m_paramsQlRl.resize(sizeQ);
@@ -256,6 +238,24 @@ void CryptoParametersBFVRNS::PrecomputeCRTTables(KeySwitchTechnique ksTech, Scal
                 m_paramsQlRl[l] = std::make_shared<ILDCRTParams<BigInteger>>(2 * n, moduliQlRl, rootsQlRl);
             }
         }
+        else {
+            m_paramsQl.resize(1);
+            m_paramsRl.resize(1);
+            m_paramsQlRl.resize(1);
+            m_paramsQl[0] = std::make_shared<ILDCRTParams<BigInteger>>(2 * n, moduliQ, rootsQ);
+            m_paramsRl[0] = std::make_shared<ILDCRTParams<BigInteger>>(2 * n, moduliR, rootsR);
+            std::vector<NativeInteger> moduliQR(sizeQ + sizeR);
+            std::vector<NativeInteger> rootsQR(sizeQ + sizeR);
+            for (size_t i = 0; i < sizeQ; i++) {
+                moduliQR[i] = moduliQ[i];
+                rootsQR[i]  = rootsQ[i];
+            }
+            for (size_t j = 0; j < sizeR; j++) {
+                moduliQR[sizeQ + j] = moduliR[j];
+                rootsQR[sizeQ + j]  = rootsR[j];
+            }
+            m_paramsQlRl[0] = std::make_shared<ILDCRTParams<BigInteger>>(2 * n, moduliQR, rootsQR);
+        }
 
         m_modrBarrettMu.resize(sizeR);
         for (uint32_t j = 0; j < moduliR.size(); j++) {
@@ -276,13 +276,11 @@ void CryptoParametersBFVRNS::PrecomputeCRTTables(KeySwitchTechnique ksTech, Scal
         // BFVrns : Mult : ScaleAndRound
         /////////////////////////////////////
 
-        const BigInteger modulusR = multTech == HPSPOVERQLEVELED || multTech == HPSPOVERQ ?
-                                        m_paramsRl[sizeQ - 1]->GetModulus() :
-                                        m_paramsRl[0]->GetModulus();
+        const BigInteger modulusR =
+            multTech == HPSPOVERQLEVELED ? m_paramsRl[sizeQ - 1]->GetModulus() : m_paramsRl[0]->GetModulus();
 
-        const BigInteger modulusQR = multTech == HPSPOVERQLEVELED || multTech == HPSPOVERQ ?
-                                         m_paramsQlRl[sizeQ - 1]->GetModulus() :
-                                         m_paramsQlRl[0]->GetModulus();
+        const BigInteger modulusQR =
+            multTech == HPSPOVERQLEVELED ? m_paramsQlRl[sizeQ - 1]->GetModulus() : m_paramsQlRl[0]->GetModulus();
 
         const BigInteger modulust(GetPlaintextModulus());
 
@@ -320,7 +318,7 @@ void CryptoParametersBFVRNS::PrecomputeCRTTables(KeySwitchTechnique ksTech, Scal
         std::vector<BigInteger> QlHat(sizeQ + 1);
         std::vector<BigInteger> RlHat(sizeQ + 1);
 
-        if (multTech == HPSPOVERQLEVELED || multTech == HPSPOVERQ) {
+        if (multTech == HPSPOVERQLEVELED) {
             Ql[0]    = 1;
             Rl[0]    = 1;
             QlRl[0]  = 1;
@@ -339,17 +337,7 @@ void CryptoParametersBFVRNS::PrecomputeCRTTables(KeySwitchTechnique ksTech, Scal
         }
 
         // BFVrns : Mult : ExpandCRTBasis
-        if (multTech == HPS) {
-            m_alphaQlModr.resize(1);
-            m_alphaQlModr[0].resize(sizeQ + 1);
-            for (usint j = 0; j < sizeR; j++) {
-                NativeInteger QModrj = modulusQ.Mod(moduliR[j]).ConvertToInt();
-                for (usint i = 0; i < sizeQ + 1; i++) {
-                    m_alphaQlModr[0][i].push_back(QModrj.ModMul(NativeInteger(i), moduliR[j]));
-                }
-            }
-        }
-        else if (multTech == HPSPOVERQLEVELED || multTech == HPSPOVERQ) {
+        if (multTech == HPSPOVERQLEVELED) {
             m_alphaQlModr.resize(sizeQ);
             for (usint l = sizeQ; l > 0; l--) {
                 m_alphaQlModr[l - 1].resize(l + 1);
@@ -362,32 +350,20 @@ void CryptoParametersBFVRNS::PrecomputeCRTTables(KeySwitchTechnique ksTech, Scal
                 }
             }
         }
-
-        // Pre-compute values [Rl/r_j]_{q_i}
-        // Pre-compute values [(Rl/r_j)^{-1}]_{r_j}
-        if (multTech == HPS) {
-            m_RlHatInvModr.resize(1);
-            m_RlHatInvModrPrecon.resize(1);
-
-            m_RlHatInvModr[0].resize(sizeR);
-            m_RlHatInvModrPrecon[0].resize(sizeR);
-            for (size_t j = 0; j < sizeR; j++) {
-                BigInteger RHatj           = modulusR / BigInteger(moduliR[j]);
-                m_RlHatInvModr[0][j]       = RHatj.ModInverse(moduliR[j]).ConvertToInt();
-                m_RlHatInvModrPrecon[0][j] = m_RlHatInvModr[0][j].PrepModMulConst(moduliR[j]);
-            }
-
-            m_RlHatModq.resize(1);
-            m_RlHatModq[0].resize(sizeQ);
-            for (usint i = 0; i < sizeQ; i++) {
-                m_RlHatModq[0][i].resize(sizeR);
-                for (usint j = 0; j < sizeR; j++) {
-                    BigInteger RHatj     = modulusR / BigInteger(moduliR[j]);
-                    m_RlHatModq[0][i][j] = RHatj.Mod(moduliQ[i]).ConvertToInt();
+        else {
+            m_alphaQlModr.resize(1);
+            m_alphaQlModr[0].resize(sizeQ + 1);
+            for (usint j = 0; j < sizeR; j++) {
+                NativeInteger QModrj = modulusQ.Mod(moduliR[j]).ConvertToInt();
+                for (usint i = 0; i < sizeQ + 1; i++) {
+                    m_alphaQlModr[0][i].push_back(QModrj.ModMul(NativeInteger(i), moduliR[j]));
                 }
             }
         }
-        else if (multTech == HPSPOVERQ || multTech == HPSPOVERQLEVELED) {
+
+        // Pre-compute values [Rl/r_j]_{q_i}
+        // Pre-compute values [(Rl/r_j)^{-1}]_{r_j}
+        if (multTech == HPSPOVERQLEVELED) {
             m_RlHatInvModr.resize(sizeR);
             m_RlHatInvModrPrecon.resize(sizeR);
             m_RlHatModq.resize(sizeR);
@@ -411,20 +387,32 @@ void CryptoParametersBFVRNS::PrecomputeCRTTables(KeySwitchTechnique ksTech, Scal
                 }
             }
         }
+        else {
+            m_RlHatInvModr.resize(1);
+            m_RlHatInvModrPrecon.resize(1);
 
-        // compute [\alpha*Rl]_{q_i} for 0 <= alpha <= sizeRl
-        // used for homomorphic multiplication
-        if (multTech == HPS) {
-            m_alphaRlModq.resize(1);
-            m_alphaRlModq[0].resize(sizeR + 1);
+            m_RlHatInvModr[0].resize(sizeR);
+            m_RlHatInvModrPrecon[0].resize(sizeR);
+            for (size_t j = 0; j < sizeR; j++) {
+                BigInteger RHatj           = modulusR / BigInteger(moduliR[j]);
+                m_RlHatInvModr[0][j]       = RHatj.ModInverse(moduliR[j]).ConvertToInt();
+                m_RlHatInvModrPrecon[0][j] = m_RlHatInvModr[0][j].PrepModMulConst(moduliR[j]);
+            }
+
+            m_RlHatModq.resize(1);
+            m_RlHatModq[0].resize(sizeQ);
             for (usint i = 0; i < sizeQ; i++) {
-                NativeInteger RModqi = modulusR.Mod(moduliQ[i]).ConvertToInt();
-                for (usint j = 0; j < sizeR + 1; ++j) {
-                    m_alphaRlModq[0][j].push_back(RModqi.ModMul(NativeInteger(j), moduliQ[i]));
+                m_RlHatModq[0][i].resize(sizeR);
+                for (usint j = 0; j < sizeR; j++) {
+                    BigInteger RHatj     = modulusR / BigInteger(moduliR[j]);
+                    m_RlHatModq[0][i][j] = RHatj.Mod(moduliQ[i]).ConvertToInt();
                 }
             }
         }
-        else if (multTech == HPSPOVERQLEVELED || multTech == HPSPOVERQ) {
+
+        // compute [\alpha*Rl]_{q_i} for 0 <= alpha <= sizeRl
+        // used for homomorphic multiplication
+        if (multTech == HPSPOVERQLEVELED) {
             m_alphaRlModq.resize(sizeR);
             for (usint l = sizeR; l > 0; l--) {
                 m_alphaRlModq[l - 1].resize(l + 1);
@@ -434,6 +422,16 @@ void CryptoParametersBFVRNS::PrecomputeCRTTables(KeySwitchTechnique ksTech, Scal
                     for (usint j = 0; j < l + 1; ++j) {
                         m_alphaRlModq[l - 1][j].push_back(RlModqi.ModMul(NativeInteger(j), qi));
                     }
+                }
+            }
+        }
+        else {
+            m_alphaRlModq.resize(1);
+            m_alphaRlModq[0].resize(sizeR + 1);
+            for (usint i = 0; i < sizeQ; i++) {
+                NativeInteger RModqi = modulusR.Mod(moduliQ[i]).ConvertToInt();
+                for (usint j = 0; j < sizeR + 1; ++j) {
+                    m_alphaRlModq[0][j].push_back(RModqi.ModMul(NativeInteger(j), moduliQ[i]));
                 }
             }
         }
@@ -498,7 +496,7 @@ void CryptoParametersBFVRNS::PrecomputeCRTTables(KeySwitchTechnique ksTech, Scal
         // BFVrns : Mult : FastExpandCRTBasisPloverQ
         /////////////////////////////////////
 
-        if (multTech == HPSPOVERQ || multTech == HPSPOVERQLEVELED) {
+        if (multTech == HPSPOVERQLEVELED) {
             m_negRlQHatInvModq.resize(sizeR);
             m_negRlQHatInvModqPrecon.resize(sizeR);
             for (usint l = sizeR; l > 0; l--) {
@@ -511,6 +509,19 @@ void CryptoParametersBFVRNS::PrecomputeCRTTables(KeySwitchTechnique ksTech, Scal
                     m_negRlQHatInvModq[l - 1][i]       = moduliQ[i].Sub(m_negRlQHatInvModq[l - 1][i]);
                     m_negRlQHatInvModqPrecon[l - 1][i] = m_negRlQHatInvModq[l - 1][i].PrepModMulConst(moduliQ[i]);
                 }
+            }
+        }
+        else if (multTech == HPSPOVERQ) {
+            m_negRlQHatInvModq.resize(1);
+            m_negRlQHatInvModqPrecon.resize(1);
+            m_negRlQHatInvModq[0].resize(sizeQ);
+            m_negRlQHatInvModqPrecon[0].resize(sizeQ);
+            for (usint i = 0; i < sizeQ; i++) {
+                BigInteger QHati               = modulusQ / BigInteger(moduliQ[i]);
+                BigInteger QHatInvModqi        = QHati.ModInverse(moduliQ[i]);
+                m_negRlQHatInvModq[0][i]       = modulusR.ModMul(QHatInvModqi, moduliQ[i]).ConvertToInt();
+                m_negRlQHatInvModq[0][i]       = moduliQ[i].Sub(m_negRlQHatInvModq[0][i]);
+                m_negRlQHatInvModqPrecon[0][i] = m_negRlQHatInvModq[0][i].PrepModMulConst(moduliQ[i]);
             }
         }
 
@@ -528,34 +539,7 @@ void CryptoParametersBFVRNS::PrecomputeCRTTables(KeySwitchTechnique ksTech, Scal
         // BFVrns : Mult : ScaleAndRoundP
         /////////////////////////////////////
 
-        if (multTech == HPS || multTech == HPSPOVERQ) {
-            m_tQlSlHatInvModsDivsFrac.resize(1);
-
-            m_tQlSlHatInvModsDivsFrac[0].resize(sizeR);
-            for (size_t j = 0; j < sizeR; j++) {
-                BigInteger rj(moduliR[j].ConvertToInt());
-                m_tQlSlHatInvModsDivsFrac[0][j] =
-                    static_cast<double>(
-                        ((modulusQR.DividedBy(rj)).ModInverse(rj) * modulusQ * modulust).Mod(rj).ConvertToInt()) /
-                    static_cast<double>(rj.ConvertToInt());
-            }
-            m_tQlSlHatInvModsDivsModq.resize(1);
-            m_tQlSlHatInvModsDivsModq[0].resize(sizeQ);
-            for (usint i = 0; i < sizeQ; i++) {
-                BigInteger qi(moduliQ[i].ConvertToInt());
-                for (usint j = 0; j < sizeR; j++) {
-                    BigInteger rj(moduliR[j].ConvertToInt());
-                    BigInteger tQlSlHatInvMods     = modulust * modulusQ * ((modulusQR.DividedBy(rj)).ModInverse(rj));
-                    BigInteger tQlSlHatInvModsDivs = tQlSlHatInvMods / rj;
-                    m_tQlSlHatInvModsDivsModq[0][i].push_back(tQlSlHatInvModsDivs.Mod(qi).ConvertToInt());
-                }
-
-                BigInteger tQlSlHatInvMods     = modulust * modulusQ * ((modulusQR.DividedBy(qi)).ModInverse(qi));
-                BigInteger tQlSlHatInvModsDivs = tQlSlHatInvMods / qi;
-                m_tQlSlHatInvModsDivsModq[0][i].push_back(tQlSlHatInvModsDivs.Mod(qi).ConvertToInt());
-            }
-        }
-        else if (multTech == HPSPOVERQLEVELED) {
+        if (multTech == HPSPOVERQLEVELED) {
             m_tQlSlHatInvModsDivsFrac.resize(sizeQ);
             m_tQlSlHatInvModsDivsModq.resize(sizeQ);
 
@@ -584,76 +568,79 @@ void CryptoParametersBFVRNS::PrecomputeCRTTables(KeySwitchTechnique ksTech, Scal
                 }
             }
         }
+        else {
+            m_tQlSlHatInvModsDivsFrac.resize(1);
+
+            m_tQlSlHatInvModsDivsFrac[0].resize(sizeR);
+            for (size_t j = 0; j < sizeR; j++) {
+                BigInteger rj(moduliR[j].ConvertToInt());
+                m_tQlSlHatInvModsDivsFrac[0][j] =
+                    static_cast<double>(
+                        ((modulusQR.DividedBy(rj)).ModInverse(rj) * modulusQ * modulust).Mod(rj).ConvertToInt()) /
+                    static_cast<double>(rj.ConvertToInt());
+            }
+            m_tQlSlHatInvModsDivsModq.resize(1);
+            m_tQlSlHatInvModsDivsModq[0].resize(sizeQ);
+            for (usint i = 0; i < sizeQ; i++) {
+                BigInteger qi(moduliQ[i].ConvertToInt());
+                for (usint j = 0; j < sizeR; j++) {
+                    BigInteger rj(moduliR[j].ConvertToInt());
+                    BigInteger tQlSlHatInvMods     = modulust * modulusQ * ((modulusQR.DividedBy(rj)).ModInverse(rj));
+                    BigInteger tQlSlHatInvModsDivs = tQlSlHatInvMods / rj;
+                    m_tQlSlHatInvModsDivsModq[0][i].push_back(tQlSlHatInvModsDivs.Mod(qi).ConvertToInt());
+                }
+
+                BigInteger tQlSlHatInvMods     = modulust * modulusQ * ((modulusQR.DividedBy(qi)).ModInverse(qi));
+                BigInteger tQlSlHatInvModsDivs = tQlSlHatInvMods / qi;
+                m_tQlSlHatInvModsDivsModq[0][i].push_back(tQlSlHatInvModsDivs.Mod(qi).ConvertToInt());
+            }
+        }
 
         /////////////////////////////////////
         // BFVrns : Mult : ScaleAndRoundQl
         /////////////////////////////////////
 
-        m_QlQHatInvModqDivqModq.resize(sizeQ);
-        m_QlQHatInvModqDivqFrac.resize(sizeQ);
-        for (usint l = sizeQ; l > 0; l--) {
-            m_QlQHatInvModqDivqFrac[l - 1].resize(sizeQ - l);
-            for (size_t j = 0; j < sizeQ - l; j++) {
-                BigInteger qj(moduliQ[j + l].ConvertToInt());
-                m_QlQHatInvModqDivqFrac[l - 1][j] =
-                    static_cast<double>(((modulusQ.DividedBy(qj)).ModInverse(qj) * Ql[l]).Mod(qj).ConvertToInt()) /
-                    static_cast<double>(qj.ConvertToInt());
-            }
-            m_QlQHatInvModqDivqModq[l - 1].resize(l);
-            for (usint i = 0; i < l; i++) {
-                BigInteger qi(moduliQ[i].ConvertToInt());
-                for (usint j = 0; j < sizeQ - l; j++) {
-                    BigInteger qj(moduliQ[l + j].ConvertToInt());
-                    BigInteger QlQHatInvModq     = Ql[l] * ((modulusQ.DividedBy(qj)).ModInverse(qj));
-                    BigInteger QlQHatInvModqDivq = QlQHatInvModq / qj;
+        if (multTech == HPSPOVERQLEVELED) {
+            m_QlQHatInvModqDivqModq.resize(sizeQ);
+            m_QlQHatInvModqDivqFrac.resize(sizeQ);
+            for (usint l = sizeQ; l > 0; l--) {
+                m_QlQHatInvModqDivqFrac[l - 1].resize(sizeQ - l);
+                for (size_t j = 0; j < sizeQ - l; j++) {
+                    BigInteger qj(moduliQ[j + l].ConvertToInt());
+                    m_QlQHatInvModqDivqFrac[l - 1][j] =
+                        static_cast<double>(((modulusQ.DividedBy(qj)).ModInverse(qj) * Ql[l]).Mod(qj).ConvertToInt()) /
+                        static_cast<double>(qj.ConvertToInt());
+                }
+                m_QlQHatInvModqDivqModq[l - 1].resize(l);
+                for (usint i = 0; i < l; i++) {
+                    BigInteger qi(moduliQ[i].ConvertToInt());
+                    for (usint j = 0; j < sizeQ - l; j++) {
+                        BigInteger qj(moduliQ[l + j].ConvertToInt());
+                        BigInteger QlQHatInvModq     = Ql[l] * ((modulusQ.DividedBy(qj)).ModInverse(qj));
+                        BigInteger QlQHatInvModqDivq = QlQHatInvModq / qj;
+                        m_QlQHatInvModqDivqModq[l - 1][i].push_back(QlQHatInvModqDivq.Mod(qi).ConvertToInt());
+                    }
+                    BigInteger QlQHatInvModq     = Ql[l] * ((modulusQ.DividedBy(qi)).ModInverse(qi));
+                    BigInteger QlQHatInvModqDivq = QlQHatInvModq / qi;
                     m_QlQHatInvModqDivqModq[l - 1][i].push_back(QlQHatInvModqDivq.Mod(qi).ConvertToInt());
                 }
-                BigInteger QlQHatInvModq     = Ql[l] * ((modulusQ.DividedBy(qi)).ModInverse(qi));
-                BigInteger QlQHatInvModqDivq = QlQHatInvModq / qi;
-                m_QlQHatInvModqDivqModq[l - 1][i].push_back(QlQHatInvModqDivq.Mod(qi).ConvertToInt());
             }
         }
-
         /////////////////////////////////////
         // BFVrns : Mult : ExpandCRTBasisQlHat
         /////////////////////////////////////
 
-        m_QlHatModq.resize(sizeQ);
-        m_QlHatModqPrecon.resize(sizeQ);
-        for (usint l = sizeQ; l > 0; l--) {
-            m_QlHatModq[l - 1].resize(l);
-            m_QlHatModqPrecon[l - 1].resize(l);
-            for (usint i = 0; i < l; i++) {
-                BigInteger qi(moduliQ[i].ConvertToInt());
-                m_QlHatModq[l - 1][i]       = QlHat[l].Mod(qi).ConvertToInt();
-                m_QlHatModqPrecon[l - 1][i] = m_QlHatModq[l - 1][i].PrepModMulConst(qi);
-            }
-        }
-
-        /////////////////////////////////////
-        // DropLastElementAndScale
-        /////////////////////////////////////
-
-        // Pre-compute omega values for rescaling in RNS
-        // modulusQ holds Q^(l) = \prod_{i=0}^{i=l}(q_i).
-        m_QlQlInvModqlDivqlModq.resize(sizeQ - 1);
-        m_QlQlInvModqlDivqlModqPrecon.resize(sizeQ - 1);
-        m_qlInvModq.resize(sizeQ - 1);
-        m_qlInvModqPrecon.resize(sizeQ - 1);
-        for (size_t k = 0; k < sizeQ - 1; k++) {
-            size_t l = sizeQ - (k + 1);
-            modulusQ = modulusQ / BigInteger(moduliQ[l]);
-            m_QlQlInvModqlDivqlModq[k].resize(l);
-            m_QlQlInvModqlDivqlModqPrecon[k].resize(l);
-            m_qlInvModq[k].resize(l);
-            m_qlInvModqPrecon[k].resize(l);
-            BigInteger QlInvModql = modulusQ.ModInverse(moduliQ[l]);
-            BigInteger result     = (QlInvModql * modulusQ) / BigInteger(moduliQ[l]);
-            for (usint i = 0; i < l; i++) {
-                m_QlQlInvModqlDivqlModq[k][i]       = result.Mod(moduliQ[i]).ConvertToInt();
-                m_QlQlInvModqlDivqlModqPrecon[k][i] = m_QlQlInvModqlDivqlModq[k][i].PrepModMulConst(moduliQ[i]);
-                m_qlInvModq[k][i]                   = moduliQ[l].ModInverse(moduliQ[i]);
-                m_qlInvModqPrecon[k][i]             = m_qlInvModq[k][i].PrepModMulConst(moduliQ[i]);
+        if (multTech == HPSPOVERQLEVELED) {
+            m_QlHatModq.resize(sizeQ);
+            m_QlHatModqPrecon.resize(sizeQ);
+            for (usint l = sizeQ; l > 0; l--) {
+                m_QlHatModq[l - 1].resize(l);
+                m_QlHatModqPrecon[l - 1].resize(l);
+                for (usint i = 0; i < l; i++) {
+                    BigInteger qi(moduliQ[i].ConvertToInt());
+                    m_QlHatModq[l - 1][i]       = QlHat[l].Mod(qi).ConvertToInt();
+                    m_QlHatModqPrecon[l - 1][i] = m_QlHatModq[l - 1][i].PrepModMulConst(qi);
+                }
             }
         }
     }

--- a/src/pke/lib/scheme/bfvrns/bfvrns-cryptoparameters.cpp
+++ b/src/pke/lib/scheme/bfvrns/bfvrns-cryptoparameters.cpp
@@ -284,13 +284,13 @@ void CryptoParametersBFVRNS::PrecomputeCRTTables(KeySwitchTechnique ksTech, Scal
 
         const BigInteger modulust(GetPlaintextModulus());
 
-        m_tRSHatInvModsDivsFrac.resize(sizeQ);
+        m_tRSHatInvModsDivsMantissa.resize(sizeQ);
         for (size_t i = 0; i < sizeQ; i++) {
             BigInteger qi(moduliQ[i].ConvertToInt());
-            m_tRSHatInvModsDivsFrac[i] =
-                static_cast<double>(
-                    ((modulusQR.DividedBy(qi)).ModInverse(qi) * modulusR * modulust).Mod(qi).ConvertToInt()) /
-                static_cast<double>(qi.ConvertToInt());
+            m_tRSHatInvModsDivsMantissa[i] =
+                (((((modulusQR.DividedBy(qi)).ModInverse(qi) * modulusR * modulust).Mod(qi)).LShift(54))
+                     .DivideAndRound(qi))
+                    .ConvertToInt();
         }
 
         m_tRSHatInvModsDivsModr.resize(sizeR);
@@ -524,17 +524,18 @@ void CryptoParametersBFVRNS::PrecomputeCRTTables(KeySwitchTechnique ksTech, Scal
         /////////////////////////////////////
 
         if (multTech == HPSPOVERQLEVELED) {
-            m_tQlSlHatInvModsDivsFrac.resize(sizeQ);
+            m_tQlSlHatInvModsDivsMantissa.resize(sizeQ);
             m_tQlSlHatInvModsDivsModq.resize(sizeQ);
 
             for (usint l = sizeQ; l > 0; l--) {
-                m_tQlSlHatInvModsDivsFrac[l - 1].resize(l);
+                m_tQlSlHatInvModsDivsMantissa[l - 1].resize(l);
                 for (size_t j = 0; j < l; j++) {
                     BigInteger rj(moduliR[j].ConvertToInt());
-                    m_tQlSlHatInvModsDivsFrac[l - 1][j] =
-                        static_cast<double>(
-                            ((QlRl[l].DividedBy(rj)).ModInverse(rj) * Ql[l] * modulust).Mod(rj).ConvertToInt()) /
-                        static_cast<double>(rj.ConvertToInt());
+                    m_tQlSlHatInvModsDivsMantissa[l - 1][j] =
+                        (((((QlRl[l].DividedBy(rj)).ModInverse(rj) * Ql[l] * modulust).Mod(rj))
+                              .LShift(DOUBLE_PRECISION))
+                             .DivideAndRound(rj))
+                            .ConvertToInt();
                 }
                 m_tQlSlHatInvModsDivsModq[l - 1].resize(l);
                 for (usint i = 0; i < l; i++) {
@@ -553,15 +554,16 @@ void CryptoParametersBFVRNS::PrecomputeCRTTables(KeySwitchTechnique ksTech, Scal
             }
         }
         else {
-            m_tQlSlHatInvModsDivsFrac.resize(1);
+            m_tQlSlHatInvModsDivsMantissa.resize(1);
 
-            m_tQlSlHatInvModsDivsFrac[0].resize(sizeR);
+            m_tQlSlHatInvModsDivsMantissa[0].resize(sizeR);
             for (size_t j = 0; j < sizeR; j++) {
                 BigInteger rj(moduliR[j].ConvertToInt());
-                m_tQlSlHatInvModsDivsFrac[0][j] =
-                    static_cast<double>(
-                        ((modulusQR.DividedBy(rj)).ModInverse(rj) * modulusQ * modulust).Mod(rj).ConvertToInt()) /
-                    static_cast<double>(rj.ConvertToInt());
+                m_tQlSlHatInvModsDivsMantissa[0][j] =
+                    (((((modulusQR.DividedBy(rj)).ModInverse(rj) * modulusQ * modulust).Mod(rj))
+                          .LShift(DOUBLE_PRECISION))
+                         .DivideAndRound(rj))
+                        .ConvertToInt();
             }
             m_tQlSlHatInvModsDivsModq.resize(1);
             m_tQlSlHatInvModsDivsModq[0].resize(sizeQ);
@@ -586,14 +588,15 @@ void CryptoParametersBFVRNS::PrecomputeCRTTables(KeySwitchTechnique ksTech, Scal
 
         if (multTech == HPSPOVERQLEVELED) {
             m_QlQHatInvModqDivqModq.resize(sizeQ);
-            m_QlQHatInvModqDivqFrac.resize(sizeQ);
+            m_QlQHatInvModqDivqMantissa.resize(sizeQ);
             for (usint l = sizeQ; l > 0; l--) {
-                m_QlQHatInvModqDivqFrac[l - 1].resize(sizeQ - l);
+                m_QlQHatInvModqDivqMantissa[l - 1].resize(sizeQ - l);
                 for (size_t j = 0; j < sizeQ - l; j++) {
                     BigInteger qj(moduliQ[j + l].ConvertToInt());
-                    m_QlQHatInvModqDivqFrac[l - 1][j] =
-                        static_cast<double>(((modulusQ.DividedBy(qj)).ModInverse(qj) * Ql[l]).Mod(qj).ConvertToInt()) /
-                        static_cast<double>(qj.ConvertToInt());
+                    m_QlQHatInvModqDivqMantissa[l - 1][j] =
+                        (((((modulusQ.DividedBy(qj)).ModInverse(qj) * Ql[l]).Mod(qj)).LShift(DOUBLE_PRECISION))
+                             .DivideAndRound(qj))
+                            .ConvertToInt();
                 }
                 m_QlQHatInvModqDivqModq[l - 1].resize(l);
                 for (usint i = 0; i < l; i++) {

--- a/src/pke/lib/scheme/bfvrns/bfvrns-leveledshe.cpp
+++ b/src/pke/lib/scheme/bfvrns/bfvrns-leveledshe.cpp
@@ -208,22 +208,18 @@ Ciphertext<DCRTPoly> LeveledSHEBFVRNS::EvalMult(ConstCiphertext<DCRTPoly> cipher
     else if (cryptoParams->GetMultiplicationTechnique() == HPSPOVERQ) {
         for (size_t i = 0; i < cv1Size; i++) {
             // Expand ciphertext1 from basis Q to PQ.
-            cv1[i].ExpandCRTBasis(cryptoParams->GetParamsQlRl(sizeQ - 1), cryptoParams->GetParamsRl(sizeQ - 1),
-                                  cryptoParams->GetQlHatInvModq(sizeQ - 1),
-                                  cryptoParams->GetQlHatInvModqPrecon(sizeQ - 1), cryptoParams->GetQlHatModr(sizeQ - 1),
-                                  cryptoParams->GetalphaQlModr(sizeQ - 1), cryptoParams->GetModrBarrettMu(),
-                                  cryptoParams->GetqInv(), Format::EVALUATION);
+            cv1[i].ExpandCRTBasis(cryptoParams->GetParamsQlRl(), cryptoParams->GetParamsRl(),
+                                  cryptoParams->GetQlHatInvModq(), cryptoParams->GetQlHatInvModqPrecon(),
+                                  cryptoParams->GetQlHatModr(), cryptoParams->GetalphaQlModr(),
+                                  cryptoParams->GetModrBarrettMu(), cryptoParams->GetqInv(), Format::EVALUATION);
         }
 
-        size_t sizeQ = cv2[0].GetNumOfElements();
-
         DCRTPoly::CRTBasisExtensionPrecomputations basisPQ(
-            cryptoParams->GetParamsQlRl(sizeQ - 1), cryptoParams->GetParamsRl(sizeQ - 1),
-            cryptoParams->GetParamsQl(sizeQ - 1), cryptoParams->GetmNegRlQHatInvModq(sizeQ - 1),
-            cryptoParams->GetmNegRlQHatInvModqPrecon(sizeQ - 1), cryptoParams->GetqInvModr(),
-            cryptoParams->GetModrBarrettMu(), cryptoParams->GetRlHatInvModr(sizeQ - 1),
-            cryptoParams->GetRlHatInvModrPrecon(sizeQ - 1), cryptoParams->GetRlHatModq(sizeQ - 1),
-            cryptoParams->GetalphaRlModq(sizeQ - 1), cryptoParams->GetModqBarrettMu(), cryptoParams->GetrInv());
+            cryptoParams->GetParamsQlRl(), cryptoParams->GetParamsRl(), cryptoParams->GetParamsQl(),
+            cryptoParams->GetmNegRlQHatInvModq(), cryptoParams->GetmNegRlQHatInvModqPrecon(),
+            cryptoParams->GetqInvModr(), cryptoParams->GetModrBarrettMu(), cryptoParams->GetRlHatInvModr(),
+            cryptoParams->GetRlHatInvModrPrecon(), cryptoParams->GetRlHatModq(), cryptoParams->GetalphaRlModq(),
+            cryptoParams->GetModqBarrettMu(), cryptoParams->GetrInv());
 
         for (size_t i = 0; i < cv2Size; i++) {
             cv2[i].SetFormat(Format::COEFFICIENT);
@@ -364,8 +360,8 @@ Ciphertext<DCRTPoly> LeveledSHEBFVRNS::EvalMult(ConstCiphertext<DCRTPoly> cipher
             // Performs the scaling by t/P followed by rounding; the result is in the
             // CRT basis Q
             cvMult[i] =
-                cvMult[i].ScaleAndRound(cryptoParams->GetElementParams(), cryptoParams->GettQlSlHatInvModsDivsModq(0),
-                                        cryptoParams->GettQlSlHatInvModsDivsFrac(0), cryptoParams->GetModqBarrettMu());
+                cvMult[i].ScaleAndRound(cryptoParams->GetElementParams(), cryptoParams->GettQlSlHatInvModsDivsModq(),
+                                        cryptoParams->GettQlSlHatInvModsDivsFrac(), cryptoParams->GetModqBarrettMu());
         }
     }
     else if (cryptoParams->GetMultiplicationTechnique() == HPSPOVERQLEVELED) {
@@ -439,20 +435,18 @@ Ciphertext<DCRTPoly> LeveledSHEBFVRNS::EvalSquare(ConstCiphertext<DCRTPoly> ciph
         cvPoverQ = cv;
         for (size_t i = 0; i < cvSize; i++) {
             // Expand ciphertext1 from basis Q to PQ.
-            cv[i].ExpandCRTBasis(cryptoParams->GetParamsQlRl(sizeQ - 1), cryptoParams->GetParamsRl(sizeQ - 1),
-                                 cryptoParams->GetQlHatInvModq(sizeQ - 1),
-                                 cryptoParams->GetQlHatInvModqPrecon(sizeQ - 1), cryptoParams->GetQlHatModr(sizeQ - 1),
-                                 cryptoParams->GetalphaQlModr(sizeQ - 1), cryptoParams->GetModrBarrettMu(),
-                                 cryptoParams->GetqInv(), Format::EVALUATION);
+            cv[i].ExpandCRTBasis(cryptoParams->GetParamsQlRl(), cryptoParams->GetParamsRl(),
+                                 cryptoParams->GetQlHatInvModq(), cryptoParams->GetQlHatInvModqPrecon(),
+                                 cryptoParams->GetQlHatModr(), cryptoParams->GetalphaQlModr(),
+                                 cryptoParams->GetModrBarrettMu(), cryptoParams->GetqInv(), Format::EVALUATION);
         }
 
         DCRTPoly::CRTBasisExtensionPrecomputations basisPQ(
-            cryptoParams->GetParamsQlRl(sizeQ - 1), cryptoParams->GetParamsRl(sizeQ - 1),
-            cryptoParams->GetParamsQl(sizeQ - 1), cryptoParams->GetmNegRlQHatInvModq(sizeQ - 1),
-            cryptoParams->GetmNegRlQHatInvModqPrecon(sizeQ - 1), cryptoParams->GetqInvModr(),
-            cryptoParams->GetModrBarrettMu(), cryptoParams->GetRlHatInvModr(sizeQ - 1),
-            cryptoParams->GetRlHatInvModrPrecon(sizeQ - 1), cryptoParams->GetRlHatModq(sizeQ - 1),
-            cryptoParams->GetalphaRlModq(sizeQ - 1), cryptoParams->GetModqBarrettMu(), cryptoParams->GetrInv());
+            cryptoParams->GetParamsQlRl(), cryptoParams->GetParamsRl(), cryptoParams->GetParamsQl(),
+            cryptoParams->GetmNegRlQHatInvModq(), cryptoParams->GetmNegRlQHatInvModqPrecon(),
+            cryptoParams->GetqInvModr(), cryptoParams->GetModrBarrettMu(), cryptoParams->GetRlHatInvModr(),
+            cryptoParams->GetRlHatInvModrPrecon(), cryptoParams->GetRlHatModq(), cryptoParams->GetalphaRlModq(),
+            cryptoParams->GetModqBarrettMu(), cryptoParams->GetrInv());
 
         for (size_t i = 0; i < cvSize; i++) {
             cvPoverQ[i].SetFormat(Format::COEFFICIENT);
@@ -651,9 +645,9 @@ Ciphertext<DCRTPoly> LeveledSHEBFVRNS::EvalSquare(ConstCiphertext<DCRTPoly> ciph
             cvSquare[i].SetFormat(COEFFICIENT);
             // Performs the scaling by t/P followed by rounding; the result is in the
             // CRT basis Q
-            cvSquare[i] = cvSquare[i].ScaleAndRound(
-                cryptoParams->GetElementParams(), cryptoParams->GettQlSlHatInvModsDivsModq(0),
-                cryptoParams->GettQlSlHatInvModsDivsFrac(0), cryptoParams->GetModqBarrettMu());
+            cvSquare[i] =
+                cvSquare[i].ScaleAndRound(cryptoParams->GetElementParams(), cryptoParams->GettQlSlHatInvModsDivsModq(),
+                                          cryptoParams->GettQlSlHatInvModsDivsFrac(), cryptoParams->GetModqBarrettMu());
         }
     }
     else if (cryptoParams->GetMultiplicationTechnique() == HPSPOVERQLEVELED) {

--- a/src/pke/lib/scheme/bfvrns/bfvrns-leveledshe.cpp
+++ b/src/pke/lib/scheme/bfvrns/bfvrns-leveledshe.cpp
@@ -243,9 +243,9 @@ Ciphertext<DCRTPoly> LeveledSHEBFVRNS::EvalMult(ConstCiphertext<DCRTPoly> cipher
             cv1[i].SetFormat(Format::COEFFICIENT);
             if (l < sizeQ - 1) {
                 // Drop from basis Q to Q_l.
-                cv1[i] =
-                    cv1[i].ScaleAndRound(cryptoParams->GetParamsQl(l), cryptoParams->GetQlQHatInvModqDivqModq(l),
-                                         cryptoParams->GetQlQHatInvModqDivqFrac(l), cryptoParams->GetModqBarrettMu());
+                cv1[i] = cv1[i].ScaleAndRound(cryptoParams->GetParamsQl(l), cryptoParams->GetQlQHatInvModqDivqModq(l),
+                                              cryptoParams->GetQlQHatInvModqDivqMantissa(l),
+                                              cryptoParams->GetModqBarrettMu());
             }
             // Expand ciphertext1 from basis Q_l to PQ_l.
             cv1[i].ExpandCRTBasis(cryptoParams->GetParamsQlRl(l), cryptoParams->GetParamsRl(l),
@@ -345,7 +345,7 @@ Ciphertext<DCRTPoly> LeveledSHEBFVRNS::EvalMult(ConstCiphertext<DCRTPoly> cipher
             // CRT basis P
             cvMult[i] =
                 cvMult[i].ScaleAndRound(cryptoParams->GetParamsRl(), cryptoParams->GettRSHatInvModsDivsModr(),
-                                        cryptoParams->GettRSHatInvModsDivsFrac(), cryptoParams->GetModrBarrettMu());
+                                        cryptoParams->GettRSHatInvModsDivsMantissa(), cryptoParams->GetModrBarrettMu());
 
             // Converts from the CRT basis P to Q
             cvMult[i] = cvMult[i].SwitchCRTBasis(cryptoParams->GetElementParams(), cryptoParams->GetRlHatInvModr(),
@@ -359,9 +359,9 @@ Ciphertext<DCRTPoly> LeveledSHEBFVRNS::EvalMult(ConstCiphertext<DCRTPoly> cipher
             cvMult[i].SetFormat(COEFFICIENT);
             // Performs the scaling by t/P followed by rounding; the result is in the
             // CRT basis Q
-            cvMult[i] =
-                cvMult[i].ScaleAndRound(cryptoParams->GetElementParams(), cryptoParams->GettQlSlHatInvModsDivsModq(),
-                                        cryptoParams->GettQlSlHatInvModsDivsFrac(), cryptoParams->GetModqBarrettMu());
+            cvMult[i] = cvMult[i].ScaleAndRound(
+                cryptoParams->GetElementParams(), cryptoParams->GettQlSlHatInvModsDivsModq(),
+                cryptoParams->GettQlSlHatInvModsDivsMantissa(), cryptoParams->GetModqBarrettMu());
         }
     }
     else if (cryptoParams->GetMultiplicationTechnique() == HPSPOVERQLEVELED) {
@@ -369,9 +369,9 @@ Ciphertext<DCRTPoly> LeveledSHEBFVRNS::EvalMult(ConstCiphertext<DCRTPoly> cipher
             cvMult[i].SetFormat(COEFFICIENT);
             // Performs the scaling by t/P followed by rounding; the result is in the
             // CRT basis Q
-            cvMult[i] =
-                cvMult[i].ScaleAndRound(cryptoParams->GetParamsQl(l), cryptoParams->GettQlSlHatInvModsDivsModq(l),
-                                        cryptoParams->GettQlSlHatInvModsDivsFrac(l), cryptoParams->GetModqBarrettMu());
+            cvMult[i] = cvMult[i].ScaleAndRound(
+                cryptoParams->GetParamsQl(l), cryptoParams->GettQlSlHatInvModsDivsModq(l),
+                cryptoParams->GettQlSlHatInvModsDivsMantissa(l), cryptoParams->GetModqBarrettMu());
 
             if (l < sizeQ - 1) {
                 // Expand back to basis Q.
@@ -473,9 +473,9 @@ Ciphertext<DCRTPoly> LeveledSHEBFVRNS::EvalSquare(ConstCiphertext<DCRTPoly> ciph
         for (size_t i = 0; i < cvSize; i++) {
             if (l < sizeQ - 1) {
                 // Drop from basis Q to Q_l.
-                cv[i] =
-                    cv[i].ScaleAndRound(cryptoParams->GetParamsQl(l), cryptoParams->GetQlQHatInvModqDivqModq(l),
-                                        cryptoParams->GetQlQHatInvModqDivqFrac(l), cryptoParams->GetModqBarrettMu());
+                cv[i] = cv[i].ScaleAndRound(cryptoParams->GetParamsQl(l), cryptoParams->GetQlQHatInvModqDivqModq(l),
+                                            cryptoParams->GetQlQHatInvModqDivqMantissa(l),
+                                            cryptoParams->GetModqBarrettMu());
             }
             // Expand ciphertext1 from basis Q_l to PQ_l.
             cv[i].ExpandCRTBasis(cryptoParams->GetParamsQlRl(l), cryptoParams->GetParamsRl(l),
@@ -629,9 +629,9 @@ Ciphertext<DCRTPoly> LeveledSHEBFVRNS::EvalSquare(ConstCiphertext<DCRTPoly> ciph
             cvSquare[i].SetFormat(Format::COEFFICIENT);
             // Performs the scaling by t/Q followed by rounding; the result is in the
             // CRT basis P
-            cvSquare[i] =
-                cvSquare[i].ScaleAndRound(cryptoParams->GetParamsRl(), cryptoParams->GettRSHatInvModsDivsModr(),
-                                          cryptoParams->GettRSHatInvModsDivsFrac(), cryptoParams->GetModrBarrettMu());
+            cvSquare[i] = cvSquare[i].ScaleAndRound(
+                cryptoParams->GetParamsRl(), cryptoParams->GettRSHatInvModsDivsModr(),
+                cryptoParams->GettRSHatInvModsDivsMantissa(), cryptoParams->GetModrBarrettMu());
 
             // Converts from the CRT basis P to Q
             cvSquare[i] = cvSquare[i].SwitchCRTBasis(cryptoParams->GetElementParams(), cryptoParams->GetRlHatInvModr(),
@@ -645,9 +645,9 @@ Ciphertext<DCRTPoly> LeveledSHEBFVRNS::EvalSquare(ConstCiphertext<DCRTPoly> ciph
             cvSquare[i].SetFormat(COEFFICIENT);
             // Performs the scaling by t/P followed by rounding; the result is in the
             // CRT basis Q
-            cvSquare[i] =
-                cvSquare[i].ScaleAndRound(cryptoParams->GetElementParams(), cryptoParams->GettQlSlHatInvModsDivsModq(),
-                                          cryptoParams->GettQlSlHatInvModsDivsFrac(), cryptoParams->GetModqBarrettMu());
+            cvSquare[i] = cvSquare[i].ScaleAndRound(
+                cryptoParams->GetElementParams(), cryptoParams->GettQlSlHatInvModsDivsModq(),
+                cryptoParams->GettQlSlHatInvModsDivsMantissa(), cryptoParams->GetModqBarrettMu());
         }
     }
     else if (cryptoParams->GetMultiplicationTechnique() == HPSPOVERQLEVELED) {
@@ -657,7 +657,7 @@ Ciphertext<DCRTPoly> LeveledSHEBFVRNS::EvalSquare(ConstCiphertext<DCRTPoly> ciph
             // CRT basis Q
             cvSquare[i] = cvSquare[i].ScaleAndRound(
                 cryptoParams->GetParamsQl(l), cryptoParams->GettQlSlHatInvModsDivsModq(l),
-                cryptoParams->GettQlSlHatInvModsDivsFrac(l), cryptoParams->GetModqBarrettMu());
+                cryptoParams->GettQlSlHatInvModsDivsMantissa(l), cryptoParams->GetModqBarrettMu());
 
             if (l < sizeQ - 1) {
                 // Expand back to basis Q.
@@ -775,7 +775,7 @@ std::shared_ptr<std::vector<DCRTPoly>> LeveledSHEBFVRNS::EvalFastRotationPrecomp
     uint32_t l = levelsDropped > 0 ? sizeQ - 1 - levelsDropped : sizeQ - 1;
     c1.SetFormat(COEFFICIENT);
     c1 = c1.ScaleAndRound(cryptoParams->GetParamsQl(l), cryptoParams->GetQlQHatInvModqDivqModq(l),
-                          cryptoParams->GetQlQHatInvModqDivqFrac(l), cryptoParams->GetModqBarrettMu());
+                          cryptoParams->GetQlQHatInvModqDivqMantissa(l), cryptoParams->GetModqBarrettMu());
 
     return algo->EvalKeySwitchPrecomputeCore(c1, ciphertext->GetCryptoParameters());
 }
@@ -855,13 +855,15 @@ void LeveledSHEBFVRNS::RelinearizeCore(Ciphertext<DCRTPoly>& ciphertext, const E
         l                      = levelsDropped > 0 ? sizeQ - 1 - levelsDropped : sizeQ - 1;
         if (isKeySwitch) {
             cv[1].SetFormat(COEFFICIENT);
-            cv[1] = cv[1].ScaleAndRound(cryptoParams->GetParamsQl(l), cryptoParams->GetQlQHatInvModqDivqModq(l),
-                                        cryptoParams->GetQlQHatInvModqDivqFrac(l), cryptoParams->GetModqBarrettMu());
+            cv[1] =
+                cv[1].ScaleAndRound(cryptoParams->GetParamsQl(l), cryptoParams->GetQlQHatInvModqDivqModq(l),
+                                    cryptoParams->GetQlQHatInvModqDivqMantissa(l), cryptoParams->GetModqBarrettMu());
         }
         else {
             cv[2].SetFormat(COEFFICIENT);
-            cv[2] = cv[2].ScaleAndRound(cryptoParams->GetParamsQl(l), cryptoParams->GetQlQHatInvModqDivqModq(l),
-                                        cryptoParams->GetQlQHatInvModqDivqFrac(l), cryptoParams->GetModqBarrettMu());
+            cv[2] =
+                cv[2].ScaleAndRound(cryptoParams->GetParamsQl(l), cryptoParams->GetQlQHatInvModqDivqModq(l),
+                                    cryptoParams->GetQlQHatInvModqDivqMantissa(l), cryptoParams->GetModqBarrettMu());
         }
     }
 

--- a/src/pke/lib/scheme/bfvrns/bfvrns-multiparty.cpp
+++ b/src/pke/lib/scheme/bfvrns/bfvrns-multiparty.cpp
@@ -160,8 +160,9 @@ DecryptResult MultipartyBFVRNS::MultipartyDecryptFusion(const std::vector<Cipher
     if (cryptoParams->GetMultiplicationTechnique() == HPS || cryptoParams->GetMultiplicationTechnique() == HPSPOVERQ ||
         cryptoParams->GetMultiplicationTechnique() == HPSPOVERQLEVELED) {
         *plaintext =
-            b.ScaleAndRound(cryptoParams->GetPlaintextModulus(), cryptoParams->GettQHatInvModqDivqModt(),
-                            cryptoParams->GettQHatInvModqDivqModtPrecon(), cryptoParams->GettQHatInvModqDivqFrac());
+            b.ScaleAndRound(cryptoParams->GetPlaintextModulus(), cryptoParams->GettInvMantissa(),
+                            cryptoParams->GettQHatInvModqDivqModt(), cryptoParams->GettQHatInvModqDivqModtPrecon(),
+                            cryptoParams->GettQHatInvModqDivqMantissa());
     }
     else {
         *plaintext =

--- a/src/pke/lib/scheme/bfvrns/bfvrns-multiparty.cpp
+++ b/src/pke/lib/scheme/bfvrns/bfvrns-multiparty.cpp
@@ -161,9 +161,7 @@ DecryptResult MultipartyBFVRNS::MultipartyDecryptFusion(const std::vector<Cipher
         cryptoParams->GetMultiplicationTechnique() == HPSPOVERQLEVELED) {
         *plaintext =
             b.ScaleAndRound(cryptoParams->GetPlaintextModulus(), cryptoParams->GettQHatInvModqDivqModt(),
-                            cryptoParams->GettQHatInvModqDivqModtPrecon(), cryptoParams->GettQHatInvModqBDivqModt(),
-                            cryptoParams->GettQHatInvModqBDivqModtPrecon(), cryptoParams->GettQHatInvModqDivqFrac(),
-                            cryptoParams->GettQHatInvModqBDivqFrac());
+                            cryptoParams->GettQHatInvModqDivqModtPrecon(), cryptoParams->GettQHatInvModqDivqFrac());
     }
     else {
         *plaintext =

--- a/src/pke/lib/scheme/bfvrns/bfvrns-pke.cpp
+++ b/src/pke/lib/scheme/bfvrns/bfvrns-pke.cpp
@@ -213,9 +213,7 @@ DecryptResult PKEBFVRNS::Decrypt(ConstCiphertext<DCRTPoly> ciphertext, const Pri
         cryptoParams->GetMultiplicationTechnique() == HPSPOVERQLEVELED) {
         *plaintext =
             b.ScaleAndRound(cryptoParams->GetPlaintextModulus(), cryptoParams->GettQHatInvModqDivqModt(),
-                            cryptoParams->GettQHatInvModqDivqModtPrecon(), cryptoParams->GettQHatInvModqBDivqModt(),
-                            cryptoParams->GettQHatInvModqBDivqModtPrecon(), cryptoParams->GettQHatInvModqDivqFrac(),
-                            cryptoParams->GettQHatInvModqBDivqFrac());
+                            cryptoParams->GettQHatInvModqDivqModtPrecon(), cryptoParams->GettQHatInvModqDivqFrac());
     }
     else {
         *plaintext =

--- a/src/pke/lib/scheme/bfvrns/bfvrns-pke.cpp
+++ b/src/pke/lib/scheme/bfvrns/bfvrns-pke.cpp
@@ -212,8 +212,9 @@ DecryptResult PKEBFVRNS::Decrypt(ConstCiphertext<DCRTPoly> ciphertext, const Pri
     if (cryptoParams->GetMultiplicationTechnique() == HPS || cryptoParams->GetMultiplicationTechnique() == HPSPOVERQ ||
         cryptoParams->GetMultiplicationTechnique() == HPSPOVERQLEVELED) {
         *plaintext =
-            b.ScaleAndRound(cryptoParams->GetPlaintextModulus(), cryptoParams->GettQHatInvModqDivqModt(),
-                            cryptoParams->GettQHatInvModqDivqModtPrecon(), cryptoParams->GettQHatInvModqDivqFrac());
+            b.ScaleAndRound(cryptoParams->GetPlaintextModulus(), cryptoParams->GettInvMantissa(),
+                            cryptoParams->GettQHatInvModqDivqModt(), cryptoParams->GettQHatInvModqDivqModtPrecon(),
+                            cryptoParams->GettQHatInvModqDivqMantissa());
     }
     else {
         *plaintext =

--- a/src/pke/unittest/utbfvrns/UnitTestBFVrnsCRTOperations.cpp
+++ b/src/pke/unittest/utbfvrns/UnitTestBFVrnsCRTOperations.cpp
@@ -385,7 +385,7 @@ TEST_F(UTBFVRNS_CRT, BFVrns_Mult_by_Constant) {
 
     DCRTPoly rounded =
         c.ScaleAndRound(paramsR, cryptoParamsBFVrns->GettRSHatInvModsDivsModr(),
-                        cryptoParamsBFVrns->GettRSHatInvModsDivsFrac(), cryptoParamsBFVrns->GetModrBarrettMu());
+                        cryptoParamsBFVrns->GettRSHatInvModsDivsMantissa(), cryptoParamsBFVrns->GetModrBarrettMu());
 
     DCRTPoly roundedQ = rounded.SwitchCRTBasis(paramsQ, cryptoParamsBFVrns->GetRlHatInvModr(),
                                                cryptoParamsBFVrns->GetRlHatInvModrPrecon(),
@@ -516,7 +516,7 @@ TEST_F(UTBFVRNS_CRT, BFVrns_Mult_by_Gaussian) {
 
     DCRTPoly rounded =
         c.ScaleAndRound(paramsR, cryptoParamsBFVrns->GettRSHatInvModsDivsModr(),
-                        cryptoParamsBFVrns->GettRSHatInvModsDivsFrac(), cryptoParamsBFVrns->GetModrBarrettMu());
+                        cryptoParamsBFVrns->GettRSHatInvModsDivsMantissa(), cryptoParamsBFVrns->GetModrBarrettMu());
 
     DCRTPoly roundedQ = rounded.SwitchCRTBasis(paramsQ, cryptoParamsBFVrns->GetRlHatInvModr(),
                                                cryptoParamsBFVrns->GetRlHatInvModrPrecon(),

--- a/src/pke/unittest/utbfvrns/UnitTestBFVrnsCRTOperations.cpp
+++ b/src/pke/unittest/utbfvrns/UnitTestBFVrnsCRTOperations.cpp
@@ -169,8 +169,6 @@ TEST_F(UTBFVRNS_CRT, BFVrns_FastExpandCRTBasisPloverQ) {
 
     const auto cryptoParamsBFVrns = std::dynamic_pointer_cast<CryptoParametersBFVRNS>(cc->GetCryptoParameters());
 
-    size_t sizeQ = 2;
-
     // Generate the element "a" of the public key
     DCRTPoly a(params, Format::COEFFICIENT);
 
@@ -195,17 +193,17 @@ TEST_F(UTBFVRNS_CRT, BFVrns_FastExpandCRTBasisPloverQ) {
     a.SetElementAtIndex(0, poly0);
     a.SetElementAtIndex(1, poly1);
 
-    auto param1  = cryptoParamsBFVrns->GetParamsQlRl(sizeQ - 1);
-    auto param2  = cryptoParamsBFVrns->GetParamsRl(sizeQ - 1);
-    auto param3  = cryptoParamsBFVrns->GetParamsQl(sizeQ - 1);
-    auto param4  = cryptoParamsBFVrns->GetmNegRlQHatInvModq(sizeQ - 1);
-    auto param5  = cryptoParamsBFVrns->GetmNegRlQHatInvModqPrecon(sizeQ - 1);
+    auto param1  = cryptoParamsBFVrns->GetParamsQlRl();
+    auto param2  = cryptoParamsBFVrns->GetParamsRl();
+    auto param3  = cryptoParamsBFVrns->GetParamsQl();
+    auto param4  = cryptoParamsBFVrns->GetmNegRlQHatInvModq();
+    auto param5  = cryptoParamsBFVrns->GetmNegRlQHatInvModqPrecon();
     auto param6  = cryptoParamsBFVrns->GetqInvModr();
     auto param7  = cryptoParamsBFVrns->GetModrBarrettMu();
-    auto param8  = cryptoParamsBFVrns->GetRlHatInvModr(sizeQ - 1);
-    auto param9  = cryptoParamsBFVrns->GetRlHatInvModrPrecon(sizeQ - 1);
-    auto param10 = cryptoParamsBFVrns->GetRlHatModq(sizeQ - 1);
-    auto param11 = cryptoParamsBFVrns->GetalphaRlModq(sizeQ - 1);
+    auto param8  = cryptoParamsBFVrns->GetRlHatInvModr();
+    auto param9  = cryptoParamsBFVrns->GetRlHatInvModrPrecon();
+    auto param10 = cryptoParamsBFVrns->GetRlHatModq();
+    auto param11 = cryptoParamsBFVrns->GetalphaRlModq();
     auto param12 = cryptoParamsBFVrns->GetModqBarrettMu();
     auto param13 = cryptoParamsBFVrns->GetrInv();
     DCRTPoly::CRTBasisExtensionPrecomputations basisPQ(param1, param2, param3, param4, param5, param6, param7, param8,


### PR DESCRIPTION
Changed floating point arithmetics to fixed point arithmetics in both: ScaleAndRound function used in multiplication and ScaleAndRound function used in decryption. 

Questions: 
1) Do we need to add tests for HPS and other variants? If so the test could be slow, as they require lot's of levels for BFV.
2) I keep temporary bfv-mult-bug.cpp example from https://github.com/openfheorg/openfhe-development/tree/Erabelli_280-bfv-mult-bug. Do we need some variant of it?
3) In case of decryption should we use previous method with floating point arithmetics, or move to new with fixed point arithmetics?
4) Should we rename functions in dcrtPoly, as they could be confusing? Make renamings as a part of another issue?