### PR TITLE
Fix unnecessary copy and change them to move

### DIFF
--- a/src/binfhe/include/binfhe-base-params.h
+++ b/src/binfhe/include/binfhe-base-params.h
@@ -69,8 +69,8 @@ public:
    * @param baseR the base for the refreshing key
    * @param method bootstrapping method (DM or CGGI)
    */
-    BinFHECryptoParams(const std::shared_ptr<LWECryptoParams> lweparams,
-                       const std::shared_ptr<RingGSWCryptoParams> rgswparams)
+    BinFHECryptoParams(const std::shared_ptr<LWECryptoParams>& lweparams,
+                       const std::shared_ptr<RingGSWCryptoParams>& rgswparams)
         : m_LWEParams(lweparams), m_RGSWParams(rgswparams) {}
 
     const std::shared_ptr<LWECryptoParams> GetLWEParams() const {

--- a/src/binfhe/include/lwe-ciphertext.h
+++ b/src/binfhe/include/lwe-ciphertext.h
@@ -49,9 +49,7 @@ class LWECiphertextImpl : public Serializable {
 public:
     LWECiphertextImpl() = default;
 
-    explicit LWECiphertextImpl(const NativeVector&& a, const NativeInteger& b) : m_a(std::move(a)), m_b(b) {}
-
-    explicit LWECiphertextImpl(const NativeVector& a, const NativeInteger& b) : m_a(a), m_b(b) {}
+    LWECiphertextImpl(const NativeVector& a, const NativeInteger& b) : m_a(a), m_b(b) {}
 
     LWECiphertextImpl(NativeVector&& a, NativeInteger b) : m_a(std::move(a)), m_b(b) {}
 
@@ -60,7 +58,7 @@ public:
         m_b = rhs.m_b;
     }
 
-    explicit LWECiphertextImpl(const LWECiphertextImpl&& rhs) {
+    explicit LWECiphertextImpl(LWECiphertextImpl&& rhs) {
         m_a = std::move(rhs.m_a);
         m_b = std::move(rhs.m_b);
     }
@@ -71,7 +69,7 @@ public:
         return *this;
     }
 
-    const LWECiphertextImpl& operator=(const LWECiphertextImpl&& rhs) {
+    const LWECiphertextImpl& operator=(LWECiphertextImpl&& rhs) {
         m_a = std::move(rhs.m_a);
         m_b = std::move(rhs.m_b);
         return *this;

--- a/src/binfhe/include/lwe-cryptoparameters.h
+++ b/src/binfhe/include/lwe-cryptoparameters.h
@@ -82,7 +82,7 @@ public:
         this->m_dgg.SetStd(rhs.m_dgg.GetStd());
     }
 
-    explicit LWECryptoParams(const LWECryptoParams&& rhs) {
+    explicit LWECryptoParams(LWECryptoParams&& rhs) {
         this->m_n      = std::move(rhs.m_n);
         this->m_N      = std::move(rhs.m_N);
         this->m_q      = std::move(rhs.m_q);
@@ -101,7 +101,7 @@ public:
         return *this;
     }
 
-    const LWECryptoParams& operator=(const LWECryptoParams&& rhs) {
+    const LWECryptoParams& operator=(LWECryptoParams&& rhs) {
         this->m_n      = std::move(rhs.m_n);
         this->m_N      = std::move(rhs.m_N);
         this->m_q      = std::move(rhs.m_q);

--- a/src/binfhe/include/lwe-keypair.h
+++ b/src/binfhe/include/lwe-keypair.h
@@ -53,7 +53,7 @@ public:
     LWEPublicKey publicKey;
     LWEPrivateKey secretKey;
 
-    LWEKeyPairImpl(LWEPublicKey Av, LWEPrivateKey s) : publicKey(Av), secretKey(s) {}
+    LWEKeyPairImpl(LWEPublicKey Av, LWEPrivateKey s) : publicKey(std::move(Av)), secretKey(std::move(s)) {}
 
     bool good() {
         return publicKey && secretKey;

--- a/src/binfhe/include/lwe-keyswitchkey.h
+++ b/src/binfhe/include/lwe-keyswitchkey.h
@@ -59,7 +59,7 @@ public:
         m_keyB = rhs.m_keyB;
     }
 
-    explicit LWESwitchingKeyImpl(const LWESwitchingKeyImpl&& rhs) {
+    explicit LWESwitchingKeyImpl(LWESwitchingKeyImpl&& rhs) {
         m_keyA = std::move(rhs.m_keyA);
         m_keyB = std::move(rhs.m_keyB);
     }

--- a/src/binfhe/include/rgsw-acc-cggi.h
+++ b/src/binfhe/include/rgsw-acc-cggi.h
@@ -57,7 +57,7 @@ public:
    * key)
    * @return a shared pointer to the resulting ciphertext
    */
-    RingGSWACCKey KeyGenAcc(const std::shared_ptr<RingGSWCryptoParams> params, const NativePoly& skNTT,
+    RingGSWACCKey KeyGenAcc(const std::shared_ptr<RingGSWCryptoParams>& params, const NativePoly& skNTT,
                             ConstLWEPrivateKey LWEsk) const override;
 
     /**
@@ -67,14 +67,14 @@ public:
    * @param &input input ciphertext
    * @param acc previous value of the accumulator
    */
-    void EvalAcc(const std::shared_ptr<RingGSWCryptoParams> params, const RingGSWACCKey ek, RLWECiphertext& acc,
+    void EvalAcc(const std::shared_ptr<RingGSWCryptoParams>& params, ConstRingGSWACCKey& ek, RLWECiphertext& acc,
                  const NativeVector& a) const override;
 
 private:
-    RingGSWEvalKey KeyGenCGGI(const std::shared_ptr<RingGSWCryptoParams> params, const NativePoly& skNTT,
+    RingGSWEvalKey KeyGenCGGI(const std::shared_ptr<RingGSWCryptoParams>& params, const NativePoly& skNTT,
                               const LWEPlaintext& m) const;
 
-    void AddToAccCGGI(const std::shared_ptr<RingGSWCryptoParams> params, const RingGSWEvalKey ek1,
+    void AddToAccCGGI(const std::shared_ptr<RingGSWCryptoParams>& params, const RingGSWEvalKey ek1,
                       const RingGSWEvalKey ek2, const NativeInteger& a, RLWECiphertext& acc) const;
 };
 

--- a/src/binfhe/include/rgsw-acc-dm.h
+++ b/src/binfhe/include/rgsw-acc-dm.h
@@ -57,7 +57,7 @@ public:
    * key)
    * @return a shared pointer to the resulting ciphertext
    */
-    RingGSWACCKey KeyGenAcc(const std::shared_ptr<RingGSWCryptoParams> params, const NativePoly& skNTT,
+    RingGSWACCKey KeyGenAcc(const std::shared_ptr<RingGSWCryptoParams>& params, const NativePoly& skNTT,
                             ConstLWEPrivateKey LWEsk) const override;
 
     /**
@@ -67,14 +67,14 @@ public:
    * @param &input input ciphertext
    * @param acc previous value of the accumulator
    */
-    void EvalAcc(const std::shared_ptr<RingGSWCryptoParams> params, const RingGSWACCKey ek, RLWECiphertext& acc,
+    void EvalAcc(const std::shared_ptr<RingGSWCryptoParams>& params, ConstRingGSWACCKey& ek, RLWECiphertext& acc,
                  const NativeVector& a) const override;
 
 private:
-    RingGSWEvalKey KeyGenDM(const std::shared_ptr<RingGSWCryptoParams> params, const NativePoly& skNTT,
+    RingGSWEvalKey KeyGenDM(const std::shared_ptr<RingGSWCryptoParams>& params, const NativePoly& skNTT,
                             const LWEPlaintext& m) const;
 
-    void AddToAccDM(const std::shared_ptr<RingGSWCryptoParams> params, const RingGSWEvalKey ek,
+    void AddToAccDM(const std::shared_ptr<RingGSWCryptoParams>& params, const RingGSWEvalKey ek,
                     RLWECiphertext& acc) const;
 };
 

--- a/src/binfhe/include/rgsw-acc.h
+++ b/src/binfhe/include/rgsw-acc.h
@@ -58,7 +58,7 @@ public:
    * key)
    * @return a shared pointer to the resulting ciphertext
    */
-    virtual RingGSWACCKey KeyGenAcc(const std::shared_ptr<RingGSWCryptoParams> params, const NativePoly& skNTT,
+    virtual RingGSWACCKey KeyGenAcc(const std::shared_ptr<RingGSWCryptoParams>& params, const NativePoly& skNTT,
                                     ConstLWEPrivateKey LWEsk) const {
         OPENFHE_THROW(not_implemented_error, "KeyGenACC operation not supported");
     }
@@ -70,7 +70,7 @@ public:
    * @param &input input ciphertext
    * @param acc previous value of the accumulator
    */
-    virtual void EvalAcc(const std::shared_ptr<RingGSWCryptoParams> params, const RingGSWACCKey ek, RLWECiphertext& acc,
+    virtual void EvalAcc(const std::shared_ptr<RingGSWCryptoParams>& params, ConstRingGSWACCKey& ek, RLWECiphertext& acc,
                          const NativeVector& a) const {
         OPENFHE_THROW(not_implemented_error, "ACC operation not supported");
     }
@@ -83,7 +83,7 @@ public:
    * @param &input input RLWE ciphertext
    * @param output input RLWE ciphertext
    */
-    void SignedDigitDecompose(const std::shared_ptr<RingGSWCryptoParams> params, const std::vector<NativePoly>& input,
+    void SignedDigitDecompose(const std::shared_ptr<RingGSWCryptoParams>& params, const std::vector<NativePoly>& input,
                               std::vector<NativePoly>& output) const;
 };
 

--- a/src/binfhe/include/rgsw-acckey.h
+++ b/src/binfhe/include/rgsw-acckey.h
@@ -83,7 +83,7 @@ public:
         this->m_key = rhs.m_key;
     }
 
-    explicit RingGSWACCKeyImpl(const RingGSWACCKeyImpl&& rhs) {
+    explicit RingGSWACCKeyImpl(RingGSWACCKeyImpl&& rhs) {
         this->m_key = std::move(rhs.m_key);
     }
 
@@ -92,7 +92,7 @@ public:
         return *this;
     }
 
-    const RingGSWACCKeyImpl& operator=(const RingGSWACCKeyImpl&& rhs) {
+    const RingGSWACCKeyImpl& operator=(RingGSWACCKeyImpl&& rhs) {
         this->m_key = std::move(rhs.m_key);
         return *this;
     }

--- a/src/binfhe/include/rgsw-evalkey.h
+++ b/src/binfhe/include/rgsw-evalkey.h
@@ -78,7 +78,7 @@ public:
         this->m_elements = rhs.m_elements;
     }
 
-    explicit RingGSWEvalKeyImpl(const RingGSWEvalKeyImpl&& rhs) {
+    explicit RingGSWEvalKeyImpl(RingGSWEvalKeyImpl&& rhs) {
         this->m_elements = std::move(rhs.m_elements);
     }
 
@@ -87,7 +87,7 @@ public:
         return *this;
     }
 
-    const RingGSWEvalKeyImpl& operator=(const RingGSWEvalKeyImpl&& rhs) {
+    const RingGSWEvalKeyImpl& operator=(RingGSWEvalKeyImpl&& rhs) {
         this->m_elements = rhs.m_elements;
         return *this;
     }

--- a/src/binfhe/include/rlwe-ciphertext.h
+++ b/src/binfhe/include/rlwe-ciphertext.h
@@ -72,7 +72,7 @@ public:
         this->m_elements = rhs.m_elements;
     }
 
-    explicit RLWECiphertextImpl(const RLWECiphertextImpl&& rhs) {
+    explicit RLWECiphertextImpl(RLWECiphertextImpl&& rhs) {
         this->m_elements = std::move(rhs.m_elements);
     }
 
@@ -81,7 +81,7 @@ public:
         return *this;
     }
 
-    const RLWECiphertextImpl& operator=(const RLWECiphertextImpl&& rhs) {
+    const RLWECiphertextImpl& operator=(RLWECiphertextImpl&& rhs) {
         this->m_elements = rhs.m_elements;
         return *this;
     }

--- a/src/binfhe/lib/rgsw-acc-cggi.cpp
+++ b/src/binfhe/lib/rgsw-acc-cggi.cpp
@@ -36,7 +36,7 @@
 namespace lbcrypto {
 
 // Key generation as described in Section 4 of https://eprint.iacr.org/2014/816
-RingGSWACCKey RingGSWAccumulatorCGGI::KeyGenAcc(const std::shared_ptr<RingGSWCryptoParams> params,
+RingGSWACCKey RingGSWAccumulatorCGGI::KeyGenAcc(const std::shared_ptr<RingGSWCryptoParams>& params,
                                                 const NativePoly& skNTT, ConstLWEPrivateKey LWEsk) const {
     auto sv         = LWEsk->GetElement();
     int32_t mod     = sv.GetModulus().ConvertToInt();
@@ -75,7 +75,7 @@ RingGSWACCKey RingGSWAccumulatorCGGI::KeyGenAcc(const std::shared_ptr<RingGSWCry
     return ek;
 }
 
-void RingGSWAccumulatorCGGI::EvalAcc(const std::shared_ptr<RingGSWCryptoParams> params, const RingGSWACCKey ek,
+void RingGSWAccumulatorCGGI::EvalAcc(const std::shared_ptr<RingGSWCryptoParams>& params, ConstRingGSWACCKey& ek,
                                      RLWECiphertext& acc, const NativeVector& a) const {
     auto mod        = a.GetModulus();
     uint32_t n      = a.GetLength();
@@ -89,7 +89,7 @@ void RingGSWAccumulatorCGGI::EvalAcc(const std::shared_ptr<RingGSWCryptoParams> 
 }
 
 // Encryption for the CGGI variant, as described in https://eprint.iacr.org/2020/086
-RingGSWEvalKey RingGSWAccumulatorCGGI::KeyGenCGGI(const std::shared_ptr<RingGSWCryptoParams> params,
+RingGSWEvalKey RingGSWAccumulatorCGGI::KeyGenCGGI(const std::shared_ptr<RingGSWCryptoParams>& params,
                                                   const NativePoly& skNTT, const LWEPlaintext& m) const {
     NativeInteger Q   = params->GetQ();
     uint32_t digitsG  = params->GetDigitsG();
@@ -133,7 +133,7 @@ RingGSWEvalKey RingGSWAccumulatorCGGI::KeyGenCGGI(const std::shared_ptr<RingGSWC
 // Added ternary MUX introduced in paper https://eprint.iacr.org/2022/074.pdf section 5
 // We optimize the algorithm by multiplying the monomial after the external product
 // This reduces the number of polynomial multiplications which further reduces the runtime
-void RingGSWAccumulatorCGGI::AddToAccCGGI(const std::shared_ptr<RingGSWCryptoParams> params, const RingGSWEvalKey ek1,
+void RingGSWAccumulatorCGGI::AddToAccCGGI(const std::shared_ptr<RingGSWCryptoParams>& params, const RingGSWEvalKey ek1,
                                           const RingGSWEvalKey ek2, const NativeInteger& a, RLWECiphertext& acc) const {
     // cycltomic order
     uint64_t MInt = 2 * params->GetN();

--- a/src/binfhe/lib/rgsw-acc-dm.cpp
+++ b/src/binfhe/lib/rgsw-acc-dm.cpp
@@ -36,7 +36,7 @@
 namespace lbcrypto {
 
 // Key generation as described in Section 4 of https://eprint.iacr.org/2014/816
-RingGSWACCKey RingGSWAccumulatorDM::KeyGenAcc(const std::shared_ptr<RingGSWCryptoParams> params,
+RingGSWACCKey RingGSWAccumulatorDM::KeyGenAcc(const std::shared_ptr<RingGSWCryptoParams>& params,
                                               const NativePoly& skNTT, ConstLWEPrivateKey LWEsk) const {
     auto sv     = LWEsk->GetElement();
     int32_t mod = sv.GetModulus().ConvertToInt();
@@ -65,7 +65,7 @@ RingGSWACCKey RingGSWAccumulatorDM::KeyGenAcc(const std::shared_ptr<RingGSWCrypt
     return ek;
 }
 
-void RingGSWAccumulatorDM::EvalAcc(const std::shared_ptr<RingGSWCryptoParams> params, const RingGSWACCKey ek,
+void RingGSWAccumulatorDM::EvalAcc(const std::shared_ptr<RingGSWCryptoParams>& params, ConstRingGSWACCKey& ek,
                                    RLWECiphertext& acc, const NativeVector& a) const {
     uint32_t baseR = params->GetBaseR();
     auto digitsR   = params->GetDigitsR();
@@ -84,7 +84,7 @@ void RingGSWAccumulatorDM::EvalAcc(const std::shared_ptr<RingGSWCryptoParams> pa
 
 // Encryption as described in Section 5 of https://eprint.iacr.org/2014/816
 // skNTT corresponds to the secret key z
-RingGSWEvalKey RingGSWAccumulatorDM::KeyGenDM(const std::shared_ptr<RingGSWCryptoParams> params,
+RingGSWEvalKey RingGSWAccumulatorDM::KeyGenDM(const std::shared_ptr<RingGSWCryptoParams>& params,
                                               const NativePoly& skNTT, const LWEPlaintext& m) const {
     NativeInteger Q   = params->GetQ();
     uint64_t q        = params->Getq().ConvertToInt();
@@ -143,7 +143,7 @@ RingGSWEvalKey RingGSWAccumulatorDM::KeyGenDM(const std::shared_ptr<RingGSWCrypt
 }
 
 // AP Accumulation as described in https://eprint.iacr.org/2020/086
-void RingGSWAccumulatorDM::AddToAccDM(const std::shared_ptr<RingGSWCryptoParams> params, const RingGSWEvalKey ek,
+void RingGSWAccumulatorDM::AddToAccDM(const std::shared_ptr<RingGSWCryptoParams>& params, const RingGSWEvalKey ek,
                                       RLWECiphertext& acc) const {
     uint32_t digitsG2 = params->GetDigitsG() << 1;
     auto polyParams   = params->GetPolyParams();

--- a/src/binfhe/lib/rgsw-acc.cpp
+++ b/src/binfhe/lib/rgsw-acc.cpp
@@ -54,7 +54,7 @@ namespace lbcrypto {
 // There are two approaches to do it.
 // The current approach appears to give the best performance
 // results. The two variants are labeled A and B.
-void RingGSWAccumulator::SignedDigitDecompose(const std::shared_ptr<RingGSWCryptoParams> params,
+void RingGSWAccumulator::SignedDigitDecompose(const std::shared_ptr<RingGSWCryptoParams>& params,
                                               const std::vector<NativePoly>& input,
                                               std::vector<NativePoly>& output) const {
     uint32_t N                           = params->GetN();

--- a/src/pke/include/ciphertext.h
+++ b/src/pke/include/ciphertext.h
@@ -395,7 +395,7 @@ public:
     /**
    * Set the Metadata map of the ciphertext.
    */
-    void SetMetadataMap(MetadataMap mdata) {
+    void SetMetadataMap(const MetadataMap& mdata) {
         this->m_metadataMap = mdata;
     }
 
@@ -437,7 +437,7 @@ public:
     /**
    * Get a Metadata element from the Metadata map of the ciphertext.
    */
-    std::shared_ptr<Metadata> GetMetadataByKey(std::string key) const {
+    std::shared_ptr<Metadata> GetMetadataByKey(const std::string& key) const {
         auto it = m_metadataMap->find(key);
         if(it == m_metadataMap->end()) {
             OPENFHE_THROW(openfhe_error, "Metadata element with key [" + key + "] is not found in the Metadata map.");
@@ -448,8 +448,8 @@ public:
     /**
    * Set a Metadata element in the Metadata map of the ciphertext.
    */
-    void SetMetadataByKey(std::string key, std::shared_ptr<Metadata> value) {
-        (*m_metadataMap)[key] = value;
+    void SetMetadataByKey(const std::string& key, std::shared_ptr<Metadata> value) {
+        (*m_metadataMap)[key] = std::move(value);
     }
 
     virtual Ciphertext<Element> Clone() const {

--- a/src/pke/include/cryptocontext.h
+++ b/src/pke/include/cryptocontext.h
@@ -280,7 +280,7 @@ protected:
    * @param a
    * @param b
    */
-    void TypeCheck(const ConstCiphertext<Element> a, const ConstPlaintext b, CALLER_INFO_ARGS_HDR) const {
+    void TypeCheck(const ConstCiphertext<Element> a, const ConstPlaintext& b, CALLER_INFO_ARGS_HDR) const {
         if (a == nullptr) {
             std::string errorMsg(std::string("Null Ciphertext") + CALLER_INFO);
             OPENFHE_THROW(type_error, errorMsg);
@@ -1084,7 +1084,7 @@ public:
    * @param plaintext
    * @return ciphertext (or null on failure)
    */
-    Ciphertext<Element> Encrypt(Plaintext plaintext, const PublicKey<Element> publicKey) const {
+    Ciphertext<Element> Encrypt(const Plaintext& plaintext, const PublicKey<Element> publicKey) const {
         if (plaintext == nullptr)
             OPENFHE_THROW(type_error, "Input plaintext is nullptr");
         CheckKey(publicKey);
@@ -1113,7 +1113,7 @@ public:
    * @param plaintext
    * @return ciphertext (or null on failure)
    */
-    Ciphertext<Element> Encrypt(Plaintext plaintext, const PrivateKey<Element> privateKey) const {
+    Ciphertext<Element> Encrypt(const Plaintext& plaintext, const PrivateKey<Element> privateKey) const {
         //    if (plaintext == nullptr)
         //      OPENFHE_THROW(type_error, "Input plaintext is nullptr");
         CheckKey(privateKey);
@@ -1836,7 +1836,7 @@ public:
         return GetScheme()->FindAutomorphismIndex(idx, m);
     }
 
-    std::vector<usint> FindAutomorphismIndices(const std::vector<usint> idxList) const {
+    std::vector<usint> FindAutomorphismIndices(const std::vector<usint>& idxList) const {
         std::vector<usint> newIndices;
         newIndices.reserve(idxList.size());
         for (const auto idx : idxList) {

--- a/src/pke/include/encoding/ckkspackedencoding.h
+++ b/src/pke/include/encoding/ckkspackedencoding.h
@@ -135,8 +135,8 @@ public:
     CKKSPackedEncoding(const CKKSPackedEncoding& rhs)
         : PlaintextImpl(rhs), value(rhs.value), m_logError(rhs.m_logError) {}
 
-    CKKSPackedEncoding(const CKKSPackedEncoding&& rhs)
-        : PlaintextImpl(rhs), value(std::move(rhs.value)), m_logError(rhs.m_logError) {}
+    CKKSPackedEncoding(CKKSPackedEncoding&& rhs)
+        : PlaintextImpl(std::move(rhs)), value(std::move(rhs.value)), m_logError(rhs.m_logError) {}
 
     bool Encode();
 

--- a/src/pke/include/encoding/encodingparams.h
+++ b/src/pke/include/encoding/encodingparams.h
@@ -71,9 +71,9 @@ public:
                        NativeInteger plaintextRootOfUnity = 0, NativeInteger plaintextBigModulus = 0,
                        NativeInteger plaintextBigRootOfUnity = 0)
         : m_plaintextModulus(plaintextModulus),
-          m_plaintextRootOfUnity(plaintextRootOfUnity),
+          m_plaintextRootOfUnity(std::move(plaintextRootOfUnity)),
           m_plaintextBigModulus(plaintextBigModulus),
-          m_plaintextBigRootOfUnity(plaintextBigRootOfUnity),
+          m_plaintextBigRootOfUnity(std::move(plaintextBigRootOfUnity)),
           m_plaintextGenerator(plaintextGenerator),
           m_batchSize(batchSize) {}
 
@@ -96,7 +96,7 @@ public:
    *
    * @param &rhs the input set of parameters which is copied.
    */
-    EncodingParamsImpl(const EncodingParamsImpl&& rhs) {
+    EncodingParamsImpl(EncodingParamsImpl&& rhs) {
         m_plaintextModulus        = std::move(rhs.m_plaintextModulus);
         m_plaintextRootOfUnity    = std::move(rhs.m_plaintextRootOfUnity);
         m_plaintextBigModulus     = std::move(rhs.m_plaintextBigModulus);
@@ -308,12 +308,12 @@ public:
     }
 };
 
-inline std::ostream& operator<<(std::ostream& out, std::shared_ptr<EncodingParamsImpl> o) {
+inline std::ostream& operator<<(std::ostream& out, const std::shared_ptr<EncodingParamsImpl>& o) {
     if (o)
         out << *o;
     return out;
 }
-inline bool operator==(std::shared_ptr<EncodingParamsImpl> o1, std::shared_ptr<EncodingParamsImpl> o2) {
+inline bool operator==(std::shared_ptr<EncodingParamsImpl> o1, const std::shared_ptr<EncodingParamsImpl>& o2) {
     if (o1 && o2)
         return *o1 == *o2;
     if (!o1 && !o2)

--- a/src/pke/include/encoding/plaintext.h
+++ b/src/pke/include/encoding/plaintext.h
@@ -86,27 +86,27 @@ protected:
     SCHEME schemeID;
 
 public:
-    PlaintextImpl(std::shared_ptr<Poly::Params> vp, EncodingParams ep, SCHEME schemeTag = SCHEME::INVALID_SCHEME,
+    PlaintextImpl(const std::shared_ptr<Poly::Params>& vp, EncodingParams ep, SCHEME schemeTag = SCHEME::INVALID_SCHEME,
                   bool isEncoded = false)
         : isEncoded(isEncoded),
           typeFlag(IsPoly),
-          encodingParams(ep),
+          encodingParams(std::move(ep)),
           encodedVector(vp, Format::COEFFICIENT),
           schemeID(schemeTag) {}
 
-    PlaintextImpl(std::shared_ptr<NativePoly::Params> vp, EncodingParams ep, SCHEME schemeTag = SCHEME::INVALID_SCHEME,
+    PlaintextImpl(const std::shared_ptr<NativePoly::Params>& vp, EncodingParams ep, SCHEME schemeTag = SCHEME::INVALID_SCHEME,
                   bool isEncoded = false)
         : isEncoded(isEncoded),
           typeFlag(IsNativePoly),
-          encodingParams(ep),
+          encodingParams(std::move(ep)),
           encodedNativeVector(vp, Format::COEFFICIENT),
           schemeID(schemeTag) {}
 
-    PlaintextImpl(std::shared_ptr<DCRTPoly::Params> vp, EncodingParams ep, SCHEME schemeTag = SCHEME::INVALID_SCHEME,
+    PlaintextImpl(const std::shared_ptr<DCRTPoly::Params>& vp, EncodingParams ep, SCHEME schemeTag = SCHEME::INVALID_SCHEME,
                   bool isEncoded = false)
         : isEncoded(isEncoded),
           typeFlag(IsDCRTPoly),
-          encodingParams(ep),
+          encodingParams(std::move(ep)),
           encodedVector(vp, Format::COEFFICIENT),
           encodedVectorDCRT(vp, Format::COEFFICIENT),
           schemeID(schemeTag) {}
@@ -124,7 +124,7 @@ public:
           slots(rhs.slots),
           schemeID(rhs.schemeID) {}
 
-    PlaintextImpl(const PlaintextImpl&& rhs)
+    PlaintextImpl(PlaintextImpl&& rhs)
         : isEncoded(rhs.isEncoded),
           typeFlag(rhs.typeFlag),
           encodingParams(std::move(rhs.encodingParams)),
@@ -417,16 +417,16 @@ inline std::ostream& operator<<(std::ostream& out, const PlaintextImpl& item) {
     return out;
 }
 
-inline std::ostream& operator<<(std::ostream& out, const Plaintext item) {
+inline std::ostream& operator<<(std::ostream& out, const Plaintext& item) {
     item->PrintValue(out);
     return out;
 }
 
-inline bool operator==(const Plaintext p1, const Plaintext p2) {
+inline bool operator==(const Plaintext& p1, const Plaintext& p2) {
     return *p1 == *p2;
 }
 
-inline bool operator!=(const Plaintext p1, const Plaintext p2) {
+inline bool operator!=(const Plaintext& p1, const Plaintext& p2) {
     return *p1 != *p2;
 }
 

--- a/src/pke/include/schemerns/rns-cryptoparameters.h
+++ b/src/pke/include/schemerns/rns-cryptoparameters.h
@@ -102,7 +102,7 @@ protected:
                         MultipartyMode multipartyMode           = FIXED_NOISE_MULTIPARTY,
                         ExecutionMode executionMode             = EXEC_EVALUATION,
                         DecryptionNoiseMode decryptionNoiseMode = FIXED_NOISE_DECRYPT)
-        : CryptoParametersRLWE<DCRTPoly>(params, EncodingParams(std::make_shared<EncodingParamsImpl>(plaintextModulus)),
+        : CryptoParametersRLWE<DCRTPoly>(std::move(params), EncodingParams(std::make_shared<EncodingParamsImpl>(plaintextModulus)),
                                          distributionParameter, assuranceMeasure, securityLevel, digitSize,
                                          maxRelinSkDeg, secretKeyDist, INDCPA, multipartyMode, executionMode,
                                          decryptionNoiseMode) {
@@ -122,7 +122,7 @@ protected:
                         DecryptionNoiseMode decryptionNoiseMode = FIXED_NOISE_DECRYPT, PlaintextModulus noiseScale = 1,
                         uint32_t statisticalSecurity = 30, uint32_t numAdversarialQueries = 1,
                         uint32_t thresholdNumOfParties = 1)
-        : CryptoParametersRLWE<DCRTPoly>(params, encodingParams, distributionParameter, assuranceMeasure, securityLevel,
+        : CryptoParametersRLWE<DCRTPoly>(std::move(params), std::move(encodingParams), distributionParameter, assuranceMeasure, securityLevel,
                                          digitSize, maxRelinSkDeg, secretKeyDist, PREMode, multipartyMode,
                                          executionMode, decryptionNoiseMode, noiseScale, statisticalSecurity,
                                          numAdversarialQueries, thresholdNumOfParties) {


### PR DESCRIPTION
Changes made in this commit:
- Identified instances of unnecessary copying in the codebase.
- Replaced the copy operations with move operations where appropriate.
- Updated relevant function signatures and parameter types to support move semantics.
- Ensured that the necessary objects were in a valid state after the move operations.
