### PR TITLE
Add numAutoKeys to RingGSWCryptoParams

### DIFF
--- a/src/binfhe/include/binfhecontext.h
+++ b/src/binfhe/include/binfhecontext.h
@@ -74,8 +74,8 @@ public:
    * @return creates the cryptocontext
    */
     void GenerateBinFHEContext(uint32_t n, uint32_t N, const NativeInteger& q, const NativeInteger& Q, double std,
-                               uint32_t baseKS, uint32_t baseG, uint32_t baseR, uint32_t numAutoKeys = 1,
-                               SECRET_KEY_DIST keyDist = UNIFORM_TERNARY, BINFHE_METHOD method = GINX);
+                               uint32_t baseKS, uint32_t baseG, uint32_t baseR, SECRET_KEY_DIST keyDist = UNIFORM_TERNARY, 
+                               BINFHE_METHOD method = GINX, uint32_t numAutoKeys = 10);
 
     /**
    * Creates a crypto context using custom parameters.

--- a/src/binfhe/include/binfhecontext.h
+++ b/src/binfhe/include/binfhecontext.h
@@ -74,7 +74,8 @@ public:
    * @return creates the cryptocontext
    */
     void GenerateBinFHEContext(uint32_t n, uint32_t N, const NativeInteger& q, const NativeInteger& Q, double std,
-                               uint32_t baseKS, uint32_t baseG, uint32_t baseR, BINFHE_METHOD method = GINX);
+                               uint32_t baseKS, uint32_t baseG, uint32_t baseR, uint32_t numAutoKeys = 1,
+                               SECRET_KEY_DIST keyDist = UNIFORM_TERNARY, BINFHE_METHOD method = GINX);
 
     /**
    * Creates a crypto context using custom parameters.

--- a/src/binfhe/include/rgsw-acc-lmkcdey.h
+++ b/src/binfhe/include/rgsw-acc-lmkcdey.h
@@ -71,8 +71,6 @@ public:
                  const NativeVector& a) const override;
 
 private:
-    const uint32_t m_window = 10;
-
     RingGSWEvalKey KeyGenLMKCDEY(const std::shared_ptr<RingGSWCryptoParams> params, const NativePoly& skNTT,
                             const LWEPlaintext& m) const;
                             

--- a/src/binfhe/include/rgsw-cryptoparameters.h
+++ b/src/binfhe/include/rgsw-cryptoparameters.h
@@ -69,9 +69,10 @@ public:
    * @param method bootstrapping method (DM or CGGI or LMKCDEY)
    */
     explicit RingGSWCryptoParams(uint32_t N, NativeInteger Q, NativeInteger q, uint32_t baseG, uint32_t baseR,
-                                 BINFHE_METHOD method, double std, SECRET_KEY_DIST keyDist = UNIFORM_TERNARY,
-                                 bool signEval = false)
-        : m_N(N), m_Q(Q), m_q(q), m_baseG(baseG), m_baseR(baseR), m_method(method), m_keyDist(keyDist) {
+                                 uint32_t numAutoKeys, BINFHE_METHOD method, double std, 
+                                 SECRET_KEY_DIST keyDist = UNIFORM_TERNARY, bool signEval = false)
+        : m_N(N), m_Q(Q), m_q(q), m_baseG(baseG), m_baseR(baseR), m_numAutoKeys(numAutoKeys), m_method(method), 
+        m_keyDist(keyDist) {
         if (!IsPowerOfTwo(baseG)) {
             OPENFHE_THROW(config_error, "Gadget base should be a power of two.");
         }
@@ -116,6 +117,10 @@ public:
 
     uint32_t GetBaseR() const {
         return m_baseR;
+    }
+
+    uint32_t GetNumAutoKeys() const{
+        return m_numAutoKeys;
     }
 
     const std::vector<NativeInteger>& GetDigitsR() const {
@@ -233,6 +238,9 @@ private:
 
     // base used for the refreshing key (used only for DM bootstrapping)
     uint32_t m_baseR = 0;
+
+    // number of automorphism keys (used only for LMKCDEY bootstrapping)
+    uint32_t m_numAutoKeys = 0;
 
     // powers of m_baseR (used only for DM bootstrapping)
     std::vector<NativeInteger> m_digitsR;

--- a/src/binfhe/include/rgsw-cryptoparameters.h
+++ b/src/binfhe/include/rgsw-cryptoparameters.h
@@ -69,12 +69,15 @@ public:
    * @param method bootstrapping method (DM or CGGI or LMKCDEY)
    */
     explicit RingGSWCryptoParams(uint32_t N, NativeInteger Q, NativeInteger q, uint32_t baseG, uint32_t baseR,
-                                 uint32_t numAutoKeys, BINFHE_METHOD method, double std, 
-                                 SECRET_KEY_DIST keyDist = UNIFORM_TERNARY, bool signEval = false)
-        : m_N(N), m_Q(Q), m_q(q), m_baseG(baseG), m_baseR(baseR), m_numAutoKeys(numAutoKeys), m_method(method), 
-        m_keyDist(keyDist) {
+                                 BINFHE_METHOD method, double std, SECRET_KEY_DIST keyDist = UNIFORM_TERNARY, 
+                                 bool signEval = false, uint32_t numAutoKeys = 10)
+        : m_N(N), m_Q(Q), m_q(q), m_baseG(baseG), m_baseR(baseR), m_method(method), m_keyDist(keyDist), 
+          m_numAutoKeys(numAutoKeys) {
         if (!IsPowerOfTwo(baseG)) {
             OPENFHE_THROW(config_error, "Gadget base should be a power of two.");
+        }
+        if ((method == LMKCDEY) & (numAutoKeys == 0)){
+            OPENFHE_THROW(config_error, "numAutoKeys should be greater than 0.");
         }
 
         m_dgg.SetStd(std);
@@ -239,9 +242,6 @@ private:
     // base used for the refreshing key (used only for DM bootstrapping)
     uint32_t m_baseR = 0;
 
-    // number of automorphism keys (used only for LMKCDEY bootstrapping)
-    uint32_t m_numAutoKeys = 0;
-
     // powers of m_baseR (used only for DM bootstrapping)
     std::vector<NativeInteger> m_digitsR;
 
@@ -277,6 +277,9 @@ private:
 
     // Secret key distribution: GAUSSIAN, UNIFORM_TERNARY, etc.
     SECRET_KEY_DIST m_keyDist = UNIFORM_TERNARY;
+
+    // number of automorphism keys (used only for LMKCDEY bootstrapping)
+    uint32_t m_numAutoKeys = 0;
 };
 
 }  // namespace lbcrypto

--- a/src/binfhe/include/rgsw-cryptoparameters.h
+++ b/src/binfhe/include/rgsw-cryptoparameters.h
@@ -69,14 +69,20 @@ public:
    * @param method bootstrapping method (DM or CGGI or LMKCDEY)
    */
     explicit RingGSWCryptoParams(uint32_t N, NativeInteger Q, NativeInteger q, uint32_t baseG, uint32_t baseR,
-                                 BINFHE_METHOD method, double std, SECRET_KEY_DIST keyDist = UNIFORM_TERNARY, 
+                                 BINFHE_METHOD method, double std, SECRET_KEY_DIST keyDist = UNIFORM_TERNARY,
                                  bool signEval = false, uint32_t numAutoKeys = 10)
-        : m_N(N), m_Q(Q), m_q(q), m_baseG(baseG), m_baseR(baseR), m_method(method), m_keyDist(keyDist), 
+        : m_N(N),
+          m_Q(Q),
+          m_q(q),
+          m_baseG(baseG),
+          m_baseR(baseR),
+          m_method(method),
+          m_keyDist(keyDist),
           m_numAutoKeys(numAutoKeys) {
         if (!IsPowerOfTwo(baseG)) {
             OPENFHE_THROW(config_error, "Gadget base should be a power of two.");
         }
-        if ((method == LMKCDEY) & (numAutoKeys == 0)){
+        if ((method == LMKCDEY) & (numAutoKeys == 0)) {
             OPENFHE_THROW(config_error, "numAutoKeys should be greater than 0.");
         }
 
@@ -122,7 +128,7 @@ public:
         return m_baseR;
     }
 
-    uint32_t GetNumAutoKeys() const{
+    uint32_t GetNumAutoKeys() const {
         return m_numAutoKeys;
     }
 
@@ -185,6 +191,7 @@ public:
         ar(::cereal::make_nvp("bs", m_dgg.GetStd()));
         ar(::cereal::make_nvp("bdigitsG", m_digitsG));
         ar(::cereal::make_nvp("bparams", m_polyParams));
+        ar(::cereal::make_nvp("numAutoKeys", m_numAutoKeys));
     }
 
     template <class Archive>
@@ -204,6 +211,7 @@ public:
         m_dgg.SetStd(sigma);
         ar(::cereal::make_nvp("bdigitsG", m_digitsG));
         ar(::cereal::make_nvp("bparams", m_polyParams));
+        ar(::cereal::make_nvp("numAutoKeys", m_numAutoKeys));
 
         PreCompute();
     }

--- a/src/binfhe/lib/binfhecontext.cpp
+++ b/src/binfhe/lib/binfhecontext.cpp
@@ -41,9 +41,9 @@ namespace lbcrypto {
 
 void BinFHEContext::GenerateBinFHEContext(uint32_t n, uint32_t N, const NativeInteger& q, const NativeInteger& Q,
                                           double std, uint32_t baseKS, uint32_t baseG, uint32_t baseR, 
-                                          uint32_t numAutoKeys, SECRET_KEY_DIST keyDist, BINFHE_METHOD method) {
+                                          SECRET_KEY_DIST keyDist, BINFHE_METHOD method, uint32_t numAutoKeys) {
     auto lweparams  = std::make_shared<LWECryptoParams>(n, N, q, Q, Q, std, baseKS);
-    auto rgswparams = std::make_shared<RingGSWCryptoParams>(N, Q, q, baseG, baseR, numAutoKeys, method, std, keyDist, true);
+    auto rgswparams = std::make_shared<RingGSWCryptoParams>(N, Q, q, baseG, baseR, method, std, keyDist, true, numAutoKeys);
     m_params        = std::make_shared<BinFHECryptoParams>(lweparams, rgswparams);
     m_binfhescheme  = std::make_shared<BinFHEScheme>(method);
 }
@@ -100,7 +100,7 @@ void BinFHEContext::GenerateBinFHEContext(BINFHE_PARAMSET set, bool arbFunc, uin
 
     uint32_t n      = (set == TOY) ? 32 : 1305;
     auto lweparams  = std::make_shared<LWECryptoParams>(n, ringDim, q, Q, qKS, 3.19, 32);
-    auto rgswparams = std::make_shared<RingGSWCryptoParams>(ringDim, Q, q, baseG, 23, 0, method, 3.19, UNIFORM_TERNARY,
+    auto rgswparams = std::make_shared<RingGSWCryptoParams>(ringDim, Q, q, baseG, 23, method, 3.19, UNIFORM_TERNARY,
                                                             ((logQ != 11) && timeOptimization));
 
     m_params       = std::make_shared<BinFHECryptoParams>(lweparams, rgswparams);
@@ -143,21 +143,21 @@ void BinFHEContext::GenerateBinFHEContext(BINFHE_PARAMSET set, BINFHE_METHOD met
         { TOY,             { 27,     1024,          64,  512,   PRIME, STD_DEV,     25,    1 <<  9,  23,     9,  UNIFORM_TERNARY} },
         { MEDIUM,          { 28,     2048,         422, 1024, 1 << 14, STD_DEV, 1 << 7,    1 << 10,  32,    10,  UNIFORM_TERNARY} },
         { STD128_LMKCDEY,  { 28,     2048,         458, 1024, 1 << 14, STD_DEV, 1 << 7,    1 << 10,  32,    10,  GAUSSIAN       } },
-        { STD128_AP,       { 27,     2048,         512, 1024, 1 << 14, STD_DEV, 1 << 7,    1 <<  9,  32,     0,  UNIFORM_TERNARY} },
-        { STD128_APOPT,    { 27,     2048,         502, 1024, 1 << 14, STD_DEV, 1 << 7,    1 <<  9,  32,     0,  UNIFORM_TERNARY} },
-        { STD128,          { 27,     2048,         512, 1024, 1 << 14, STD_DEV, 1 << 7,    1 <<  7,  32,     0,  UNIFORM_TERNARY} },
-        { STD128_OPT,      { 27,     2048,         502, 1024, 1 << 14, STD_DEV, 1 << 7,    1 <<  7,  32,     0,  UNIFORM_TERNARY} },
-        { STD192,          { 37,     4096,        1024, 1024, 1 << 19, STD_DEV,     28,    1 << 13,  32,     0,  UNIFORM_TERNARY} },
-        { STD192_OPT,      { 37,     4096,         805, 1024, 1 << 15, STD_DEV,     32,    1 << 13,  32,     0,  UNIFORM_TERNARY} },
-        { STD256,          { 29,     4096,        1024, 2048, 1 << 14, STD_DEV, 1 << 7,    1 <<  8,  46,     0,  UNIFORM_TERNARY} },
-        { STD256_OPT,      { 29,     4096,         990, 2048, 1 << 14, STD_DEV, 1 << 7,    1 <<  8,  46,     0,  UNIFORM_TERNARY} },
-        { STD128Q,         { 50,     4096,        1024, 1024, 1 << 25, STD_DEV,     32,    1 << 25,  32,     0,  UNIFORM_TERNARY} },
-        { STD128Q_OPT,     { 50,     4096,         585, 1024, 1 << 15, STD_DEV,     32,    1 << 25,  32,     0,  UNIFORM_TERNARY} },
-        { STD192Q,         { 35,     4096,        1024, 1024, 1 << 17, STD_DEV,     64,    1 << 12,  32,     0,  UNIFORM_TERNARY} },
-        { STD192Q_OPT,     { 35,     4096,         875, 1024, 1 << 15, STD_DEV,     32,    1 << 12,  32,     0,  UNIFORM_TERNARY} },
-        { STD256Q,         { 27,     4096,        2048, 2048, 1 << 16, STD_DEV,     16,    1 <<  7,  46,     0,  UNIFORM_TERNARY} },
-        { STD256Q_OPT,     { 27,     4096,        1225, 1024, 1 << 16, STD_DEV,     16,    1 <<  7,  32,     0,  UNIFORM_TERNARY} },
-        { SIGNED_MOD_TEST, { 28,     2048,         512, 1024,   PRIME, STD_DEV,     25,    1 <<  7,  23,     0,  UNIFORM_TERNARY} },
+        { STD128_AP,       { 27,     2048,         512, 1024, 1 << 14, STD_DEV, 1 << 7,    1 <<  9,  32,    10,  UNIFORM_TERNARY} },
+        { STD128_APOPT,    { 27,     2048,         502, 1024, 1 << 14, STD_DEV, 1 << 7,    1 <<  9,  32,    10,  UNIFORM_TERNARY} },
+        { STD128,          { 27,     2048,         512, 1024, 1 << 14, STD_DEV, 1 << 7,    1 <<  7,  32,    10,  UNIFORM_TERNARY} },
+        { STD128_OPT,      { 27,     2048,         502, 1024, 1 << 14, STD_DEV, 1 << 7,    1 <<  7,  32,    10,  UNIFORM_TERNARY} },
+        { STD192,          { 37,     4096,        1024, 1024, 1 << 19, STD_DEV,     28,    1 << 13,  32,    10,  UNIFORM_TERNARY} },
+        { STD192_OPT,      { 37,     4096,         805, 1024, 1 << 15, STD_DEV,     32,    1 << 13,  32,    10,  UNIFORM_TERNARY} },
+        { STD256,          { 29,     4096,        1024, 2048, 1 << 14, STD_DEV, 1 << 7,    1 <<  8,  46,    10,  UNIFORM_TERNARY} },
+        { STD256_OPT,      { 29,     4096,         990, 2048, 1 << 14, STD_DEV, 1 << 7,    1 <<  8,  46,    10,  UNIFORM_TERNARY} },
+        { STD128Q,         { 50,     4096,        1024, 1024, 1 << 25, STD_DEV,     32,    1 << 25,  32,    10,  UNIFORM_TERNARY} },
+        { STD128Q_OPT,     { 50,     4096,         585, 1024, 1 << 15, STD_DEV,     32,    1 << 25,  32,    10,  UNIFORM_TERNARY} },
+        { STD192Q,         { 35,     4096,        1024, 1024, 1 << 17, STD_DEV,     64,    1 << 12,  32,    10,  UNIFORM_TERNARY} },
+        { STD192Q_OPT,     { 35,     4096,         875, 1024, 1 << 15, STD_DEV,     32,    1 << 12,  32,    10,  UNIFORM_TERNARY} },
+        { STD256Q,         { 27,     4096,        2048, 2048, 1 << 16, STD_DEV,     16,    1 <<  7,  46,    10,  UNIFORM_TERNARY} },
+        { STD256Q_OPT,     { 27,     4096,        1225, 1024, 1 << 16, STD_DEV,     16,    1 <<  7,  32,    10,  UNIFORM_TERNARY} },
+        { SIGNED_MOD_TEST, { 28,     2048,         512, 1024,   PRIME, STD_DEV,     25,    1 <<  7,  23,    10,  UNIFORM_TERNARY} },
     });
     // clang-format on
 
@@ -179,7 +179,7 @@ void BinFHEContext::GenerateBinFHEContext(BINFHE_PARAMSET set, BINFHE_METHOD met
                           std::make_shared<LWECryptoParams>(params.latticeParam, ringDim, params.mod, Q, params.modKS,
                                                            params.stdDev, params.baseKS, params.keyDist);
     auto rgswparams = std::make_shared<RingGSWCryptoParams>(ringDim, Q, params.mod, params.gadgetBase, params.baseRK,
-                                                            params.numAutoKeys, method, params.stdDev, params.keyDist);
+                                                            method, params.stdDev, params.keyDist, false, params.numAutoKeys);
 
     m_params       = std::make_shared<BinFHECryptoParams>(lweparams, rgswparams);
     m_binfhescheme = std::make_shared<BinFHEScheme>(method);

--- a/src/binfhe/lib/rgsw-acc-lmkcdey.cpp
+++ b/src/binfhe/lib/rgsw-acc-lmkcdey.cpp
@@ -43,6 +43,7 @@ RingGSWACCKey RingGSWAccumulatorLMKCDEY::KeyGenAcc(const std::shared_ptr<RingGSW
     int32_t modHalf = mod >> 1;
     uint32_t N = params->GetN();
     uint32_t n = sv.GetLength();
+    uint32_t numAutoKeys = params->GetNumAutoKeys();
 
     // dim2, 0: for RGSW(X^si), 1: for automorphism keys
     // only w automorphism keys required
@@ -62,10 +63,9 @@ RingGSWACCKey RingGSWAccumulatorLMKCDEY::KeyGenAcc(const std::shared_ptr<RingGSW
     NativeInteger gen = NativeInteger(5);
     
     (*ek)[0][1][0] = KeyGenAuto(params, skNTT, 2*N - gen.ConvertToInt());
-
-    // m_window: window size, consider parameterization in the future
+    
 #pragma omp parallel for
-    for (size_t i = 1; i < m_window+1; i++)
+    for (size_t i = 1; i < numAutoKeys+1; i++)
     {
         (*ek)[0][1][i] = KeyGenAuto(params, skNTT, 
             gen.ModExp(i, 2*N).ConvertToInt());
@@ -80,6 +80,7 @@ void RingGSWAccumulatorLMKCDEY::EvalAcc(const std::shared_ptr<RingGSWCryptoParam
     uint32_t n      = a.GetLength();
     uint32_t Nh     = params->GetN() / 2;
     uint32_t M      = 2 * params->GetN();
+    uint32_t numAutoKeys = params->GetNumAutoKeys();
 
     NativeInteger MNative(M);
 
@@ -123,7 +124,7 @@ void RingGSWAccumulatorLMKCDEY::EvalAcc(const std::shared_ptr<RingGSWCryptoParam
         }
         nSkips++;
 
-        if(nSkips == m_window || i == 1){
+        if(nSkips == numAutoKeys || i == 1){
             Automorphism(params, gen.ModExp(nSkips, M), (*ek)[0][1][nSkips], acc);
             nSkips = 0;
         }
@@ -154,7 +155,7 @@ void RingGSWAccumulatorLMKCDEY::EvalAcc(const std::shared_ptr<RingGSWCryptoParam
         }
         nSkips++;
 
-        if(nSkips == m_window || i == 1){
+        if(nSkips == numAutoKeys || i == 1){
             Automorphism(params, gen.ModExp(nSkips, M), (*ek)[0][1][nSkips], acc);
             nSkips = 0;
         }


### PR DESCRIPTION
This PR introduces parameterization for the number of automorphism keys in the LMKCDEY bootstrapping. 
The formerly hardcoded value of `m_window = 10` has been updated and is now integrated into `RingGSWCryptoParams` under the variable name `numAutoKeys`.