### PR TITLE
added support for Compress to BFV for HPS* modes

### DIFF
--- a/src/core/include/math/hal/intnat/ubintnat.h
+++ b/src/core/include/math/hal/intnat/ubintnat.h
@@ -598,8 +598,10 @@ public:
    * @return is the result of multiply and round operation.
    */
     NativeIntegerT MultiplyAndRound(const NativeIntegerT& p, const NativeIntegerT& q) const {
-        NativeIntegerT ans = m_value * p.m_value;
-        return ans.DivideAndRound(q);
+        double value = static_cast<double>(m_value);
+        double qd    = static_cast<double>(q.m_value);
+        double pd    = static_cast<double>(p.m_value);
+        return static_cast<NativeInt>(pd * (value / qd) + 0.5);
     }
 
     /**
@@ -611,8 +613,10 @@ public:
    * @return is the result of multiply and round operation.
    */
     const NativeIntegerT& MultiplyAndRoundEq(const NativeIntegerT& p, const NativeIntegerT& q) {
-        this->MulEq(p);
-        this->DivideAndRoundEq(q);
+        double value = static_cast<double>(m_value);
+        double qd    = static_cast<double>(q.m_value);
+        double pd    = static_cast<double>(p.m_value);
+        m_value      = static_cast<NativeInt>(pd * (value / qd) + 0.5);
         return *this;
     }
 

--- a/src/pke/include/scheme/bfvrns/bfvrns-leveledshe.h
+++ b/src/pke/include/scheme/bfvrns/bfvrns-leveledshe.h
@@ -119,6 +119,8 @@ public:
 
     usint FindAutomorphismIndex(usint index, usint m) const override;
 
+    Ciphertext<DCRTPoly> Compress(ConstCiphertext<DCRTPoly> ciphertext, size_t towersLeft) const override;
+
     /////////////////////////////////////
     // SERIALIZATION
     /////////////////////////////////////

--- a/src/pke/lib/scheme/bfvrns/bfvrns-pke.cpp
+++ b/src/pke/lib/scheme/bfvrns/bfvrns-pke.cpp
@@ -210,19 +210,38 @@ DecryptResult PKEBFVRNS::Decrypt(ConstCiphertext<DCRTPoly> ciphertext, const Pri
     DCRTPoly b                      = DecryptCore(cv, privateKey);
     b.SetFormat(Format::COEFFICIENT);
 
-    if (cryptoParams->GetMultiplicationTechnique() == HPS || cryptoParams->GetMultiplicationTechnique() == HPSPOVERQ ||
-        cryptoParams->GetMultiplicationTechnique() == HPSPOVERQLEVELED) {
-        *plaintext =
-            b.ScaleAndRound(cryptoParams->GetPlaintextModulus(), cryptoParams->GettQHatInvModqDivqModt(),
-                            cryptoParams->GettQHatInvModqDivqModtPrecon(), cryptoParams->GettQHatInvModqBDivqModt(),
-                            cryptoParams->GettQHatInvModqBDivqModtPrecon(), cryptoParams->GettQHatInvModqDivqFrac(),
-                            cryptoParams->GettQHatInvModqBDivqFrac());
+    size_t sizeQl = b.GetNumOfElements();
+
+    // use RNS procedures only if the number of RNS limbs is larger than 1
+    if (sizeQl > 1) {
+        if (cryptoParams->GetMultiplicationTechnique() == HPS ||
+            cryptoParams->GetMultiplicationTechnique() == HPSPOVERQ ||
+            cryptoParams->GetMultiplicationTechnique() == HPSPOVERQLEVELED) {
+            *plaintext =
+                b.ScaleAndRound(cryptoParams->GetPlaintextModulus(), cryptoParams->GettQHatInvModqDivqModt(),
+                                cryptoParams->GettQHatInvModqDivqModtPrecon(), cryptoParams->GettQHatInvModqBDivqModt(),
+                                cryptoParams->GettQHatInvModqBDivqModtPrecon(), cryptoParams->GettQHatInvModqDivqFrac(),
+                                cryptoParams->GettQHatInvModqBDivqFrac());
+        }
+        else {
+            *plaintext = b.ScaleAndRound(
+                cryptoParams->GetModuliQ(), cryptoParams->GetPlaintextModulus(), cryptoParams->Gettgamma(),
+                cryptoParams->GettgammaQHatInvModq(), cryptoParams->GettgammaQHatInvModqPrecon(),
+                cryptoParams->GetNegInvqModtgamma(), cryptoParams->GetNegInvqModtgammaPrecon());
+        }
     }
     else {
-        *plaintext =
-            b.ScaleAndRound(cryptoParams->GetModuliQ(), cryptoParams->GetPlaintextModulus(), cryptoParams->Gettgamma(),
-                            cryptoParams->GettgammaQHatInvModq(), cryptoParams->GettgammaQHatInvModqPrecon(),
-                            cryptoParams->GetNegInvqModtgamma(), cryptoParams->GetNegInvqModtgammaPrecon());
+        const NativeInteger t = cryptoParams->GetPlaintextModulus();
+        NativePoly element    = b.GetElementAtIndex(0);
+        const NativeInteger q = element.GetModulus();
+        element               = element.MultiplyAndRound(t, q);
+
+        // Setting the root of unity to ONE as the calculation is expensive
+        // It is assumed that no polynomial multiplications in evaluation
+        // representation are performed after this
+        element.SwitchModulus(t, 1, 0, 0);
+
+        *plaintext = element;
     }
 
     return DecryptResult(plaintext->GetLength());

--- a/src/pke/unittest/UnitTestSHE.cpp
+++ b/src/pke/unittest/UnitTestSHE.cpp
@@ -646,14 +646,36 @@ protected:
             Plaintext results;
 
             cResult = cc->EvalMult(ciphertext1, ciphertext2);
+
             cc->Decrypt(kp.secretKey, cResult, &results);
             results->SetLength(intArrayExpected->GetLength());
             EXPECT_EQ(intArrayExpected->GetPackedValue(), results->GetPackedValue()) << failmsg << " EvalMult fails";
 
+            if (!((cc->getSchemeId() == SCHEME::BFVRNS_SCHEME) &&
+                  (std::dynamic_pointer_cast<CryptoParametersBFVRNS>(cc->GetCryptoParameters())
+                       ->GetMultiplicationTechnique() == BEHZ))) {
+                cResult = cc->Compress(cResult, 1);
+                cc->Decrypt(kp.secretKey, cResult, &results);
+                results->SetLength(intArrayExpected->GetLength());
+                EXPECT_EQ(intArrayExpected->GetPackedValue(), results->GetPackedValue())
+                    << failmsg << " EvalMult fails after Compress";
+            }
+
             cResult = ciphertext1 * ciphertext2;
+
             cc->Decrypt(kp.secretKey, cResult, &results);
             results->SetLength(intArrayExpected->GetLength());
             EXPECT_EQ(intArrayExpected->GetPackedValue(), results->GetPackedValue()) << failmsg << " operator* fails";
+
+            if (!((cc->getSchemeId() == SCHEME::BFVRNS_SCHEME) &&
+                  (std::dynamic_pointer_cast<CryptoParametersBFVRNS>(cc->GetCryptoParameters())
+                       ->GetMultiplicationTechnique() == BEHZ))) {
+                cResult = cc->Compress(cResult, 1);
+                cc->Decrypt(kp.secretKey, cResult, &results);
+                results->SetLength(intArrayExpected->GetLength());
+                EXPECT_EQ(intArrayExpected->GetPackedValue(), results->GetPackedValue())
+                    << failmsg << " operator* fails after Compress";
+            }
 
             Ciphertext<Element> cmulInplace = ciphertext1->Clone();
             cmulInplace *= ciphertext2;


### PR DESCRIPTION
As part of the change, rewrote MultiplyAndRound for the native backend. This method is now used for BFV decryption for a DCRTPoly with a single RNS limb.