### PR TITLE
implemented approximate gadget decomposition + optimization for LMKCDEY

### DIFF
--- a/src/binfhe/lib/rgsw-acc-cggi.cpp
+++ b/src/binfhe/lib/rgsw-acc-cggi.cpp
@@ -77,7 +77,9 @@ RingGSWEvalKey RingGSWAccumulatorCGGI::KeyGenCGGI(const std::shared_ptr<RingGSWC
     NativeInteger Q{params->GetQ()};
     dug.SetModulus(Q);
 
-    uint32_t digitsG2{params->GetDigitsG() << 1};
+    // approximate gadget decomposition is used; the first digit is ignored
+    uint32_t digitsG2{(params->GetDigitsG() - 1) << 1};
+
     std::vector<NativePoly> tempA(digitsG2, NativePoly(dug, polyParams, Format::COEFFICIENT));
     RingGSWEvalKeyImpl result(digitsG2, 2);
 
@@ -86,7 +88,7 @@ RingGSWEvalKey RingGSWAccumulatorCGGI::KeyGenCGGI(const std::shared_ptr<RingGSWC
         tempA[i].SetFormat(Format::EVALUATION);
         result[i][1] = NativePoly(params->GetDgg(), polyParams, Format::COEFFICIENT);
         if (m)
-            result[i][i & 0x1][0].ModAddFastEq(Gpow[i >> 1], Q);
+            result[i][i & 0x1][0].ModAddFastEq(Gpow[(i >> 1) + 1], Q);
         result[i][0].SetFormat(Format::EVALUATION);
         result[i][1].SetFormat(Format::EVALUATION);
         result[i][1] += (tempA[i] *= skNTT);
@@ -104,7 +106,8 @@ void RingGSWAccumulatorCGGI::AddToAccCGGI(const std::shared_ptr<RingGSWCryptoPar
     ct[0].SetFormat(Format::COEFFICIENT);
     ct[1].SetFormat(Format::COEFFICIENT);
 
-    uint32_t digitsG2{params->GetDigitsG() << 1};
+    // approximate gadget decomposition is used; the first digit is ignored
+    uint32_t digitsG2{(params->GetDigitsG() - 1) << 1};
     std::vector<NativePoly> dct(digitsG2, NativePoly(params->GetPolyParams(), Format::COEFFICIENT, true));
 
     SignedDigitDecompose(params, ct, dct);

--- a/src/binfhe/lib/rgsw-acc.cpp
+++ b/src/binfhe/lib/rgsw-acc.cpp
@@ -58,7 +58,8 @@ void RingGSWAccumulator::SignedDigitDecompose(const std::shared_ptr<RingGSWCrypt
     auto Q_int{params->GetQ().ConvertToInt<NativeInteger::SignedNativeInt>()};
     auto gBits{static_cast<NativeInteger::SignedNativeInt>(__builtin_ctz(params->GetBaseG()))};
     auto gBitsMaxBits{static_cast<NativeInteger::SignedNativeInt>(NativeInteger::MaxBits() - gBits)};
-    uint32_t digitsG2{params->GetDigitsG() << 1};
+    // approximate gadget decomposition is used; the first digit is ignored
+    uint32_t digitsG2{(params->GetDigitsG() - 1) << 1};
     uint32_t N{params->GetN()};
 
     for (uint32_t k{0}; k < N; ++k) {
@@ -67,14 +68,20 @@ void RingGSWAccumulator::SignedDigitDecompose(const std::shared_ptr<RingGSWCrypt
         auto t1{input[1][k].ConvertToInt<BasicInteger>()};
         auto d1{static_cast<NativeInteger::SignedNativeInt>(t1 < QHalf ? t1 : t1 - Q_int)};
 
+        auto r0{(d0 << gBitsMaxBits) >> gBitsMaxBits};
+        d0 = (d0 - r0) >> gBits;
+
+        auto r1{(d1 << gBitsMaxBits) >> gBitsMaxBits};
+        d1 = (d1 - r1) >> gBits;
+
         for (uint32_t d{0}; d < digitsG2; d += 2) {
-            auto r0{(d0 << gBitsMaxBits) >> gBitsMaxBits};
+            r0 = (d0 << gBitsMaxBits) >> gBitsMaxBits;
             d0 = (d0 - r0) >> gBits;
             if (r0 < 0)
                 r0 += Q_int;
             output[d + 0][k] += r0;
 
-            auto r1{(d1 << gBitsMaxBits) >> gBitsMaxBits};
+            r1 = (d1 << gBitsMaxBits) >> gBitsMaxBits;
             d1 = (d1 - r1) >> gBits;
             if (r1 < 0)
                 r1 += Q_int;
@@ -85,21 +92,24 @@ void RingGSWAccumulator::SignedDigitDecompose(const std::shared_ptr<RingGSWCrypt
 
 // Decompose a ring element, not ciphertext
 void RingGSWAccumulator::SignedDigitDecompose(const std::shared_ptr<RingGSWCryptoParams>& params,
-                                              const NativePoly& input,
-                                              std::vector<NativePoly>& output) const {
+                                              const NativePoly& input, std::vector<NativePoly>& output) const {
     auto QHalf{params->GetQ().ConvertToInt<BasicInteger>() >> 1};
     auto Q_int{params->GetQ().ConvertToInt<NativeInteger::SignedNativeInt>()};
     auto gBits{static_cast<NativeInteger::SignedNativeInt>(__builtin_ctz(params->GetBaseG()))};
     auto gBitsMaxBits{static_cast<NativeInteger::SignedNativeInt>(NativeInteger::MaxBits() - gBits)};
-    uint32_t digitsG{params->GetDigitsG()};
+    // approximate gadget decomposition is used; the first digit is ignored
+    uint32_t digitsG{params->GetDigitsG() - 1};
     uint32_t N{params->GetN()};
 
     for (uint32_t k{0}; k < N; ++k) {
         auto t0{input[k].ConvertToInt<BasicInteger>()};
         auto d0{static_cast<NativeInteger::SignedNativeInt>(t0 < QHalf ? t0 : t0 - Q_int)};
 
+        auto r0{(d0 << gBitsMaxBits) >> gBitsMaxBits};
+        d0 = (d0 - r0) >> gBits;
+
         for (uint32_t d{0}; d < digitsG; ++d) {
-            auto r0{(d0 << gBitsMaxBits) >> gBitsMaxBits};
+            r0 = (d0 << gBitsMaxBits) >> gBitsMaxBits;
             d0 = (d0 - r0) >> gBits;
             if (r0 < 0)
                 r0 += Q_int;


### PR DESCRIPTION
* Re-implemented the changes in PR #482 as the binfhe code has significantly changed as compared to the commit the branch was created from (it was easier to reimplement than resolve the conflicts)
* Optimized the `Automorphism` bootstrapping step for the LMKCDEY mode
    * Removed 2 NTTs (automorphisms can be done directly in EVALUATION representation)
    * Switched to an optimized version of automorphisms (with precomputed bit reversal tables)

Ran benchmarks for STD128* on an Intel(R) Core(TM) i7-9700 CPU @ 3.00GHz and 64 GB of RAM, running Ubuntu 20.04 LTS with clang 10.0.0 (CMake flags: NATIVE_SIZE=32; WITH_NATIVEOPT=ON; OMP_NUM_THREADS=1)
* GINX (TFHE) runtime went down from 49 ms to 39 ms.
* LMKCDEY (FHEW) runtime went down from 40 ms to 29 ms.
   