### PR TITLE
Code for multi-input gates

### DIFF
--- a/src/binfhe/examples/boolean-multi-input.cpp
+++ b/src/binfhe/examples/boolean-multi-input.cpp
@@ -1,0 +1,181 @@
+//==================================================================================
+// BSD 2-Clause License
+//
+// Copyright (c) 2014-2022, NJIT, Duality Technologies Inc. and other contributors
+//
+// All rights reserved.
+//
+// Author TPOC: contact@openfhe.org
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//==================================================================================
+
+/*
+  Example for the FHEW scheme using the default bootstrapping method (GINX)
+ */
+
+#include "binfhecontext.h"
+
+using namespace lbcrypto;
+
+int main() {
+    // Sample Program: Step 1: Set CryptoContext
+
+    auto cc = BinFHEContext();
+
+    cc.GenerateBinFHEContext(STD128Q_OPT_4);
+
+    // Sample Program: Step 2: Key Generation
+
+    // Generate the secret key
+    auto sk = cc.KeyGen();
+
+    std::cout << "Generating the bootstrapping keys..." << std::endl;
+
+    // Generate the bootstrapping keys (refresh and switching keys)
+    cc.BTKeyGen(sk);
+
+    std::cout << "Completed the key generation." << std::endl;
+
+    // Sample Program: Step 3: Encryption
+
+    // Encrypt several ciphertexts representing Boolean True (1) or False (0).
+    // plaintext modulus is set higher than 4 to 2 * num_of_inputs
+    auto p          = 6;
+    auto ct1_3input = cc.Encrypt(sk, 1, SMALL_DIM, p);
+    auto ct2_3input = cc.Encrypt(sk, 1, SMALL_DIM, p);
+    auto ct3_3input = cc.Encrypt(sk, 0, SMALL_DIM, p);
+
+    // 1, 1, 0
+    std::vector<LWECiphertext> ct123;
+    ct123.push_back(ct1_3input);
+    ct123.push_back(ct2_3input);
+    ct123.push_back(ct3_3input);
+
+    // 1, 1, 0
+    auto ctAND3 = cc.EvalBinGate(AND3, ct123);
+
+    // 1, 1, 0
+    auto ctOR3 = cc.EvalBinGate(OR3, ct123);
+    // Sample Program: Step 5: Decryption
+
+    LWEPlaintext result;
+    cc.Decrypt(sk, ctAND3, &result, p);
+    if (result != 0)
+        OPENFHE_THROW(math_error, "Decryption failure");
+
+    std::cout << "Result of encrypted computation of AND(1, 1, 0) = " << result << std::endl;
+
+    cc.Decrypt(sk, ctOR3, &result, p);
+    if (result != 1)
+        OPENFHE_THROW(math_error, "Decryption failure");
+
+    std::cout << "Result of encrypted computation of OR(1, 1, 0) = " << result << std::endl;
+
+    // majority gate and cmux for 3 input does not need higher plaintext modulus
+    p                  = 4;
+    auto ct1_3input_p4 = cc.Encrypt(sk, 1, SMALL_DIM, p);
+    auto ct2_3input_p4 = cc.Encrypt(sk, 1, SMALL_DIM, p);
+    auto ct3_3input_p4 = cc.Encrypt(sk, 0, SMALL_DIM, p);
+    auto ct4_3input_p4 = cc.Encrypt(sk, 0, SMALL_DIM, p);
+
+    // 1, 1, 0
+    std::vector<LWECiphertext> ct123_p4;
+    ct123_p4.push_back(ct1_3input_p4);
+    ct123_p4.push_back(ct2_3input_p4);
+    ct123_p4.push_back(ct3_3input_p4);
+
+    // 1, 0, 0
+    std::vector<LWECiphertext> ct134_p4;
+    ct134_p4.push_back(ct1_3input_p4);
+    ct134_p4.push_back(ct3_3input_p4);
+    ct134_p4.push_back(ct4_3input_p4);
+
+    // 1, 0, 1
+    std::vector<LWECiphertext> ct132_p4;
+    ct132_p4.push_back(ct1_3input_p4);
+    ct132_p4.push_back(ct3_3input_p4);
+    ct132_p4.push_back(ct2_3input_p4);
+
+    // 1, 1, 0
+    auto ctMajority = cc.EvalBinGate(MAJORITY, ct123_p4);
+
+    // 1, 0, 1
+    auto ctCMUX0 = cc.EvalBinGate(CMUX, ct132_p4);
+
+    // 1, 0, 0
+    auto ctCMUX1 = cc.EvalBinGate(CMUX, ct134_p4);
+
+    cc.Decrypt(sk, ctMajority, &result);
+    if (result != 1)
+        OPENFHE_THROW(math_error, "Decryption failure");
+
+    std::cout << "Result of encrypted computation of Majority(1, 1, 0) = " << result << std::endl;
+
+    cc.Decrypt(sk, ctCMUX1, &result);
+    if (result != 1)
+        OPENFHE_THROW(math_error, "Decryption failure");
+    std::cout << "Result of encrypted computation of CMUX(1, 0, 0) = " << result << std::endl;
+
+    cc.Decrypt(sk, ctCMUX0, &result);
+    if (result != 0)
+        OPENFHE_THROW(math_error, "Decryption failure");
+
+    std::cout << "Result of encrypted computation of CMUX(1, 0, 1) = " << result << std::endl;
+
+    // for 4 input gates
+    p               = 8;
+    auto ct1_4input = cc.Encrypt(sk, 1, SMALL_DIM, p);
+    auto ct2_4input = cc.Encrypt(sk, 0, SMALL_DIM, p);
+    auto ct3_4input = cc.Encrypt(sk, 0, SMALL_DIM, p);
+    auto ct4_4input = cc.Encrypt(sk, 0, SMALL_DIM, p);
+
+    // 1, 0, 0, 0
+    std::vector<LWECiphertext> ct1234;
+    ct1234.push_back(ct1_4input);
+    ct1234.push_back(ct2_4input);
+    ct1234.push_back(ct3_4input);
+    ct1234.push_back(ct4_4input);
+
+    // Sample Program: Step 4: Evaluation
+
+    // 1, 0, 0, 0
+    auto ctAND4 = cc.EvalBinGate(AND4, ct1234);
+
+    // 1, 0, 0, 0
+    auto ctOR4 = cc.EvalBinGate(OR4, ct1234);
+
+    // Sample Program: Step 5: Decryption
+    cc.Decrypt(sk, ctAND4, &result, p);
+    if (result != 0)
+        OPENFHE_THROW(math_error, "Decryption failure");
+
+    std::cout << "Result of encrypted computation of AND(1, 0, 0, 0) = " << result << std::endl;
+
+    cc.Decrypt(sk, ctOR4, &result, p);
+    if (result != 1)
+        OPENFHE_THROW(math_error, "Decryption failure");
+
+    std::cout << "Result of encrypted computation of OR(1, 0, 0, 0) = " << result << std::endl;
+
+    return 0;
+}

--- a/src/binfhe/include/binfhe-base-scheme.h
+++ b/src/binfhe/include/binfhe-base-scheme.h
@@ -104,6 +104,19 @@ public:
                               ConstLWECiphertext& ct1, ConstLWECiphertext& ct2) const;
 
     /**
+   * Evaluates a binary gate on a vector of ciphertexts (calls bootstrapping as a subroutine)
+   *
+   * @param params a shared pointer to RingGSW scheme parameters
+   * @param gate the gate; can be AND, OR, NAND, NOR, XOR, or XOR
+   * @param &EK a shared pointer to the bootstrapping keys
+   * @param ctvector vector of ciphertexts
+   * @param lwescheme a shared pointer to additive LWE scheme
+   * @return a shared pointer to the resulting ciphertext
+   */
+    LWECiphertext EvalBinGate(const std::shared_ptr<BinFHECryptoParams>& params, BINGATE gate, const RingGSWBTKey& EK,
+                              const std::vector<LWECiphertext>& ctvector) const;
+
+    /**
    * Evaluates NOT gate
    *
    * @param params a shared pointer to RingGSW scheme parameters

--- a/src/binfhe/include/binfhe-base-scheme.h
+++ b/src/binfhe/include/binfhe-base-scheme.h
@@ -104,10 +104,11 @@ public:
                               ConstLWECiphertext& ct1, ConstLWECiphertext& ct2) const;
 
     /**
-   * Evaluates a binary gate on a vector of ciphertexts (calls bootstrapping as a subroutine)
+   * Evaluates a binary gate on a vector of ciphertexts (calls bootstrapping as a subroutine).
+   * The evaluation of the gates in this function is specific to 3 input and 4 input
    *
    * @param params a shared pointer to RingGSW scheme parameters
-   * @param gate the gate; can be AND, OR, NAND, NOR, XOR, or XOR
+   * @param gate the gate; can be for 3-input: AND3, OR3, MAJORITY, CMUX, for 4-input: AND4, OR4
    * @param &EK a shared pointer to the bootstrapping keys
    * @param ctvector vector of ciphertexts
    * @param lwescheme a shared pointer to additive LWE scheme

--- a/src/binfhe/include/binfhe-constants.h
+++ b/src/binfhe/include/binfhe-constants.h
@@ -79,6 +79,18 @@ enum BINFHE_PARAMSET {
                      // same setup as HE standard
     STD256Q_OPT,     // more than 256 bits of security for quantum attacks -
                      // optimize runtime by finding a non-power-of-two n
+    STD128Q_OPT_3,   // more than 128 bits of security for quantum computer attacks -
+                     // optimize runtime by finding a non-power-of-two n for 3 binary inputs
+    STD192Q_OPT_3,   // more than 192 bits of security for quantum computer attacks -
+                     // optimize runtime by finding a non-power-of-two n for 3 binary inputs
+    STD256Q_OPT_3,   // more than 256 bits of security for quantum computer attacks -
+                     // optimize runtime by finding a non-power-of-two n for 3 binary inputs
+    STD128Q_OPT_4,   // more than 128 bits of security for quantum computer attacks -
+                     // optimize runtime by finding a non-power-of-two n for 4 binary inputs
+    STD192Q_OPT_4,   // more than 192 bits of security for quantum computer attacks -
+                     // optimize runtime by finding a non-power-of-two n for 4 binary inputs
+    STD256Q_OPT_4,   // more than 256 bits of security for quantum computer attacks -
+                     // optimize runtime by finding a non-power-of-two n for 4 binary inputs
     SIGNED_MOD_TEST  // special parameter set for confirming the signed modular
                      // reduction in the accumulator updates works correctly
 };
@@ -98,13 +110,13 @@ std::ostream& operator<<(std::ostream& s, BINFHE_OUTPUT f);
 
 enum BINFHE_METHOD {
     INVALID_METHOD = 0,
-    AP,    // Ducas-Micciancio variant
-    GINX,  // Chillotti-Gama-Georgieva-Izabachene variant
-    LMKCDEY, // Lee-Micciancio-Kim-Choi-Deryabin-Eom-Yoo variant, ia.cr/2022/198
+    AP,       // Ducas-Micciancio variant
+    GINX,     // Chillotti-Gama-Georgieva-Izabachene variant
+    LMKCDEY,  // Lee-Micciancio-Kim-Choi-Deryabin-Eom-Yoo variant, ia.cr/2022/198
 };
 std::ostream& operator<<(std::ostream& s, BINFHE_METHOD f);
 
-enum BINGATE { OR, AND, NOR, NAND, XOR_FAST, XNOR_FAST, XOR, XNOR };
+enum BINGATE { OR, AND, NOR, NAND, XOR_FAST, XNOR_FAST, MAJORITY, AND3, OR3, AND4, OR4, CMUX, XOR, XNOR };
 std::ostream& operator<<(std::ostream& s, BINGATE f);
 
 /**

--- a/src/binfhe/include/binfhecontext.h
+++ b/src/binfhe/include/binfhecontext.h
@@ -48,6 +48,30 @@
 
 namespace lbcrypto {
 
+// TODO: reorder to optimize struct size/alignment
+struct BinFHEContextParams {
+    // for intermediate prime, modulus for RingGSW / RLWE used in bootstrapping
+    usint numberBits;
+    usint cyclOrder;
+
+    // for LWE crypto parameters
+    usint latticeParam;
+    usint mod;  // modulus for additive LWE
+    // modulus for key switching; if it is zero, then it is replaced with intermediate prime for LWE crypto parameters
+    usint modKS;
+    double stdDev;
+    usint baseKS;  // base for key switching
+
+    // for Ring GSW + LWE parameters
+    usint gadgetBase;  // gadget base used in the bootstrapping
+    usint baseRK;      // base for the refreshing key
+
+    // number of Automorphism keys for LMKCDEY (> 0)
+    usint numAutoKeys;
+
+    // for key distribution
+    SECRET_KEY_DIST keyDist;
+};
 /**
  * @brief BinFHEContext
  *
@@ -74,8 +98,9 @@ public:
    * @return creates the cryptocontext
    */
     void GenerateBinFHEContext(uint32_t n, uint32_t N, const NativeInteger& q, const NativeInteger& Q, double std,
-                               uint32_t baseKS, uint32_t baseG, uint32_t baseR, SECRET_KEY_DIST keyDist = UNIFORM_TERNARY, 
-                               BINFHE_METHOD method = GINX, uint32_t numAutoKeys = 10);
+                               uint32_t baseKS, uint32_t baseG, uint32_t baseR,
+                               SECRET_KEY_DIST keyDist = UNIFORM_TERNARY, BINFHE_METHOD method = GINX,
+                               uint32_t numAutoKeys = 10);
 
     /**
    * Creates a crypto context using custom parameters.
@@ -102,6 +127,15 @@ public:
    * @return create the cryptocontext
    */
     void GenerateBinFHEContext(BINFHE_PARAMSET set, BINFHE_METHOD method = GINX);
+
+    /**
+   * Creates a crypto context using custom parameters.
+   *
+   * @param set the parameter context
+   * @param method the bootstrapping method (DM or CGGI or LMKCDEY)
+   * @return create the cryptocontext
+   */
+    void GenerateBinFHEContext(const BinFHEContextParams& params, BINFHE_METHOD method = GINX);
 
     /**
    * Gets the refreshing key (used for serialization).
@@ -271,6 +305,15 @@ public:
    * @return a shared pointer to the resulting ciphertext
    */
     LWECiphertext EvalBinGate(BINGATE gate, ConstLWECiphertext& ct1, ConstLWECiphertext& ct2) const;
+
+    /**
+   * Evaluates a binary gate on vector of ciphertexts (calls bootstrapping as a subroutine)
+   *
+   * @param gate the gate; can be MAJORITY as of now
+   * @param cts vector of ciphertexts
+   * @return a shared pointer to the resulting ciphertext
+   */
+    LWECiphertext EvalBinGate(BINGATE gate, const std::vector<LWECiphertext>& ctvector) const;
 
     /**
    * Bootstraps a ciphertext (without peforming any operation)

--- a/src/binfhe/include/lwe-ciphertext.h
+++ b/src/binfhe/include/lwe-ciphertext.h
@@ -101,6 +101,10 @@ public:
         return m_a.GetLength();
     }
 
+    const NativeInteger& GetptModulus() const {
+        return m_p;
+    }
+
     void SetA(const NativeVector& a) {
         m_a = a;
     }
@@ -113,6 +117,10 @@ public:
         m_a.ModEq(mod);
         m_a.SetModulus(mod);
         m_b.ModEq(mod);
+    }
+
+    void SetptModulus(const NativeInteger& pmod) {
+        m_p = pmod;
     }
 
     bool operator==(const LWECiphertextImpl& other) const {
@@ -150,6 +158,7 @@ public:
 private:
     NativeVector m_a{};
     NativeInteger m_b{};
+    NativeInteger m_p = 4;  // pt modulus
 };
 
 }  // namespace lbcrypto

--- a/src/binfhe/lib/binfhe-base-scheme.cpp
+++ b/src/binfhe/lib/binfhe-base-scheme.cpp
@@ -201,7 +201,6 @@ LWECiphertext BinFHEScheme::Bootstrap(const std::shared_ptr<BinFHECryptoParams>&
     const auto& LWEParams = params->GetLWEParams();
     NativeInteger Q{LWEParams->GetQ()};
     NativeInteger b = Q / NativeInteger(2 * p) + 1;
-    // NativeInteger b{(Q >> 3) + 1}; (Sara: commented out Carlo's change account for p > 4)
     b.ModAddFastEq(accVec[1][0], Q);
 
     auto ctExt = std::make_shared<LWECiphertextImpl>(std::move(accVec[0].GetValues()), std::move(b));

--- a/src/binfhe/lib/binfhe-base-scheme.cpp
+++ b/src/binfhe/lib/binfhe-base-scheme.cpp
@@ -123,8 +123,67 @@ LWECiphertext BinFHEScheme::EvalBinGate(const std::shared_ptr<BinFHECryptoParams
 }
 
 // Full evaluation as described in https://eprint.iacr.org/2020/086
+LWECiphertext BinFHEScheme::EvalBinGate(const std::shared_ptr<BinFHECryptoParams>& params, BINGATE gate,
+                                        const RingGSWBTKey& EK, const std::vector<LWECiphertext>& ctvector) const {
+    // check if the ciphertexts are all independent
+    for (size_t i = 0; i < ctvector.size(); i++) {
+        for (size_t j = i + 1; j < ctvector.size(); j++) {
+            if (ctvector[j] == ctvector[i]) {
+                OPENFHE_THROW(config_error, "Input ciphertexts should be independent");
+            }
+        }
+    }
+
+    NativeInteger p = ctvector[0]->GetptModulus();
+
+    LWECiphertext ctprep = std::make_shared<LWECiphertextImpl>(*ctvector[0]);
+    ctprep->SetptModulus(p);
+    if ((gate == MAJORITY) || (gate == AND3) || (gate == OR3) || (gate == AND4) || (gate == OR4)) {
+        // we simply compute sum(ctvector[i]) mod p
+        for (size_t i = 1; i < ctvector.size(); i++) {
+            LWEscheme->EvalAddEq(ctprep, ctvector[i]);
+        }
+        auto acc = BootstrapGateCore(params, gate, EK.BSkey, ctprep);
+
+        std::vector<NativePoly>& accVec = acc->GetElements();
+        // the accumulator result is encrypted w.r.t. the transposed secret key
+        // we can transpose "a" to get an encryption under the original secret key
+        accVec[0] = accVec[0].Transpose();
+        accVec[0].SetFormat(Format::COEFFICIENT);
+        accVec[1].SetFormat(Format::COEFFICIENT);
+
+        // we add Q/8 to "b" to to map back to Q/4 (i.e., mod 2) arithmetic.
+        auto& LWEParams = params->GetLWEParams();
+        NativeInteger Q = LWEParams->GetQ();
+        NativeInteger b = Q / NativeInteger(2 * p) + 1;
+        b.ModAddFastEq(accVec[1][0], Q);
+
+        auto ctExt = std::make_shared<LWECiphertextImpl>(std::move(accVec[0].GetValues()), std::move(b));
+        // Modulus switching to a middle step Q'
+        auto ctMS = LWEscheme->ModSwitch(LWEParams->GetqKS(), ctExt);
+        // Key switching
+        auto ctKS = LWEscheme->KeySwitch(LWEParams, EK.KSkey, ctMS);
+        // Modulus switching
+        return LWEscheme->ModSwitch(ctvector[0]->GetModulus(), ctKS);
+    }
+    else if (gate == CMUX) {
+        if (ctvector.size() != 3)
+            OPENFHE_THROW(not_implemented_error, "CMUX gate implemented for ciphertext vectors of size 3");
+
+        auto ccNOT   = EvalNOT(params, ctvector[2]);
+        auto ctNAND1 = EvalBinGate(params, NAND, EK, ctvector[0], ccNOT);
+        auto ctNAND2 = EvalBinGate(params, NAND, EK, ctvector[1], ctvector[2]);
+        auto ctCMUX  = EvalBinGate(params, NAND, EK, ctNAND1, ctNAND2);
+        return ctCMUX;
+    }
+    else {
+        OPENFHE_THROW(not_implemented_error, "This gate is not implemented for vector of ciphertexts at this time");
+    }
+}
+// Full evaluation as described in https://eprint.iacr.org/2020/086
 LWECiphertext BinFHEScheme::Bootstrap(const std::shared_ptr<BinFHECryptoParams>& params, const RingGSWBTKey& EK,
                                       ConstLWECiphertext& ct) const {
+    NativeInteger p = ct->GetptModulus();
     LWECiphertext ctprep{std::make_shared<LWECiphertextImpl>(*ct)};
     // ctprep = ct + q/4
     LWEscheme->EvalAddConstEq(ctprep, (ct->GetModulus() >> 2));
@@ -141,7 +200,8 @@ LWECiphertext BinFHEScheme::Bootstrap(const std::shared_ptr<BinFHECryptoParams>&
     // we add Q/8 to "b" to to map back to Q/4 (i.e., mod 2) arithmetic.
     const auto& LWEParams = params->GetLWEParams();
     NativeInteger Q{LWEParams->GetQ()};
-    NativeInteger b{(Q >> 3) + 1};
+    NativeInteger b = Q / NativeInteger(2 * p) + 1;
+    // NativeInteger b{(Q >> 3) + 1}; (Sara: commented out Carlo's change account for p > 4)
     b.ModAddFastEq(accVec[1][0], Q);
 
     auto ctExt = std::make_shared<LWECiphertextImpl>(std::move(accVec[0].GetValues()), std::move(b));
@@ -436,6 +496,7 @@ RLWECiphertext BinFHEScheme::BootstrapGateCore(const std::shared_ptr<BinFHECrypt
     auto polyParams  = RGSWParams->GetPolyParams();
 
     // Specifies the range [q1,q2) that will be used for mapping
+    NativeInteger p  = ct->GetptModulus();
     NativeInteger q  = ct->GetModulus();
     uint32_t qHalf   = q.ConvertToInt() >> 1;
     NativeInteger q1 = RGSWParams->GetGateConst()[static_cast<size_t>(gate)];
@@ -443,9 +504,9 @@ RLWECiphertext BinFHEScheme::BootstrapGateCore(const std::shared_ptr<BinFHECrypt
 
     // depending on whether the value is the range, it will be set
     // to either Q/8 or -Q/8 to match binary arithmetic
-    NativeInteger Q     = LWEParams->GetQ();
-    NativeInteger Q8    = Q / NativeInteger(8) + 1;
-    NativeInteger Q8Neg = Q - Q8;
+    NativeInteger Q      = LWEParams->GetQ();
+    NativeInteger Q2p    = Q / NativeInteger(2 * p) + 1;
+    NativeInteger Q2pNeg = Q - Q2p;
 
     uint32_t N = LWEParams->GetN();
     NativeVector m(N, Q);
@@ -457,9 +518,9 @@ RLWECiphertext BinFHEScheme::BootstrapGateCore(const std::shared_ptr<BinFHECrypt
     for (size_t j = 0; j < qHalf; ++j) {
         NativeInteger temp = b.ModSub(j, q);
         if (q1 < q2)
-            m[j * factor] = ((temp >= q1) && (temp < q2)) ? Q8Neg : Q8;
+            m[j * factor] = ((temp >= q1) && (temp < q2)) ? Q2pNeg : Q2p;
         else
-            m[j * factor] = ((temp >= q2) && (temp < q1)) ? Q8 : Q8Neg;
+            m[j * factor] = ((temp >= q2) && (temp < q1)) ? Q2p : Q2pNeg;
     }
     std::vector<NativePoly> res(2);
     // no need to do NTT as all coefficients of this poly are zero

--- a/src/binfhe/lib/binfhe-constants-impl.cpp
+++ b/src/binfhe/lib/binfhe-constants-impl.cpp
@@ -88,6 +88,24 @@ std::ostream& operator<<(std::ostream& s, BINFHE_PARAMSET f) {
         case STD256Q_OPT:
             s << "STD256Q_OPT";
             break;
+        case STD128Q_OPT_3:
+            s << "STD128Q_OPT_3";
+            break;
+        case STD192Q_OPT_3:
+            s << "STD192Q_OPT_3";
+            break;
+        case STD256Q_OPT_3:
+            s << "STD256Q_OPT_3";
+            break;
+        case STD128Q_OPT_4:
+            s << "STD128Q_OPT_4";
+            break;
+        case STD192Q_OPT_4:
+            s << "STD192Q_OPT_4";
+            break;
+        case STD256Q_OPT_4:
+            s << "STD256Q_OPT_4";
+            break;
         case SIGNED_MOD_TEST:
             s << "SIGNED_MOD_TEST";
             break;
@@ -156,6 +174,24 @@ std::ostream& operator<<(std::ostream& s, BINGATE f) {
             break;
         case XNOR:
             s << "XNOR";
+            break;
+        case AND3:
+            s << "AND3";
+            break;
+        case OR3:
+            s << "OR3";
+            break;
+        case AND4:
+            s << "AND4";
+            break;
+        case OR4:
+            s << "OR4";
+            break;
+        case MAJORITY:
+            s << "MAJORITY";
+            break;
+        case CMUX:
+            s << "CMUX";
             break;
         default:
             s << "UNKNOWN";

--- a/src/binfhe/lib/binfhecontext.cpp
+++ b/src/binfhe/lib/binfhecontext.cpp
@@ -180,12 +180,13 @@ void BinFHEContext::GenerateBinFHEContext(const BinFHEContextParams& params, BIN
 
     auto lweparams = (PRIME == params.modKS) ?
                          std::make_shared<LWECryptoParams>(params.latticeParam, ringDim, params.mod, Q, Q,
-                                                           params.stdDev, params.baseKS) :
+                                                           params.stdDev, params.baseKS, params.keyDist) :
                          std::make_shared<LWECryptoParams>(params.latticeParam, ringDim, params.mod, Q, params.modKS,
-                                                           params.stdDev, params.baseKS);
+                                                           params.stdDev, params.baseKS, params.keyDist);
 
-    auto rgswparams = std::make_shared<RingGSWCryptoParams>(ringDim, Q, params.mod, params.gadgetBase, params.baseRK,
-                                                            method, params.stdDev);
+    auto rgswparams =
+        std::make_shared<RingGSWCryptoParams>(ringDim, Q, params.mod, params.gadgetBase, params.baseRK, method,
+                                              params.stdDev, params.keyDist, false, params.numAutoKeys);
 
     m_params       = std::make_shared<BinFHECryptoParams>(lweparams, rgswparams);
     m_binfhescheme = std::make_shared<BinFHEScheme>(method);

--- a/src/binfhe/lib/lwe-pke.cpp
+++ b/src/binfhe/lib/lwe-pke.cpp
@@ -142,7 +142,6 @@ LWECiphertext LWEEncryptionScheme::Encrypt(const std::shared_ptr<LWECryptoParams
         b += a[i].ModMulFast(s[i], mod, mu);
     }
 
-    // (Sara: edited this change from Carlo)
     auto ct = std::make_shared<LWECiphertextImpl>(LWECiphertextImpl(std::move(a), b.Mod(mod)));
     ct->SetptModulus(p);
     return ct;
@@ -189,7 +188,6 @@ LWECiphertext LWEEncryptionScheme::EncryptN(const std::shared_ptr<LWECryptoParam
         b.ModAddEq(bp[i].ModMulFast(sp[i], mod, mu), mod);
     }
 
-    // (Sara: edited this change from Carlo)
     auto ct = std::make_shared<LWECiphertextImpl>(LWECiphertextImpl(a, b));
     ct->SetptModulus(p);
     return ct;
@@ -247,7 +245,6 @@ void LWEEncryptionScheme::Decrypt(const std::shared_ptr<LWECryptoParams>& params
     double error =
         (static_cast<double>(p) * (r.ConvertToDouble() - mod.ConvertToInt() / (p * 2))) / mod.ConvertToDouble() -
         static_cast<double>(*result);
-    std::cerr << mod << " " << p << " " << r << " error:\t" << error << std::endl;
     std::cerr << error * mod.ConvertToDouble() / static_cast<double>(p) << std::endl;
 #endif
 }

--- a/src/binfhe/lib/lwe-pke.cpp
+++ b/src/binfhe/lib/lwe-pke.cpp
@@ -141,7 +141,11 @@ LWECiphertext LWEEncryptionScheme::Encrypt(const std::shared_ptr<LWECryptoParams
     for (size_t i = 0; i < n; ++i) {
         b += a[i].ModMulFast(s[i], mod, mu);
     }
-    return std::make_shared<LWECiphertextImpl>(LWECiphertextImpl(std::move(a), b.Mod(mod)));
+
+    // (Sara: edited this change from Carlo)
+    auto ct = std::make_shared<LWECiphertextImpl>(LWECiphertextImpl(std::move(a), b.Mod(mod)));
+    ct->SetptModulus(p);
+    return ct;
 }
 
 // classical public key LWE encryption
@@ -185,7 +189,10 @@ LWECiphertext LWEEncryptionScheme::EncryptN(const std::shared_ptr<LWECryptoParam
         b.ModAddEq(bp[i].ModMulFast(sp[i], mod, mu), mod);
     }
 
-    return std::make_shared<LWECiphertextImpl>(LWECiphertextImpl(a, b));
+    // (Sara: edited this change from Carlo)
+    auto ct = std::make_shared<LWECiphertextImpl>(LWECiphertextImpl(a, b));
+    ct->SetptModulus(p);
+    return ct;
 }
 
 // convert ciphertext with modulus Q and dimension N to ciphertext with modulus q and dimension n

--- a/src/binfhe/lib/rgsw-cryptoparameters.cpp
+++ b/src/binfhe/lib/rgsw-cryptoparameters.cpp
@@ -75,12 +75,17 @@ void RingGSWCryptoParams::PreCompute(bool signEval) {
 
     // Sets the gate constants for supported binary operations
     m_gateConst = {
-        NativeInteger(5) * (m_q >> 3),  // OR
-        NativeInteger(7) * (m_q >> 3),  // AND
-        NativeInteger(1) * (m_q >> 3),  // NOR
-        NativeInteger(3) * (m_q >> 3),  // NAND
-        NativeInteger(5) * (m_q >> 3),  // XOR_FAST
-        NativeInteger(1) * (m_q >> 3)   // XNOR_FAST
+        NativeInteger(5) * (m_q >> 3),   // OR
+        NativeInteger(7) * (m_q >> 3),   // AND
+        NativeInteger(1) * (m_q >> 3),   // NOR
+        NativeInteger(3) * (m_q >> 3),   // NAND
+        NativeInteger(5) * (m_q >> 3),   // XOR_FAST
+        NativeInteger(1) * (m_q >> 3),   // XNOR_FAST
+        NativeInteger(7) * (m_q >> 3),   // MAJORITY
+        NativeInteger(11) * (m_q / 12),  // AND3
+        NativeInteger(7) * (m_q / 12),   // OR3
+        NativeInteger(15) * (m_q >> 4),  // AND4
+        NativeInteger(9) * (m_q >> 4)    // OR4
     };
 
     // Computes polynomials X^m - 1 that are needed in the accumulator for the

--- a/src/binfhe/unittest/UnitTestFHEW.cpp
+++ b/src/binfhe/unittest/UnitTestFHEW.cpp
@@ -55,6 +55,12 @@ enum TEST_CASE_TYPE {
     FHEW_KEY_SWITCH,
     FHEW_MOD_SWITCH,
     FHEW_NOT,
+    FHEW_AND3,
+    FHEW_OR3,
+    FHEW_AND4,
+    FHEW_OR4,
+    FHEW_MAJORITY,
+    FHEW_CMUX,
 };
 
 static std::ostream& operator<<(std::ostream& os, const TEST_CASE_TYPE& type) {
@@ -96,6 +102,24 @@ static std::ostream& operator<<(std::ostream& os, const TEST_CASE_TYPE& type) {
         case FHEW_NOT:
             typeName = "FHEW_NOT";
             break;
+        case FHEW_AND3:
+            typeName = "FHEW_AND3";
+            break;
+        case FHEW_OR3:
+            typeName = "FHEW_OR3";
+            break;
+        case FHEW_AND4:
+            typeName = "FHEW_AND4";
+            break;
+        case FHEW_OR4:
+            typeName = "FHEW_OR4";
+            break;
+        case FHEW_MAJORITY:
+            typeName = "FHEW_MAJORITY";
+            break;
+        case FHEW_CMUX:
+            typeName = "FHEW_CMUX";
+            break;
         default:
             typeName = "UNKNOWN_TESTTYPE";
             break;
@@ -109,12 +133,13 @@ struct TEST_CASE_UTGENERAL_FHEW {
     std::string description;
 
     BINFHE_PARAMSET securityLevel;
-    BINFHE_METHOD   method;
+    BINFHE_METHOD method;
+    uint32_t num_of_inputs;
+    LWEPlaintextModulus ptmodulus;
 
     BINGATE gate;
 
     std::vector<LWEPlaintext> results;
-
 
     // additional test case data
     // ........
@@ -126,10 +151,8 @@ struct TEST_CASE_UTGENERAL_FHEW {
     }
     std::string toString() const {
         std::stringstream ss;
-        ss << "testCaseType [" << testCaseType
-           << "], BINFHE_PARAMSET: " << securityLevel
-           << "BINFHE_METHOD: " << method
-           << "BINGATE: " << gate;
+        ss << "testCaseType [" << testCaseType << "], BINFHE_PARAMSET: " << securityLevel
+           << ", BINFHE_METHOD: " << method << ", number of inputs: " << num_of_inputs << ", BINGATE: " << gate;
         return ss.str();
     }
 };
@@ -146,59 +169,81 @@ static std::ostream& operator<<(std::ostream& os, const TEST_CASE_UTGENERAL_FHEW
 //===========================================================================================================
 // clang-format off
 static std::vector<TEST_CASE_UTGENERAL_FHEW> testCasesUTGENERAL_FHEW = {
-    // TestType, Descr,  ParamSet, Method,  Gate, Results
-    { FHEW_AND,  "01",   TOY,      GINX,    AND,   {1, 0, 0, 0} },
-    { FHEW_AND,  "02",   TOY,      AP,      AND,   {1, 0, 0, 0} },
-    { FHEW_AND,  "03",   TOY,      LMKCDEY, AND,   {1, 0, 0, 0} },
+    // TestType, Descr,  ParamSet, Method,  num_of_inputs, ptmodulus, Gate, Results
+    { FHEW_AND,  "01",   TOY,      GINX,    2,              4,        AND,   {1, 0, 0, 0} },
+    { FHEW_AND,  "02",   TOY,      AP,      2,              4,        AND,   {1, 0, 0, 0} },
+    { FHEW_AND,  "03",   TOY,      LMKCDEY, 2,              4,        AND,   {1, 0, 0, 0} },
     // ==========================================
-    { FHEW_NAND, "01",   TOY,      GINX,    NAND,  {0, 1, 1, 1} },
-    { FHEW_NAND, "02",   TOY,      AP,      NAND,  {0, 1, 1, 1} },
-    { FHEW_NAND, "03",   TOY,      LMKCDEY, NAND,  {0, 1, 1, 1} },
+    { FHEW_NAND, "01",   TOY,      GINX,    2,              4,        NAND,  {0, 1, 1, 1} },
+    { FHEW_NAND, "02",   TOY,      AP,      2,              4,        NAND,  {0, 1, 1, 1} },
+    { FHEW_NAND, "03",   TOY,      LMKCDEY, 2,              4,        NAND,  {0, 1, 1, 1} },
     // ==========================================
-    { FHEW_OR,   "01",   TOY,      GINX,    OR,    {1, 1, 1, 0} },
-    { FHEW_OR,   "02",   TOY,      AP,      OR,    {1, 1, 1, 0} },
-    { FHEW_OR,   "03",   TOY,      LMKCDEY, OR,    {1, 1, 1, 0} },
+    { FHEW_OR,   "01",   TOY,      GINX,    2,              4,        OR,    {1, 1, 1, 0} },
+    { FHEW_OR,   "02",   TOY,      AP,      2,              4,        OR,    {1, 1, 1, 0} },
+    { FHEW_OR,   "03",   TOY,      LMKCDEY, 2,              4,        OR,    {1, 1, 1, 0} },
     // ==========================================
-    { FHEW_NOR,  "01",   TOY,      GINX,    NOR,   {0, 0, 0, 1} },
-    { FHEW_NOR,  "02",   TOY,      AP,      NOR,   {0, 0, 0, 1} },
-    { FHEW_NOR,  "03",   TOY,      LMKCDEY, NOR,   {0, 0, 0, 1} },
+    { FHEW_NOR,  "01",   TOY,      GINX,    2,              4,        NOR,   {0, 0, 0, 1} },
+    { FHEW_NOR,  "02",   TOY,      AP,      2,              4,        NOR,   {0, 0, 0, 1} },
+    { FHEW_NOR,  "03",   TOY,      LMKCDEY, 2,              4,        NOR,   {0, 0, 0, 1} },
     // ==========================================
-    { FHEW_XOR,  "01",   TOY,      GINX,    XOR,   {0, 1, 1, 0} },
-    { FHEW_XOR,  "02",   TOY,      AP,      XOR,   {0, 1, 1, 0} },
-    { FHEW_XOR,  "03",   TOY,      LMKCDEY, XOR,   {0, 1, 1, 0} },
+    { FHEW_XOR,  "01",   TOY,      GINX,    2,              4,        XOR,   {0, 1, 1, 0} },
+    { FHEW_XOR,  "02",   TOY,      AP,      2,              4,        XOR,   {0, 1, 1, 0} },
+    { FHEW_XOR,  "03",   TOY,      LMKCDEY, 2,              4,        XOR,   {0, 1, 1, 0} },
     // ==========================================
 
-    { FHEW_XNOR,  "01",  TOY,      GINX,    XNOR,  {1, 0, 0, 1} },
-    { FHEW_XNOR,  "02",  TOY,      AP,      XNOR,  {1, 0, 0, 1} },
-    { FHEW_XNOR,  "03",  TOY,      LMKCDEY, XNOR,  {1, 0, 0, 1} },
+    { FHEW_XNOR,  "01",  TOY,      GINX,    2,              4,        XNOR,  {1, 0, 0, 1} },
+    { FHEW_XNOR,  "02",  TOY,      AP,      2,              4,        XNOR,  {1, 0, 0, 1} },
+    { FHEW_XNOR,  "03",  TOY,      LMKCDEY, 2,              4,        XNOR,  {1, 0, 0, 1} },
     // ==========================================
-    // TestType,     Descr, ParamSet, Method,  Gate,      Results
-    { FHEW_XOR_FAST,  "01", TOY,      GINX,    XOR_FAST,  {0, 1, 1, 0} },
-    { FHEW_XOR_FAST,  "02", TOY,      AP,      XOR_FAST,  {0, 1, 1, 0} },
-    { FHEW_XOR_FAST,  "03", TOY,      LMKCDEY, XOR_FAST,  {0, 1, 1, 0} },
+    { FHEW_XOR_FAST,  "01", TOY,      GINX,    2,           4,        XOR_FAST,  {0, 1, 1, 0} },
+    { FHEW_XOR_FAST,  "02", TOY,      AP,      2,           4,        XOR_FAST,  {0, 1, 1, 0} },
+    { FHEW_XOR_FAST,  "03", TOY,      LMKCDEY, 2,           4,        XOR_FAST,  {0, 1, 1, 0} },
     // ==========================================
-    { FHEW_XNOR_FAST, "01", TOY,      GINX,    XNOR_FAST, {1, 0, 0, 1} },
-    { FHEW_XNOR_FAST, "02", TOY,      AP,      XNOR_FAST, {1, 0, 0, 1} },
-    { FHEW_XNOR_FAST, "03", TOY,      LMKCDEY, XNOR_FAST, {1, 0, 0, 1} },
+    { FHEW_XNOR_FAST, "01", TOY,      GINX,    2,           4,        XNOR_FAST, {1, 0, 0, 1} },
+    { FHEW_XNOR_FAST, "02", TOY,      AP,      2,           4,        XNOR_FAST, {1, 0, 0, 1} },
+    { FHEW_XNOR_FAST, "03", TOY,      LMKCDEY, 2,           4,        XNOR_FAST, {1, 0, 0, 1} },
     // ==========================================
-    { FHEW_SIGNED_MODE, "01", SIGNED_MOD_TEST, GINX, AND, {1, 0, 0, 0} },
+    { FHEW_AND3, "01", TOY,      GINX,         3,           6,        AND3,      {0} },
+    { FHEW_AND3, "02", TOY,      AP,           3,           6,        AND3,      {0} },
+    { FHEW_AND3, "03", TOY,      LMKCDEY,      3,           6,        AND3,      {0} },
     // ==========================================
-    { FHEW_KEY_SWITCH, "01", TOY,      GINX,    OR, {1, 0} }, // OR is not needed; added as a random value
-    { FHEW_KEY_SWITCH, "02", TOY,      AP,      OR, {1, 0} }, // OR is not needed; added as a random value
-    { FHEW_KEY_SWITCH, "03", TOY,      LMKCDEY, OR, {1, 0} }, // OR is not needed; added as a random value
+    { FHEW_OR3, "01", TOY,      GINX,         3,            6,        OR3,      {1} },
+    { FHEW_OR3, "02", TOY,      AP,           3,            6,        OR3,      {1} },
+    { FHEW_OR3, "03", TOY,      LMKCDEY,      3,            6,        OR3,      {1} },
     // ==========================================
-    { FHEW_MOD_SWITCH, "01", TOY,      GINX,    OR, {1, 0} }, // OR is not needed; added as a random value
-    { FHEW_MOD_SWITCH, "02", TOY,      AP,      OR, {1, 0} }, // OR is not needed; added as a random value
-    { FHEW_MOD_SWITCH, "03", TOY,      LMKCDEY, OR, {1, 0} }, // OR is not needed; added as a random value
+    { FHEW_AND4, "01", TOY,      GINX,         4,           8,        AND4,      {0} },
+    { FHEW_AND4, "02", TOY,      AP,           4,           8,        AND4,      {0} },
+    { FHEW_AND4, "03", TOY,      LMKCDEY,      4,           8,        AND4,      {0} },
     // ==========================================
-    { FHEW_NOT, "01", TOY,      GINX,    OR, {0, 1} }, // OR is not needed; added as a random value
-    { FHEW_NOT, "02", TOY,      AP,      OR, {0, 1} }, // OR is not needed; added as a random value
-    { FHEW_NOT, "03", TOY,      LMKCDEY, OR, {0, 1} }, // OR is not needed; added as a random value
+    { FHEW_OR4, "01", TOY,      GINX,         4,            8,        OR4,      {1} },
+    { FHEW_OR4, "02", TOY,      AP,           4,            8,        OR4,      {1} },
+    { FHEW_OR4, "03", TOY,      LMKCDEY,      4,            8,        OR4,      {1} },
+    // ==========================================
+    { FHEW_MAJORITY, "01", TOY,      GINX,       3,         4,        MAJORITY,      {1} },
+    { FHEW_MAJORITY, "02", TOY,      AP,         3,         4,        MAJORITY,      {1} },
+    { FHEW_MAJORITY, "03", TOY,      LMKCDEY,    3,         4,        MAJORITY,      {1} },
+    // ==========================================
+    { FHEW_CMUX, "01", TOY,      GINX,         3,           4,        CMUX,      {1, 0} },
+    { FHEW_CMUX, "02", TOY,      AP,           3,           4,        CMUX,      {1, 0} },
+    { FHEW_CMUX, "03", TOY,      LMKCDEY,      3,           4,        CMUX,      {1, 0} },
+    // ==========================================
+    { FHEW_SIGNED_MODE, "01", SIGNED_MOD_TEST, GINX, 2,     4,        AND, {1, 0, 0, 0} },
+    // ==========================================
+    { FHEW_KEY_SWITCH, "01", TOY,      GINX,    2,          4,        OR, {1, 0} },  // OR is not needed; added as a random value
+    { FHEW_KEY_SWITCH, "02", TOY,      AP,      2,          4,        OR, {1, 0} },  // OR is not needed; added as a random value
+    { FHEW_KEY_SWITCH, "03", TOY,      LMKCDEY, 2,          4,        OR, {1, 0} },  // OR is not needed; added as a random value
+    // ==========================================
+    { FHEW_MOD_SWITCH, "01", TOY,      GINX,    2,          4,        OR, {1, 0} },  // OR is not needed; added as a random value
+    { FHEW_MOD_SWITCH, "02", TOY,      AP,      2,          4,        OR, {1, 0} },  // OR is not needed; added as a random value
+    { FHEW_MOD_SWITCH, "03", TOY,      LMKCDEY, 2,          4,        OR, {1, 0} },  // OR is not needed; added as a random value
+    // ==========================================
+    { FHEW_NOT, "01", TOY,      GINX,    2,                 4,        OR, {0, 1} },  // OR is not needed; added as a random value
+    { FHEW_NOT, "02", TOY,      AP,      2,                 4,        OR, {0, 1} },  // OR is not needed; added as a random value
+    { FHEW_NOT, "03", TOY,      LMKCDEY, 2,                 4,        OR, {0, 1} },  // OR is not needed; added as a random value
 };
 // clang-format on
 //===========================================================================================================
 class UTGENERAL_FHEW : public ::testing::TestWithParam<TEST_CASE_UTGENERAL_FHEW> {
-
 protected:
     void SetUp() {}
     void TearDown() {}
@@ -395,6 +440,120 @@ protected:
             EXPECT_TRUE(0 == 1) << failmsg;
         }
     }
+
+    void UnitTest_FHEW_MULTIINPUT(const TEST_CASE_UTGENERAL_FHEW& testData,
+                                  const std::string& failmsg = std::string()) {
+        try {
+            auto cc = BinFHEContext();
+            cc.GenerateBinFHEContext(testData.securityLevel, testData.method);
+
+            auto sk = cc.KeyGen();
+
+            cc.BTKeyGen(sk);
+
+            std::vector<LWECiphertext> ctvec;
+            if (testData.num_of_inputs == 3) {
+                auto ct1 = cc.Encrypt(sk, 1, SMALL_DIM, testData.ptmodulus);
+                auto ct2 = cc.Encrypt(sk, 1, SMALL_DIM, testData.ptmodulus);
+                auto ct3 = cc.Encrypt(sk, 0, SMALL_DIM, testData.ptmodulus);
+                ctvec.push_back(ct1);
+                ctvec.push_back(ct2);
+                ctvec.push_back(ct3);
+            }
+            else if (testData.num_of_inputs == 4) {
+                auto ct1 = cc.Encrypt(sk, 1, SMALL_DIM, testData.ptmodulus);
+                auto ct2 = cc.Encrypt(sk, 0, SMALL_DIM, testData.ptmodulus);
+                auto ct3 = cc.Encrypt(sk, 0, SMALL_DIM, testData.ptmodulus);
+                auto ct4 = cc.Encrypt(sk, 0, SMALL_DIM, testData.ptmodulus);
+                ctvec.push_back(ct1);
+                ctvec.push_back(ct2);
+                ctvec.push_back(ct3);
+                ctvec.push_back(ct4);
+            }
+
+            auto ct11 = cc.EvalBinGate(testData.gate, ctvec);
+            LWEPlaintext result11;
+            cc.Decrypt(sk, ct11, &result11, testData.ptmodulus);
+
+            std::string failed = testData.toString() + " failed";
+
+            EXPECT_EQ(testData.results[0], result11) << failed;
+        }
+        catch (std::exception& e) {
+            std::cerr << "Exception thrown from " << __func__ << "(): " << e.what() << std::endl;
+            // make it fail
+            EXPECT_TRUE(0 == 1) << failmsg;
+        }
+        catch (...) {
+#if defined EMSCRIPTEN
+            std::string name("EMSCRIPTEN_UNKNOWN");
+#else
+            std::string name(demangle(__cxxabiv1::__cxa_current_exception_type()->name()));
+#endif
+            std::cerr << "Unknown exception of type \"" << name << "\" thrown from " << __func__ << "()" << std::endl;
+            // make it fail
+            EXPECT_TRUE(0 == 1) << failmsg;
+        }
+    }
+
+    void UnitTest_FHEW_CMUX(const TEST_CASE_UTGENERAL_FHEW& testData, const std::string& failmsg = std::string()) {
+        try {
+            auto cc = BinFHEContext();
+            cc.GenerateBinFHEContext(testData.securityLevel, testData.method);
+
+            auto sk = cc.KeyGen();
+            cc.BTKeyGen(sk);
+
+            auto ct1 = cc.Encrypt(sk, 1, SMALL_DIM, testData.ptmodulus);
+            auto ct2 = cc.Encrypt(sk, 1, SMALL_DIM, testData.ptmodulus);
+            auto ct3 = cc.Encrypt(sk, 0, SMALL_DIM, testData.ptmodulus);
+            auto ct4 = cc.Encrypt(sk, 0, SMALL_DIM, testData.ptmodulus);
+
+            // 1, 0, 0
+            std::vector<LWECiphertext> ct134;
+            ct134.push_back(ct1);
+            ct134.push_back(ct3);
+            ct134.push_back(ct4);
+
+            // 1, 0, 1
+            std::vector<LWECiphertext> ct132;
+            ct132.push_back(ct1);
+            ct132.push_back(ct3);
+            ct132.push_back(ct2);
+
+            // 1, 0, 1
+            auto ctCMUX0 = cc.EvalBinGate(testData.gate, ct132);
+
+            // 1, 0, 0
+            auto ctCMUX1 = cc.EvalBinGate(testData.gate, ct134);
+
+            LWEPlaintext result1;
+            cc.Decrypt(sk, ctCMUX1, &result1, testData.ptmodulus);
+
+            LWEPlaintext result0;
+            cc.Decrypt(sk, ctCMUX0, &result0, testData.ptmodulus);
+
+            std::string failed = testData.toString() + " failed";
+
+            EXPECT_EQ(testData.results[0], result1) << failed;
+            EXPECT_EQ(testData.results[1], result0) << failed;
+        }
+        catch (std::exception& e) {
+            std::cerr << "Exception thrown from " << __func__ << "(): " << e.what() << std::endl;
+            // make it fail
+            EXPECT_TRUE(0 == 1) << failmsg;
+        }
+        catch (...) {
+#if defined EMSCRIPTEN
+            std::string name("EMSCRIPTEN_UNKNOWN");
+#else
+            std::string name(demangle(__cxxabiv1::__cxa_current_exception_type()->name()));
+#endif
+            std::cerr << "Unknown exception of type \"" << name << "\" thrown from " << __func__ << "()" << std::endl;
+            // make it fail
+            EXPECT_TRUE(0 == 1) << failmsg;
+        }
+    }
 };
 //===========================================================================================================
 TEST_P(UTGENERAL_FHEW, BINFHE) {
@@ -412,6 +571,16 @@ TEST_P(UTGENERAL_FHEW, BINFHE) {
         case FHEW_XNOR_FAST:
         case FHEW_SIGNED_MODE:
             UnitTest_FHEW(test, test.buildTestName());
+            break;
+        case FHEW_AND3:
+        case FHEW_OR3:
+        case FHEW_AND4:
+        case FHEW_OR4:
+        case FHEW_MAJORITY:
+            UnitTest_FHEW_MULTIINPUT(test, test.buildTestName());
+            break;
+        case FHEW_CMUX:
+            UnitTest_FHEW_CMUX(test, test.buildTestName());
             break;
         case FHEW_KEY_SWITCH:
             UnitTest_FHEW_KeySwitch(test, test.buildTestName());


### PR DESCRIPTION
duplicate of PR #480 with new branch

* Updated AND3, OR3, MAJORITY, CMUX gates for 3 inputs and AND4, OR4 for 4 inputs. CMUX is implemented with 3 NAND operations (3 bootstrappings).
* Added unit tests for the gates in UnitTestFHEW
* Added example boolean-multi-input