### PR TITLE
Hardening and optimizations of CKKS bootstrapping for sparse secret distribution

### DIFF
--- a/src/pke/include/README.md
+++ b/src/pke/include/README.md
@@ -27,7 +27,7 @@
   - SecretKeyDistribution
     - Ring Learning with Error (GAUSSIAN)
     - Optimized (UNIFORM_TERNARY)
-    - Sparse (SPARSE_TERNARY; Hamming weight is 64)
+    - Sparse (SPARSE_TERNARY; Hamming weight is 192)
 
   - Scaling Technique
     - Fixed Manual (FIXEDMANUAL)

--- a/src/pke/lib/scheme/bfvrns/bfvrns-multiparty.cpp
+++ b/src/pke/lib/scheme/bfvrns/bfvrns-multiparty.cpp
@@ -114,7 +114,7 @@ KeyPair<DCRTPoly> MultipartyBFVRNS::MultipartyKeyGen(CryptoContext<DCRTPoly> cc,
             s = DCRTPoly(tug, paramsPK, Format::EVALUATION);
             break;
         case SPARSE_TERNARY:
-            s = DCRTPoly(tug, paramsPK, Format::EVALUATION, 64);
+            s = DCRTPoly(tug, paramsPK, Format::EVALUATION, 192);
             break;
         default:
             break;

--- a/src/pke/lib/scheme/bfvrns/bfvrns-pke.cpp
+++ b/src/pke/lib/scheme/bfvrns/bfvrns-pke.cpp
@@ -71,7 +71,7 @@ KeyPair<DCRTPoly> PKEBFVRNS::KeyGenInternal(CryptoContext<DCRTPoly> cc, bool mak
             s = DCRTPoly(tug, paramsPK, Format::EVALUATION);
             break;
         case SPARSE_TERNARY:
-            s = DCRTPoly(tug, paramsPK, Format::EVALUATION, 64);
+            s = DCRTPoly(tug, paramsPK, Format::EVALUATION, 192);
             break;
         default:
             break;

--- a/src/pke/lib/schemebase/base-multiparty.cpp
+++ b/src/pke/lib/schemebase/base-multiparty.cpp
@@ -108,7 +108,7 @@ KeyPair<Element> MultipartyBase<Element>::MultipartyKeyGen(CryptoContext<Element
             s = Element(tug, paramsPK, Format::EVALUATION);
             break;
         case SPARSE_TERNARY:
-            s = Element(tug, paramsPK, Format::EVALUATION, 64);
+            s = Element(tug, paramsPK, Format::EVALUATION, 192);
             break;
         default:
             break;

--- a/src/pke/lib/schemebase/base-pke.cpp
+++ b/src/pke/lib/schemebase/base-pke.cpp
@@ -66,7 +66,7 @@ KeyPair<Element> PKEBase<Element>::KeyGenInternal(CryptoContext<Element> cc, boo
             break;
         case SPARSE_TERNARY:
             // https://github.com/openfheorg/openfhe-development/issues/311
-            s = Element(tug, paramsPK, Format::EVALUATION, 64);
+            s = Element(tug, paramsPK, Format::EVALUATION, 192);
             break;
         default:
             break;


### PR DESCRIPTION
1. Increased the Hamming weight from 64 to 192.
2. Switched from Chebyshev approximation to Chebyshev approximation + double-angle formula.