### PR TITLE
add google* to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ _build/
 api/
 doxyoutput/
 
+third-party/
 
 .ipynb_checkpoints
 


### PR DESCRIPTION
Got hundreds of Google-* files after running "make", which may be ignored. 