### PR TITLE
patched encoding

### DIFF
--- a/src/pke/lib/scheme/ckksrns/ckksrns-schemeswitching.cpp
+++ b/src/pke/lib/scheme/ckksrns/ckksrns-schemeswitching.cpp
@@ -226,17 +226,21 @@ Plaintext SWITCHCKKSRNS::MakeAuxPlaintext(const CryptoContextImpl<DCRTPoly>& cc,
     double powP = scFact;
 
     // Compute approxFactor, a value to scale down by, in case the value exceeds a 64-bit integer.
-    int32_t MAX_BITS_IN_WORD = 62;
+    constexpr int32_t MAX_BITS_IN_WORD = 61;
 
     int32_t logc = 0;
     for (size_t i = 0; i < slots; ++i) {
         inverse[i] *= powP;
-        int32_t logci = static_cast<int32_t>(ceil(log2(std::abs(inverse[i].real()))));
-        if (logc < logci)
-            logc = logci;
-        logci = static_cast<int32_t>(ceil(log2(std::abs(inverse[i].imag()))));
-        if (logc < logci)
-            logc = logci;
+        if (inverse[i].real() != 0) {
+            int32_t logci = static_cast<int32_t>(ceil(log2(std::abs(inverse[i].real()))));
+            if (logc < logci)
+                logc = logci;
+        }
+        if (inverse[i].imag() != 0) {
+            int32_t logci = static_cast<int32_t>(ceil(log2(std::abs(inverse[i].imag()))));
+            if (logc < logci)
+                logc = logci;
+        }
     }
     if (logc < 0) {
         OPENFHE_THROW(math_error, "Too small scaling factor");


### PR DESCRIPTION
The encoding for complex numbers in scheme switching has now the patches for avoiding overflow from ckksrns-fhe.