### PR TITLE
Fixes a bug in the interface for BFV generation

### DIFF
--- a/src/pke/include/scheme/bfvrns/gen-cryptocontext-bfvrns-internal.h
+++ b/src/pke/include/scheme/bfvrns/gen-cryptocontext-bfvrns-internal.h
@@ -92,7 +92,7 @@ typename ContextGeneratorType::ContextType genCryptoContextBFVRNSInternal(
         parameters.GetEvalAddCount(),
         parameters.GetMultiplicativeDepth(),
         parameters.GetKeySwitchCount(),
-        parameters.GetFirstModSize(),
+        parameters.GetScalingModSize(),
         parameters.GetRingDim(),
         parameters.GetNumLargeDigits());
     // clang-format on

--- a/src/pke/include/schemerns/rns-parametergeneration.h
+++ b/src/pke/include/schemerns/rns-parametergeneration.h
@@ -131,7 +131,7 @@ public:
 protected:
     enum DCRT_MODULUS {
         DEFAULT_EXTRA_MOD_SIZE = 20,
-        MIN_SIZE               = 30,
+        MIN_SIZE               = 14,
         MAX_SIZE               = 60,
     };
 };


### PR DESCRIPTION
1. Now uses the scaling mod size instead of first mod size for setting the size of RNS moduli in BFV
2. Reduces the MIN_SIZE from 30 to 14

Closes #619 and #555 