### PR TITLE
Add `<cmath>` header to fix ambiguity for `abs`

### DIFF
--- a/src/core/include/utils/utilities.h
+++ b/src/core/include/utils/utilities.h
@@ -36,6 +36,7 @@
 #include "utils/inttypes.h"
 
 #include <climits>  // CHAR_BIT
+#include <cmath>
 #include <limits>   // std::numeric_limits
 #include <string>
 #include <type_traits>  // std::is_integral


### PR DESCRIPTION
While trying to build OpenFHE using [BinaryBuilder.jl](https://github.com/JuliaPackaging/BinaryBuilder.jl), I received some method ambiguity errors for the use of `abs` on macOS, on both `aarch64` ([log](https://buildkite.com/julialang/yggdrasil/builds/7423#018cb78b-6c8b-4a3f-8d6d-fc563f4a950c/630-937)) and `x86_64` ([log](https://buildkite.com/julialang/yggdrasil/builds/7423#018cb78b-6c88-46d2-b894-f44e06259b21/631-934)):
```
In file included from /workspace/srcdir/openfhe-development/src/core/lib/utils/utilities.cpp:36:
/workspace/srcdir/openfhe-development/src/core/include/utils/utilities.h:118:12: error: call to 'abs' is ambiguous
    return std::abs(d) > static_cast<double>(Max64BitValue());
           ^~~~~~~~
/opt/x86_64-apple-darwin14/x86_64-apple-darwin14/sys-root/usr/include/stdlib.h:129:6: note: candidate function
int      abs(int) __pure2;
         ^
/opt/x86_64-apple-darwin14/x86_64-apple-darwin14/sys-root/usr/include/c++/v1/stdlib.h:111:44: note: candidate function
inline _LIBCPP_INLINE_VISIBILITY long      abs(     long __x) _NOEXCEPT {return  labs(__x);}
                                           ^
/opt/x86_64-apple-darwin14/x86_64-apple-darwin14/sys-root/usr/include/c++/v1/stdlib.h:113:44: note: candidate function
inline _LIBCPP_INLINE_VISIBILITY long long abs(long long __x) _NOEXCEPT {return llabs(__x);}
                                           ^
In file included from /workspace/srcdir/openfhe-development/src/core/lib/utils/utilities.cpp:36:
/workspace/srcdir/openfhe-development/src/core/include/utils/utilities.h:135:16: error: call to 'abs' is ambiguous
        return std::abs(d) <= static_cast<double>(std::numeric_limits<int32_t>::max());
               ^~~~~~~~
/opt/x86_64-apple-darwin14/x86_64-apple-darwin14/sys-root/usr/include/stdlib.h:129:6: note: candidate function
int      abs(int) __pure2;
         ^
/opt/x86_64-apple-darwin14/x86_64-apple-darwin14/sys-root/usr/include/c++/v1/stdlib.h:111:44: note: candidate function
inline _LIBCPP_INLINE_VISIBILITY long      abs(     long __x) _NOEXCEPT {return  labs(__x);}
                                           ^
/opt/x86_64-apple-darwin14/x86_64-apple-darwin14/sys-root/usr/include/c++/v1/stdlib.h:113:44: note: candidate function
inline _LIBCPP_INLINE_VISIBILITY long long abs(long long __x) _NOEXCEPT {return llabs(__x);}
                                           ^
In file included from /workspace/srcdir/openfhe-development/src/core/lib/utils/utilities.cpp:36:
/workspace/srcdir/openfhe-development/src/core/include/utils/utilities.h:137:16: error: call to 'abs' is ambiguous
        return std::abs(d) <= static_cast<double>(Max64BitValue());
               ^~~~~~~~
/opt/x86_64-apple-darwin14/x86_64-apple-darwin14/sys-root/usr/include/stdlib.h:129:6: note: candidate function
int      abs(int) __pure2;
         ^
/opt/x86_64-apple-darwin14/x86_64-apple-darwin14/sys-root/usr/include/c++/v1/stdlib.h:111:44: note: candidate function
inline _LIBCPP_INLINE_VISIBILITY long      abs(     long __x) _NOEXCEPT {return  labs(__x);}
                                           ^
/opt/x86_64-apple-darwin14/x86_64-apple-darwin14/sys-root/usr/include/c++/v1/stdlib.h:113:44: note: candidate function
inline _LIBCPP_INLINE_VISIBILITY long long abs(long long __x) _NOEXCEPT {return llabs(__x);}
                                           ^
3 errors generated.
```
By including `<cmath>` in [`src/core/include/utils/utilities.h`](https://github.com/openfheorg/openfhe-development/blob/main/src/core/include/utils/utilities.h), this error seems to be fixed.