### PR TITLE
Fix for slowdown at a large number of threads

### DIFF
--- a/benchmark/src/lib-benchmark.cpp
+++ b/benchmark/src/lib-benchmark.cpp
@@ -34,14 +34,14 @@
  * BFVrns, CKKSrns, BGVrns. It also contains several performance tests for NTT and INTT transformations.
  */
 
-#define PROFILE
 #define _USE_MATH_DEFINES
+
+#include "benchmark/benchmark.h"
+#include "math/hal/basicint.h"
 #include "scheme/ckksrns/gen-cryptocontext-ckksrns.h"
 #include "scheme/bfvrns/gen-cryptocontext-bfvrns.h"
 #include "scheme/bgvrns/gen-cryptocontext-bgvrns.h"
 #include "gen-cryptocontext.h"
-
-#include "benchmark/benchmark.h"
 
 #include <fstream>
 #include <iostream>
@@ -55,212 +55,142 @@ using namespace lbcrypto;
  * Context setup utility methods
  */
 
-CryptoContext<DCRTPoly> GenerateBFVrnsContext() {
+[[maybe_unused]] static void DepthArgs(benchmark::internal::Benchmark* b) {
+    for (uint32_t d : {1, 4, 16, 32})
+        //    for (uint32_t d : {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+        b->ArgName("depth")->Arg(d);
+}
+
+[[maybe_unused]] static CryptoContext<DCRTPoly> GenerateBFVrnsContext(uint32_t mdepth = 1) {
     CCParams<CryptoContextBFVRNS> parameters;
     parameters.SetPlaintextModulus(65537);
     parameters.SetScalingModSize(60);
-
+    parameters.SetMultiplicativeDepth(mdepth);
     CryptoContext<DCRTPoly> cc = GenCryptoContext(parameters);
-    // Enable features that you wish to use
     cc->Enable(PKE);
     cc->Enable(KEYSWITCH);
     cc->Enable(LEVELEDSHE);
-
     return cc;
 }
 
-CryptoContext<DCRTPoly> GenerateCKKSContext() {
+[[maybe_unused]] static CryptoContext<DCRTPoly> GenerateCKKSContext(uint32_t mdepth = 1) {
     CCParams<CryptoContextCKKSRNS> parameters;
     parameters.SetScalingModSize(48);
     parameters.SetBatchSize(8);
     parameters.SetScalingTechnique(FIXEDMANUAL);
-
-    CryptoContext<DCRTPoly> cc = GenCryptoContext(parameters);
+    parameters.SetMultiplicativeDepth(mdepth);
+    auto cc = GenCryptoContext(parameters);
     cc->Enable(PKE);
     cc->Enable(KEYSWITCH);
     cc->Enable(LEVELEDSHE);
-
     return cc;
 }
 
-CryptoContext<DCRTPoly> GenerateBGVrnsContext() {
+[[maybe_unused]] static CryptoContext<DCRTPoly> GenerateBGVrnsContext(uint32_t mdepth = 1) {
     CCParams<CryptoContextBGVRNS> parameters;
     parameters.SetPlaintextModulus(65537);
     parameters.SetMaxRelinSkDeg(1);
     parameters.SetScalingTechnique(FIXEDMANUAL);
-
+    parameters.SetMultiplicativeDepth(mdepth);
     CryptoContext<DCRTPoly> cc = GenCryptoContext(parameters);
     cc->Enable(PKE);
     cc->Enable(KEYSWITCH);
     cc->Enable(LEVELEDSHE);
-
     return cc;
 }
 
-void NTTTransform1024(benchmark::State& state) {
-    usint m    = 2048;
-    usint phim = 1024;
+/*
+ * Native NTT benchmarks
+ */
 
-    NativeInteger modulusQ("288230376151748609");
+[[maybe_unused]] static void RingArgs(benchmark::internal::Benchmark* b) {
+    for (uint32_t r : {1024, 4096, 8192})
+        b->ArgName("ringdm")->Arg(r);
+}
+
+[[maybe_unused]] static void NativeNTT(benchmark::State& state) {
+    uint32_t n = state.range(0);
+    uint32_t m = n << 1;
+
+    NativeInteger modulusQ(LastPrime<NativeInteger>(MAX_MODULUS_SIZE, m));
     NativeInteger rootOfUnity = RootOfUnity(m, modulusQ);
 
     DiscreteUniformGeneratorImpl<NativeVector> dug;
-    NativeVector x = dug.GenerateVector(phim, modulusQ);
-    NativeVector X(phim);
+    NativeVector x = dug.GenerateVector(n, modulusQ);
+    NativeVector X(n);
 
     ChineseRemainderTransformFTT<NativeVector> crtFTT;
     crtFTT.PreCompute(rootOfUnity, m, modulusQ);
 
-    while (state.KeepRunning()) {
+    for (auto _ : state)
         crtFTT.ForwardTransformToBitReverse(x, rootOfUnity, m, &X);
-    }
+
+    state.SetComplexityN(state.range(0));
 }
 
-BENCHMARK(NTTTransform1024)->Unit(benchmark::kMicrosecond);
+[[maybe_unused]] static void NativeINTT(benchmark::State& state) {
+    uint32_t n = state.range(0);
+    uint32_t m = n << 1;
 
-void INTTTransform1024(benchmark::State& state) {
-    usint m    = 2048;
-    usint phim = 1024;
-
-    NativeInteger modulusQ("288230376151748609");
+    NativeInteger modulusQ(LastPrime<NativeInteger>(MAX_MODULUS_SIZE, m));
     NativeInteger rootOfUnity = RootOfUnity(m, modulusQ);
 
     DiscreteUniformGeneratorImpl<NativeVector> dug;
-    NativeVector x = dug.GenerateVector(phim, modulusQ);
-    NativeVector X(phim);
+    NativeVector x = dug.GenerateVector(n, modulusQ);
+    NativeVector X(n);
 
     ChineseRemainderTransformFTT<NativeVector> crtFTT;
     crtFTT.PreCompute(rootOfUnity, m, modulusQ);
 
-    while (state.KeepRunning()) {
+    for (auto _ : state)
         crtFTT.InverseTransformFromBitReverse(x, rootOfUnity, m, &X);
-    }
+
+    state.SetComplexityN(state.range(0));
 }
 
-BENCHMARK(INTTTransform1024)->Unit(benchmark::kMicrosecond);
+[[maybe_unused]] static void NativeNTTInPlace(benchmark::State& state) {
+    uint32_t n = state.range(0);
+    uint32_t m = n << 1;
 
-void NTTTransform4096(benchmark::State& state) {
-    usint m    = 8192;
-    usint phim = 4096;
-
-    NativeInteger modulusQ("1152921496017387521");
+    NativeInteger modulusQ(LastPrime<NativeInteger>(MAX_MODULUS_SIZE, m));
     NativeInteger rootOfUnity = RootOfUnity(m, modulusQ);
 
     DiscreteUniformGeneratorImpl<NativeVector> dug;
-    NativeVector x = dug.GenerateVector(phim, modulusQ);
-    NativeVector X(phim);
+    NativeVector x = dug.GenerateVector(n, modulusQ);
 
     ChineseRemainderTransformFTT<NativeVector> crtFTT;
     crtFTT.PreCompute(rootOfUnity, m, modulusQ);
 
-    while (state.KeepRunning()) {
-        crtFTT.ForwardTransformToBitReverse(x, rootOfUnity, m, &X);
-    }
-}
-
-BENCHMARK(NTTTransform4096)->Unit(benchmark::kMicrosecond);
-
-void INTTTransform4096(benchmark::State& state) {
-    usint m    = 8192;
-    usint phim = 4096;
-
-    NativeInteger modulusQ("1152921496017387521");
-    NativeInteger rootOfUnity = RootOfUnity(m, modulusQ);
-
-    DiscreteUniformGeneratorImpl<NativeVector> dug;
-    NativeVector x = dug.GenerateVector(phim, modulusQ);
-    NativeVector X(phim);
-
-    ChineseRemainderTransformFTT<NativeVector> crtFTT;
-    crtFTT.PreCompute(rootOfUnity, m, modulusQ);
-
-    while (state.KeepRunning()) {
-        crtFTT.InverseTransformFromBitReverse(x, rootOfUnity, m, &X);
-    }
-}
-
-BENCHMARK(INTTTransform4096)->Unit(benchmark::kMicrosecond);
-
-void NTTTransformInPlace1024(benchmark::State& state) {
-    usint m    = 2048;
-    usint phim = 1024;
-
-    NativeInteger modulusQ("288230376151748609");
-    NativeInteger rootOfUnity = RootOfUnity(m, modulusQ);
-
-    DiscreteUniformGeneratorImpl<NativeVector> dug;
-    NativeVector x = dug.GenerateVector(phim, modulusQ);
-
-    ChineseRemainderTransformFTT<NativeVector> crtFTT;
-    crtFTT.PreCompute(rootOfUnity, m, modulusQ);
-
-    while (state.KeepRunning()) {
+    for (auto _ : state)
         crtFTT.ForwardTransformToBitReverseInPlace(rootOfUnity, m, &x);
-    }
+
+    state.SetComplexityN(state.range(0));
 }
 
-BENCHMARK(NTTTransformInPlace1024)->Unit(benchmark::kMicrosecond);
+[[maybe_unused]] static void NativeINTTInPlace(benchmark::State& state) {
+    uint32_t n = state.range(0);
+    uint32_t m = n << 1;
 
-void INTTTransformInPlace1024(benchmark::State& state) {
-    usint m    = 2048;
-    usint phim = 1024;
-
-    NativeInteger modulusQ("288230376151748609");
+    NativeInteger modulusQ(LastPrime<NativeInteger>(MAX_MODULUS_SIZE, m));
     NativeInteger rootOfUnity = RootOfUnity(m, modulusQ);
 
     DiscreteUniformGeneratorImpl<NativeVector> dug;
-    NativeVector x = dug.GenerateVector(phim, modulusQ);
+    NativeVector x = dug.GenerateVector(n, modulusQ);
 
     ChineseRemainderTransformFTT<NativeVector> crtFTT;
     crtFTT.PreCompute(rootOfUnity, m, modulusQ);
 
-    while (state.KeepRunning()) {
+    for (auto _ : state)
         crtFTT.InverseTransformFromBitReverseInPlace(rootOfUnity, m, &x);
-    }
+
+    state.SetComplexityN(state.range(0));
 }
 
-BENCHMARK(INTTTransformInPlace1024)->Unit(benchmark::kMicrosecond);
-
-void NTTTransformInPlace4096(benchmark::State& state) {
-    usint m    = 8192;
-    usint phim = 4096;
-
-    NativeInteger modulusQ("1152921496017387521");
-    NativeInteger rootOfUnity = RootOfUnity(m, modulusQ);
-
-    DiscreteUniformGeneratorImpl<NativeVector> dug;
-    NativeVector x = dug.GenerateVector(phim, modulusQ);
-
-    ChineseRemainderTransformFTT<NativeVector> crtFTT;
-    crtFTT.PreCompute(rootOfUnity, m, modulusQ);
-
-    while (state.KeepRunning()) {
-        crtFTT.ForwardTransformToBitReverseInPlace(rootOfUnity, m, &x);
-    }
-}
-
-BENCHMARK(NTTTransformInPlace4096)->Unit(benchmark::kMicrosecond);
-
-void INTTTransformInPlace4096(benchmark::State& state) {
-    usint m    = 8192;
-    usint phim = 4096;
-
-    NativeInteger modulusQ("1152921496017387521");
-    NativeInteger rootOfUnity = RootOfUnity(m, modulusQ);
-
-    DiscreteUniformGeneratorImpl<NativeVector> dug;
-    NativeVector x = dug.GenerateVector(phim, modulusQ);
-    NativeVector X(phim);
-
-    ChineseRemainderTransformFTT<NativeVector> crtFTT;
-    crtFTT.PreCompute(rootOfUnity, m, modulusQ);
-
-    while (state.KeepRunning()) {
-        crtFTT.InverseTransformFromBitReverseInPlace(rootOfUnity, m, &x);
-    }
-}
-
-BENCHMARK(INTTTransformInPlace4096)->Unit(benchmark::kMicrosecond);
+// BENCHMARK(NativeNTT)->Unit(benchmark::kMicrosecond)->RangeMultiplier(2)->Range(1<<10, 1<<16)->Complexity(benchmark::oAuto);
+BENCHMARK(NativeNTT)->Unit(benchmark::kMicrosecond)->Apply(RingArgs);          // ->Complexity(benchmark::oAuto);
+BENCHMARK(NativeINTT)->Unit(benchmark::kMicrosecond)->Apply(RingArgs);         // ->Complexity(benchmark::oAuto);
+BENCHMARK(NativeNTTInPlace)->Unit(benchmark::kMicrosecond)->Apply(RingArgs);   // ->Complexity(benchmark::oAuto);
+BENCHMARK(NativeINTTInPlace)->Unit(benchmark::kMicrosecond)->Apply(RingArgs);  // ->Complexity(benchmark::oAuto);
 
 /*
  * BFVrns benchmarks
@@ -291,6 +221,7 @@ void BFVrns_MultKeyGen(benchmark::State& state) {
 
 BENCHMARK(BFVrns_MultKeyGen)->Unit(benchmark::kMicrosecond);
 
+// TODO: revisit this?
 void BFVrns_EvalAtIndexKeyGen(benchmark::State& state) {
     CryptoContext<DCRTPoly> cc = GenerateBFVrnsContext();
 
@@ -600,7 +531,7 @@ void CKKSrns_AddInPlace(benchmark::State& state) {
 BENCHMARK(CKKSrns_AddInPlace)->Unit(benchmark::kMicrosecond);
 
 void CKKSrns_MultNoRelin(benchmark::State& state) {
-    CryptoContext<DCRTPoly> cc = GenerateCKKSContext();
+    CryptoContext<DCRTPoly> cc = GenerateCKKSContext(state.range(0));
 
     KeyPair<DCRTPoly> keyPair = cc->KeyGen();
 
@@ -620,12 +551,14 @@ void CKKSrns_MultNoRelin(benchmark::State& state) {
     while (state.KeepRunning()) {
         auto ciphertextMul = cc->EvalMultNoRelin(ciphertext1, ciphertext2);
     }
+
+    state.SetComplexityN(state.range(0));
 }
 
-BENCHMARK(CKKSrns_MultNoRelin)->Unit(benchmark::kMicrosecond);
+BENCHMARK(CKKSrns_MultNoRelin)->Unit(benchmark::kMicrosecond)->Apply(DepthArgs);  // ->Complexity(benchmark::oAuto);
 
 void CKKSrns_MultRelin(benchmark::State& state) {
-    CryptoContext<DCRTPoly> cc = GenerateCKKSContext();
+    CryptoContext<DCRTPoly> cc = GenerateCKKSContext(state.range(0));
 
     KeyPair<DCRTPoly> keyPair = cc->KeyGen();
     cc->EvalMultKeyGen(keyPair.secretKey);
@@ -646,9 +579,11 @@ void CKKSrns_MultRelin(benchmark::State& state) {
     while (state.KeepRunning()) {
         auto ciphertextMul = cc->EvalMult(ciphertext1, ciphertext2);
     }
+
+    state.SetComplexityN(state.range(0));
 }
 
-BENCHMARK(CKKSrns_MultRelin)->Unit(benchmark::kMicrosecond);
+BENCHMARK(CKKSrns_MultRelin)->Unit(benchmark::kMicrosecond)->Apply(DepthArgs);  // ->Complexity(benchmark::oAuto);
 
 void CKKSrns_Relin(benchmark::State& state) {
     CryptoContext<DCRTPoly> cc = GenerateCKKSContext();

--- a/benchmark/src/poly-benchmark.h
+++ b/benchmark/src/poly-benchmark.h
@@ -48,7 +48,7 @@ using namespace lbcrypto;
 constexpr size_t POLY_NUM    = 16;
 constexpr size_t POLY_NUM_M1 = (POLY_NUM - 1);
 
-std::vector<uint32_t> tow_args({1, 2, 4, 8});
+std::vector<uint32_t> tow_args({1, 2, 4, 8, 16});
 std::shared_ptr<std::vector<NativePoly>> NativepolysEval;
 std::shared_ptr<std::vector<NativePoly>> NativepolysCoef;
 std::map<uint32_t, std::shared_ptr<std::vector<DCRTPoly>>> DCRTpolysEval;

--- a/src/core/include/lattice/hal/dcrtpoly-interface.h
+++ b/src/core/include/lattice/hal/dcrtpoly-interface.h
@@ -247,7 +247,8 @@ public:
    */
     // TODO: this doesn't look right
     const BigIntType GetRootOfUnity() const {
-        return BigIntType(0);
+        //        return BigIntType(0);
+        return this->GetDerived().GetParams()->GetRootOfUnity();
     }
 
     /**
@@ -265,18 +266,24 @@ public:
    * Note this operation is computationally intense. Does bound checking
    * @return interpolated value at index i.
    */
-    BigIntType& at(usint i) override             = 0;
-    const BigIntType& at(usint i) const override = 0;
+    BigIntType& at(usint i) final {
+        OPENFHE_THROW(not_implemented_error, "at() not implemented for DCRTPoly");
+    }
+    const BigIntType& at(usint i) const final {
+        OPENFHE_THROW(not_implemented_error, "const at() not implemented for DCRTPoly");
+    }
 
     /**
    * @brief Get interpolated value of element at index i.
    * Note this operation is computationally intense. No bound checking
    * @return interpolated value at index i.
    */
-    BigIntType& operator[](usint i) override = 0;
-    //    return this->GetDerived()[i];
-    const BigIntType& operator[](usint i) const override = 0;
-    //    return this->GetDerived()[i];
+    BigIntType& operator[](usint i) final {
+        OPENFHE_THROW(not_implemented_error, "operator[] not implemented for DCRTPoly");
+    }
+    const BigIntType& operator[](usint i) const final {
+        OPENFHE_THROW(not_implemented_error, "const operator[] not implemented for DCRTPoly");
+    }
 
     /**
    * @brief Get method that returns a vector of all component elements.
@@ -307,19 +314,6 @@ public:
    * @returns a reference to the returned tower
    */
     const TowerType& GetElementAtIndex(usint i) const {
-        return this->GetDerived().GetAllElements()[i];
-    }
-
-    /**
-   * @brief Get value of element at index i.
-   *
-   * @return value at index i.
-   *
-   * @warning Should be removed to disable access to the towers, all modifications
-   * in the lattice layer should be done in the lattice layer. This means new functions
-   * will be need in the lattice layer.
-   */
-    TowerType& ElementAtIndex(usint i) {
         return this->GetDerived().GetAllElements()[i];
     }
 
@@ -670,9 +664,7 @@ public:
    * @warning Will remove, this is only inplace because of BFV
    */
     DerivedType MultiplyAndRound(const BigIntType& p, const BigIntType& q) const final {
-        std::string errMsg = "Operation not implemented yet";
-        OPENFHE_THROW(not_implemented_error, errMsg);
-        return this->GetDerived();
+        OPENFHE_THROW(not_implemented_error, "MultiplyAndRound not implemented for DCRTPoly");
     }
 
     /**
@@ -685,9 +677,7 @@ public:
    * @warning Will remove, this is only inplace because of BFV
    */
     DerivedType DivideAndRound(const BigIntType& q) const final {
-        std::string errMsg = "Operation not implemented yet";
-        OPENFHE_THROW(not_implemented_error, errMsg);
-        return this->GetDerived();
+        OPENFHE_THROW(not_implemented_error, "DivideAndRound not implemented for DCRTPoly");
     }
 
     /**
@@ -719,7 +709,7 @@ public:
     virtual DerivedType& operator*=(const LilIntType& rhs)  = 0;
 
     /**
-   * @brief Performs an multiplication operation and returns the result.
+   * @brief Performs a multiplication operation and returns the result.
    *
    * @param &element is the element to multiply with.
    * @return is the result of the multiplication.
@@ -744,7 +734,7 @@ public:
    * @warning Doesn't make sense for DCRT
    */
     DerivedType ModByTwo() const final {
-        OPENFHE_THROW(not_implemented_error, "Mod of an BigIntType not implemented on DCRTPoly");
+        OPENFHE_THROW(not_implemented_error, "Mod of a BigIntType not implemented for DCRTPoly");
     }
 
     /**
@@ -757,7 +747,7 @@ public:
    * @warning Doesn't make sense for DCRT
    */
     DerivedType Mod(const BigIntType& modulus) const final {
-        OPENFHE_THROW(not_implemented_error, "Mod of an BigIntType not implemented on DCRTPoly");
+        OPENFHE_THROW(not_implemented_error, "Mod of a BigIntType not implemented for DCRTPoly");
     }
 
     /**
@@ -768,7 +758,7 @@ public:
    * @warning Doesn't make sense for DCRT
    */
     const BigVecType& GetValues() const final {
-        OPENFHE_THROW(not_implemented_error, "GetValues not implemented on DCRTPoly");
+        OPENFHE_THROW(not_implemented_error, "GetValues not implemented for DCRTPoly");
     }
 
     /**
@@ -780,7 +770,7 @@ public:
    * @warning Doesn't make sense for DCRT
    */
     void SetValues(const BigVecType& values, Format format) {
-        OPENFHE_THROW(not_implemented_error, "SetValues not implemented on DCRTPoly");
+        OPENFHE_THROW(not_implemented_error, "SetValues not implemented for DCRTPoly");
     }
 
     /**
@@ -848,9 +838,7 @@ public:
    * @param &qlInvModqPrecon NTL-specific precomputations
    */
     virtual void DropLastElementAndScale(const std::vector<NativeInteger>& QlQlInvModqlDivqlModq,
-                                         const std::vector<NativeInteger>& QlQlInvModqlDivqlModqPrecon,
-                                         const std::vector<NativeInteger>& qlInvModq,
-                                         const std::vector<NativeInteger>& qlInvModqPrecon) = 0;
+                                         const std::vector<NativeInteger>& qlInvModq) = 0;
 
     /**
    * @brief ModReduces reduces the DCRTPoly element's composite modulus by
@@ -870,7 +858,7 @@ public:
                            const std::vector<NativeInteger>& qlInvModqPrecon) = 0;
 
     /**
-   * @brief Interpolates the DCRTPoly to an Poly based on the Chinese Remainder
+   * @brief Interpolates the DCRTPoly to a Poly based on the Chinese Remainder
    * Transform Interpolation. and then returns a Poly with that single element
    *
    * @return the interpolated ring element as a Poly object.
@@ -889,7 +877,7 @@ public:
     virtual TowerType ToNativePoly() const = 0;
 
     /**
-   * @brief Interpolates the DCRTPoly to an Poly based on the Chinese Remainder
+   * @brief Interpolates the DCRTPoly to a Poly based on the Chinese Remainder
    * Transform Interpolation, only at element index i, all other elements are
    * zero. and then returns a Poly with that single element
    *
@@ -1396,7 +1384,7 @@ public:
     void SwitchFormat() override = 0;
 
     /**
-   * @brief Sets format to value without calling FFT. Only use if you know what you're doing.
+   * @brief Sets format to value without performing NTT. Only use if you know what you're doing.
    *
    */
     virtual void OverrideFormat(const Format f) = 0;
@@ -1413,7 +1401,7 @@ public:
    */
     void SwitchModulus(const BigIntType& modulus, const BigIntType& rootOfUnity, const BigIntType& modulusArb,
                        const BigIntType& rootOfUnityArb) final {
-        OPENFHE_THROW(not_implemented_error, "SwitchModulus not implemented on DCRTPoly");
+        OPENFHE_THROW(not_implemented_error, "SwitchModulus not implemented for DCRTPoly");
     }
 
     /**

--- a/src/core/include/lattice/hal/default/dcrtpoly.h
+++ b/src/core/include/lattice/hal/default/dcrtpoly.h
@@ -120,15 +120,6 @@ public:
     DCRTPolyType CloneWithNoise(const DiscreteGaussianGeneratorImpl<VecType>& dgg, Format format) const override;
     DCRTPolyType CloneTowers(uint32_t startTower, uint32_t endTower) const;
 
-    Integer& at(usint i) override;
-    const Integer& at(usint i) const override;
-    Integer& operator[](usint i) override {
-        return DCRTPolyType::CRTInterpolateIndex(i)[i];
-    }
-    const Integer& operator[](usint i) const override {
-        return DCRTPolyType::CRTInterpolateIndex(i)[i];
-    }
-
     bool operator==(const DCRTPolyType& rhs) const override;
 
     DCRTPolyType& operator+=(const DCRTPolyType& rhs) override;
@@ -216,9 +207,7 @@ public:
     void DropLastElement() override;
     void DropLastElements(size_t i) override;
     void DropLastElementAndScale(const std::vector<NativeInteger>& QlQlInvModqlDivqlModq,
-                                 const std::vector<NativeInteger>& QlQlInvModqlDivqlModqPrecon,
-                                 const std::vector<NativeInteger>& qlInvModq,
-                                 const std::vector<NativeInteger>& qlInvModqPrecon) override;
+                                 const std::vector<NativeInteger>& qlInvModq) override;
 
     void ModReduce(const NativeInteger& t, const std::vector<NativeInteger>& tModqPrecon,
                    const NativeInteger& negtInvModq, const NativeInteger& negtInvModqPrecon,

--- a/src/core/include/lattice/ilelement.h
+++ b/src/core/include/lattice/ilelement.h
@@ -153,10 +153,10 @@ public:
    * @return will throw an error.
    */
     virtual IntType& at(usint i) {
-        OPENFHE_THROW(not_implemented_error, "at not implemented");
+        OPENFHE_THROW(not_implemented_error, "at() not implemented");
     }
     virtual const IntType& at(usint i) const {
-        OPENFHE_THROW(not_implemented_error, "const at not implemented");
+        OPENFHE_THROW(not_implemented_error, "const at() not implemented");
     }
     virtual IntType& operator[](usint i) {
         OPENFHE_THROW(not_implemented_error, "[] not implemented");

--- a/src/pke/lib/scheme/ckksrns/ckksrns-leveledshe.cpp
+++ b/src/pke/lib/scheme/ckksrns/ckksrns-leveledshe.cpp
@@ -116,9 +116,7 @@ void LeveledSHECKKSRNS::ModReduceInternalInPlace(Ciphertext<DCRTPoly>& ciphertex
     for (size_t l = 0; l < levels; ++l) {
         for (size_t i = 0; i < cv.size(); ++i) {
             cv[i].DropLastElementAndScale(cryptoParams->GetQlQlInvModqlDivqlModq(diffQl + l),
-                                          cryptoParams->GetQlQlInvModqlDivqlModqPrecon(diffQl + l),
-                                          cryptoParams->GetqlInvModq(diffQl + l),
-                                          cryptoParams->GetqlInvModqPrecon(diffQl + l));
+                                          cryptoParams->GetqlInvModq(diffQl + l));
         }
     }
 

--- a/src/pke/unittest/utbfvrns/UnitTestBFVrnsCRTOperations.cpp
+++ b/src/pke/unittest/utbfvrns/UnitTestBFVrnsCRTOperations.cpp
@@ -458,7 +458,9 @@ TEST_F(UTBFVRNS_CRT, BFVrns_Mult_by_Constant) {
                      cryptoParamsBFVrns->GetalphaQlModr(), cryptoParamsBFVrns->GetModrBarrettMu(),
                      cryptoParamsBFVrns->GetqInv(), Format::EVALUATION);
 
-    Poly resultExpandedB = b.CRTInterpolate();
+    auto tmp{b};
+    tmp.SetFormat(Format::COEFFICIENT);
+    Poly resultExpandedB = tmp.CRTInterpolate();
 
     BigInteger A0 = bPoly.at(0);
 
@@ -587,7 +589,9 @@ TEST_F(UTBFVRNS_CRT, BFVrns_Mult_by_Gaussian) {
                      cryptoParamsBFVrns->GetalphaQlModr(), cryptoParamsBFVrns->GetModrBarrettMu(),
                      cryptoParamsBFVrns->GetqInv(), Format::EVALUATION);
 
-    Poly resultExpandedB = b.CRTInterpolate();
+    auto tmp{b};
+    tmp.SetFormat(Format::COEFFICIENT);
+    Poly resultExpandedB = tmp.CRTInterpolate();
 
     BigInteger A0 = bPoly.at(0);
 


### PR DESCRIPTION
- Fix for slowdown at a large number of threads
- Remove at() and [] access operators from DCRTPoly
- Force DCRTPoly::CRTInterpoate() to only use COEFFICIENT format
- Remove Precon variables from DropLastElementAndScale
- Updates to lib-benchmark poly-benchmark
