### PR TITLE
fix index out of bounds errors

### DIFF
--- a/src/pke/lib/scheme/ckksrns/ckksrns-schemeswitching.cpp
+++ b/src/pke/lib/scheme/ckksrns/ckksrns-schemeswitching.cpp
@@ -654,8 +654,8 @@ std::vector<std::vector<NativeInteger>> ExtractLWEpacked(const Ciphertext<DCRTPo
     auto& originalAVals = originalA.GetValues();
     auto& originalBVals = originalB.GetValues();
 
-    extracted[1].insert(extracted[1].end(), &originalAVals[0], &originalAVals[N]);
-    extracted[0].insert(extracted[0].end(), &originalBVals[0], &originalBVals[N]);
+    extracted[1].insert(extracted[1].end(), &originalAVals[0], &originalAVals[N - 1]);
+    extracted[0].insert(extracted[0].end(), &originalBVals[0], &originalBVals[N - 1]);
 
     return extracted;
 }
@@ -1421,7 +1421,7 @@ Ciphertext<DCRTPoly> SWITCHCKKSRNS::EvalFHEWtoCKKS(std::vector<std::shared_ptr<L
     std::vector<double> coefficientsFHEW;  // EvalFHEWtoCKKS assumes lattice parameter n is at most 2048.
     if (n == 32) {
         K = 16.0;
-        coefficientsFHEW.insert(coefficientsFHEW.end(), &g_coefficientsFHEW16[0], &g_coefficientsFHEW16[LEN_16]);
+        coefficientsFHEW.insert(coefficientsFHEW.end(), &g_coefficientsFHEW16[0], &g_coefficientsFHEW16[LEN_16 - 1]);
     }
     else {
         K = 128.0;  // Failure probability of 2^{-49}
@@ -1429,11 +1429,11 @@ Ciphertext<DCRTPoly> SWITCHCKKSRNS::EvalFHEWtoCKKS(std::vector<std::shared_ptr<L
             coefficientsFHEW.insert(
                 coefficientsFHEW.end(), &g_coefficientsFHEW128_8[0],
                 &g_coefficientsFHEW128_8
-                    [LEN_128_8]);  // If the output messages are bits, we could use a lower degree polynomial
+                    [LEN_128_8 - 1]);  // If the output messages are bits, we could use a lower degree polynomial
         }
         else {
             coefficientsFHEW.insert(coefficientsFHEW.end(), &g_coefficientsFHEW128_9[0],
-                                    &g_coefficientsFHEW128_9[LEN_128_9]);
+                                    &g_coefficientsFHEW128_9[LEN_128_9 - 1]);
         }
     }
 


### PR DESCRIPTION
The arrays indexed in the lines changed in this PR can be trivially proven to have length `N`, but are indexed at their "last" index `N` instead of `N-1`. This caused assertion failures when running with Google's internal clang of the form

```
[ RUN      ] UnitTests/UTCKKSRNS_SCHEMESWITCH.CKKSRNS/SCHEME_SWITCH_CKKS_FHEW_03                                                                                
third_party/crosstool/v18/stable/toolchain/bin/../include/c++/v1/vector:1400: assertion __n < size() failed: vector[] index out of bounds                       
Execution stopped after processing signal [6] - abnormal termination condition, as is e.g. initiated by std::abort()
```

Investigated with @dsuponitskiy, though what's concerning is that the upstream test suite seems to work with or without this change, and we have not yet figured out exactly what set of flags triggers the assertion on Google's toolchain. And even with this change, there are still many actual test failures such as

```
third_party/openfhe/src/pke/unittest/utckksrns/UnitTestSchemeSwitch.cpp:358: Failure                                                                             
Expected equality of these values:                                                                                                                               
  result                                                                                                                                                         
    Which is: 69050                                                                                                                                              
  inputInt[i]                                                                                                                                                    
    Which is: 32768                                                                                                                                              
Scheme switching from CKKS to FHEW for sparsely packed ciphertexts fails.                                                                                        
                                                                                                                                                                 
third_party/openfhe/src/pke/unittest/utckksrns/UnitTestSchemeSwitch.cpp:358: Failure                                                                             
Expected equality of these values:                                                                                                                               
  result                                                                                                                                                         
    Which is: 50703                                                                                                                                              
  inputInt[i]                                                                                                                                                    
    Which is: 65536                                                                                                                                              
Scheme switching from CKKS to FHEW for sparsely packed ciphertexts fails.                                                                                        
                                                                                                                                                                 
third_party/openfhe/src/pke/unittest/utckksrns/UnitTestSchemeSwitch.cpp:358: Failure                                                                             
Expected equality of these values:                                                                                                                               
  result                                                                                                                                                         
    Which is: 101909                                                                                                                                             
  inputInt[i]                                                                                                                                                    
    Which is: 0                                                                                                                                                  
Scheme switching from CKKS to FHEW for sparsely packed ciphertexts fails. 
```

The complete list of flags used in our internal clang is given here: https://gist.github.com/j2kun/a04ee69636f1b1c1fb47b26c8005fd18

Google's clang is built from upstream (probably with Google-specific internal patches) at commit 0784b1eefa36d4acbb0dacd2d18796e26313b6c5, i.e., https://github.com/llvm/llvm-project/releases/tag/llvmorg-19-init