### PR TITLE
Update lwe-pke.cpp

### DIFF
--- a/src/binfhe/lib/lwe-pke.cpp
+++ b/src/binfhe/lib/lwe-pke.cpp
@@ -52,6 +52,8 @@ LWEPrivateKey LWEEncryptionScheme::KeyGen(usint size, const NativeInteger& modul
 
 LWEPrivateKey LWEEncryptionScheme::KeyGenGaussian(usint size, const NativeInteger& modulus) const {
     DiscreteGaussianGeneratorImpl<NativeVector> dgg;
+    double STD_DEV = 3.19 ;
+    dgg.SetStd(STD_DEV);
     return std::make_shared<LWEPrivateKeyImpl>(LWEPrivateKeyImpl(dgg.GenerateVector(size, modulus)));
 }
 


### PR DESCRIPTION
The variance of dgg here is the default value of 1.0, but the variance of the lwe private key should be the same as the variance of member m_dgg in lwe-cryptoparameters.
You can refer to Table 2 on page 19 of the paper.
[lmkcdey.pdf](https://github.com/openfheorg/openfhe-development/files/14125507/lmkcdey.pdf)
