### PR TITLE
629 correct the use of compress in the scheme switching code

### DIFF
--- a/src/pke/examples/SCHEME_SWITCHING_CAPABILITY.md
+++ b/src/pke/examples/SCHEME_SWITCHING_CAPABILITY.md
@@ -34,15 +34,15 @@ The features that need to be enabled are PKE, KEYSWITCH, LEVELEDSHE and SCHEMESW
 The user has to generate a CKKS cryptocontext and keys with the desired parameters, as well as to set up the FHEW cryptocontext and
 private key through `EvalCKKStoFHEWSetup` and the automorphism keys and key switch hints through `EvalCKKStoFHEWKeyGen`. The setup is
 completed by calling `EvalCKKStoFHEWPrecompute` which takes as argument the scale with which to multiply the decoding matrix, which
-in most cases should be chosen by the user to be Q / (scFactor * p), where Q is the CKKS ciphertext modulus on level 0, scFactor is the
-CKKS scaling factor for that level, and p is the desired FHEW plaintext modulus. If the scale is left to be the default value of 1, the
-implicit FHEW plaintext modulus will be Q / scFactor, and the user should take this into account. Finally, the user can also divide
-separately the messages by p, and input plaintexts in the unit circle, then scale only by Q / scFactor and recover the initial message
-in FHEW.
+in most cases should be chosen by the user to be 1 / p, where p is the desired FHEW plaintext modulus; internally, the scale will be
+transformed to Q / (scFactor * p), where Q is the CKKS ciphertext modulus on level 0, scFactor is the CKKS scaling factor for that level.
+If the scale is left to be the default value of 1, the implicit FHEW plaintext modulus will be Q / scFactor, and the user should take this
+into account. Finally, the user can also divide separately the messages by p, and input plaintexts in the unit circle (which translates
+to an internal scaling only by Q / scFactor) and recover the initial message in FHEW.
 
 After the setup and precomputation, the user should call `EvalCKKStoFHEW`. The number of slots to be converted is specified by the user,
 otherwise it defaults to the number of slots specified in the CKKS scheme. Note that FHEW plaintexts are integers, so the messages from
-CKKS will be rounded.
+CKKS will be rounded (and are expected to fit in the FHEW plaintext modulus).
 
 **FHEW->CKKS**
 We can transform a number of FHEW ciphertexts (symmetric key encryption) into a CKKS ciphertext (public key encryption) encrypting in

--- a/src/pke/examples/advanced-real-numbers.cpp
+++ b/src/pke/examples/advanced-real-numbers.cpp
@@ -158,6 +158,9 @@ void AutomaticRescaleDemo(ScalingTechnique scalTech) {
     if (scalTech == FLEXIBLEAUTO) {
         std::cout << std::endl << std::endl << std::endl << " ===== FlexibleAutoDemo ============= " << std::endl;
     }
+    else if (scalTech == FLEXIBLEAUTOEXT) {
+        std::cout << std::endl << std::endl << std::endl << " ===== FlexibleAutoExtDemo ============= " << std::endl;
+    }
     else {
         std::cout << std::endl << std::endl << std::endl << " ===== FixedAutoDemo ============= " << std::endl;
     }

--- a/src/pke/examples/scheme-switching-serial.cpp
+++ b/src/pke/examples/scheme-switching-serial.cpp
@@ -238,7 +238,7 @@ void clientProcess(uint32_t modulus_LWE) {
     auto beta        = clientBinCC->GetBeta().ConvertToInt();
     auto pLWE        = modulus_LWE / (2 * beta);  // Large precision
 
-    clientCC->EvalCompareSwitchPrecompute(pLWE, 0, scaleSign, false);
+    clientCC->EvalCompareSwitchPrecompute(pLWE, scaleSign, false);
 
     std::cout << "Done with precomputations" << '\n' << std::endl;
 

--- a/src/pke/extras/scheme-switching-timing.cpp
+++ b/src/pke/extras/scheme-switching-timing.cpp
@@ -389,16 +389,11 @@ void ComparisonViaSchemeSwitching(uint32_t depth, uint32_t slots, uint32_t numVa
 
     TIC(t);
     // Pre-computations
-    auto modulus_LWE = 1 << logQ_ccLWE;
-    auto beta        = ccLWE->GetBeta().ConvertToInt();
-    auto pLWE        = modulus_LWE / (2 * beta);
-
-    double scaleSignFHEW    = 8.0;
-    const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersCKKSRNS>(cc->GetCryptoParameters());
-    uint32_t init_level     = 0;
-    if (cryptoParams->GetScalingTechnique() == FLEXIBLEAUTOEXT)
-        init_level = 1;
-    cc->EvalCompareSwitchPrecompute(pLWE, init_level, scaleSignFHEW);
+    auto modulus_LWE     = 1 << logQ_ccLWE;
+    auto beta            = ccLWE->GetBeta().ConvertToInt();
+    auto pLWE            = modulus_LWE / (2 * beta);
+    double scaleSignFHEW = 8.0;
+    cc->EvalCompareSwitchPrecompute(pLWE, scaleSignFHEW);
     timePrecomp = TOC(t);
     std::cout << "Time to perform precomputations: " << timePrecomp / 1000 << " s" << std::endl;
 
@@ -539,12 +534,7 @@ void ArgminViaSchemeSwitching(uint32_t depth, uint32_t slots, uint32_t numValues
     auto modulus_LWE = 1 << logQ_ccLWE;
     auto beta        = ccLWE->GetBeta().ConvertToInt();
     auto pLWE        = modulus_LWE / (2 * beta);  // Large precision
-
-    uint32_t init_level     = 0;
-    const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersCKKSRNS>(cc->GetCryptoParameters());
-    if (cryptoParams->GetScalingTechnique() == FLEXIBLEAUTOEXT)
-        init_level = 1;
-    cc->EvalCompareSwitchPrecompute(pLWE, init_level, scaleSign);
+    cc->EvalCompareSwitchPrecompute(pLWE, scaleSign);
     timePrecomp = TOC(t);
     std::cout << "Time to do the precomputations: " << timePrecomp / 1000 << " s" << std::endl;
 
@@ -695,12 +685,7 @@ void ArgminViaSchemeSwitchingAlt(uint32_t depth, uint32_t slots, uint32_t numVal
     auto modulus_LWE = 1 << logQ_ccLWE;
     auto beta        = ccLWE->GetBeta().ConvertToInt();
     auto pLWE        = modulus_LWE / (2 * beta);  // Large precision
-
-    uint32_t init_level     = 0;
-    const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersCKKSRNS>(cc->GetCryptoParameters());
-    if (cryptoParams->GetScalingTechnique() == FLEXIBLEAUTOEXT)
-        init_level = 1;
-    cc->EvalCompareSwitchPrecompute(pLWE, init_level, scaleSign);
+    cc->EvalCompareSwitchPrecompute(pLWE, scaleSign);
     timePrecomp = TOC(t);
     std::cout << "Time to do the precomputations: " << timePrecomp / 1000 << " s" << std::endl;
 
@@ -853,12 +838,7 @@ void Argmin(uint32_t depth, uint32_t slots, uint32_t numValues, uint32_t ringDim
     auto modulus_LWE = 1 << logQ_ccLWE;
     auto beta        = ccLWE->GetBeta().ConvertToInt();
     auto pLWE        = modulus_LWE / (2 * beta);  // Large precision
-
-    uint32_t init_level     = 0;
-    const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersCKKSRNS>(cc->GetCryptoParameters());
-    if (cryptoParams->GetScalingTechnique() == FLEXIBLEAUTOEXT)
-        init_level = 1;
-    cc->EvalCompareSwitchPrecompute(pLWE, init_level, scaleSign);
+    cc->EvalCompareSwitchPrecompute(pLWE, scaleSign);
     timePrecomp = TOC(t);
     std::cout << "Time to do the precomputations: " << timePrecomp / 1000 << " s" << std::endl;
 

--- a/src/pke/include/cryptocontext.h
+++ b/src/pke/include/cryptocontext.h
@@ -3401,15 +3401,13 @@ public:
    * to allow the user to specify a scale that depends on the CKKS and FHEW cryptocontexts
    *
    * @param pLWE the desired plaintext modulus for the new FHEW ciphertexts
-   * @param initLevel the level of the ciphertext that will be switched
    * @param scaleSign factor to multiply the CKKS ciphertext when switching to FHEW in case the messages are too small;
    * the resulting FHEW ciphertexts will encrypt values modulo pLWE, so scaleSign should account for this
    * @param unit whether the input messages are normalized to the unit circle
    */
-    void EvalCompareSwitchPrecompute(uint32_t pLWE = 0, uint32_t initLevel = 0, double scaleSign = 1.0,
-                                     bool unit = false) {
+    void EvalCompareSwitchPrecompute(uint32_t pLWE = 0, double scaleSign = 1.0, bool unit = false) {
         VerifyCKKSScheme(__func__);
-        GetScheme()->EvalCompareSwitchPrecompute(*this, pLWE, initLevel, scaleSign, unit);
+        GetScheme()->EvalCompareSwitchPrecompute(*this, pLWE, scaleSign, unit);
     }
 
     /**

--- a/src/pke/include/scheme/ckksrns/ckksrns-schemeswitching.h
+++ b/src/pke/include/scheme/ckksrns/ckksrns-schemeswitching.h
@@ -89,8 +89,8 @@ public:
     std::shared_ptr<std::map<usint, EvalKey<DCRTPoly>>> EvalSchemeSwitchingKeyGen(const KeyPair<DCRTPoly>& keyPair,
                                                                                   ConstLWEPrivateKey& lwesk) override;
 
-    void EvalCompareSwitchPrecompute(const CryptoContextImpl<DCRTPoly>& ccCKKS, uint32_t pLWE, uint32_t init_level,
-                                     double scaleSign, bool unit) override;
+    void EvalCompareSwitchPrecompute(const CryptoContextImpl<DCRTPoly>& ccCKKS, uint32_t pLWE, double scaleSign,
+                                     bool unit) override;
 
     Ciphertext<DCRTPoly> EvalCompareSchemeSwitching(ConstCiphertext<DCRTPoly> ciphertext1,
                                                     ConstCiphertext<DCRTPoly> ciphertext2, uint32_t numCtxts,

--- a/src/pke/include/schemebase/base-fhe.h
+++ b/src/pke/include/schemebase/base-fhe.h
@@ -216,13 +216,12 @@ public:
    *
    * @param cc the CKKS cryptocontext from which to switch
    * @param pLWE the desired plaintext modulus for the new FHEW ciphertexts
-   * @param initLevel the level of the ciphertext that will be switched
    * @param scaleSign factor to multiply the CKKS ciphertext when switching to FHEW in case the messages are too small;
    * the resulting FHEW ciphertexts will encrypt values modulo pLWE, so scaleSign should account for this
    * @param unit whether the input messages are normalized to the unit circle
    */
-    virtual void EvalCompareSwitchPrecompute(const CryptoContextImpl<Element>& ccCKKS, uint32_t pLWE,
-                                             uint32_t initLevel, double scaleSign, bool unit) {
+    virtual void EvalCompareSwitchPrecompute(const CryptoContextImpl<Element>& ccCKKS, uint32_t pLWE, double scaleSign,
+                                             bool unit) {
         OPENFHE_THROW(not_implemented_error, "EvalCompareSwitchPrecompute is not supported for this scheme");
     }
 

--- a/src/pke/include/schemebase/base-scheme.h
+++ b/src/pke/include/schemebase/base-scheme.h
@@ -1446,9 +1446,9 @@ public:
     }
 
     void EvalCompareSwitchPrecompute(const CryptoContextImpl<Element>& ccCKKS, uint32_t pLWE = 0,
-                                     uint32_t initLevel = 0, double scaleSign = 1.0, bool unit = false) {
+                                     double scaleSign = 1.0, bool unit = false) {
         VerifySchemeSwitchEnabled(__func__);
-        m_SchemeSwitch->EvalCompareSwitchPrecompute(ccCKKS, pLWE, initLevel, scaleSign, unit);
+        m_SchemeSwitch->EvalCompareSwitchPrecompute(ccCKKS, pLWE, scaleSign, unit);
         return;
     }
 

--- a/src/pke/lib/scheme/ckksrns/ckksrns-schemeswitching.cpp
+++ b/src/pke/lib/scheme/ckksrns/ckksrns-schemeswitching.cpp
@@ -487,21 +487,6 @@ NativeInteger RoundqQAlter(const NativeInteger& v, const NativeInteger& q, const
         .Mod(q);
 }
 
-NativeInteger RoundqQAlterDouble(const double& v, const NativeInteger& q, const double& Q) {
-    return NativeInteger((BasicInteger)std::floor(0.5 + v * q.ConvertToDouble() / Q)).Mod(q);
-}
-
-NativeInteger RoundqScale(const NativeInteger& v, const NativeInteger& q, const double& Q) {
-    return NativeInteger((BasicInteger)std::floor(0.5 + v.ConvertToDouble() / Q * q.ConvertToDouble())).Mod(q);
-}
-
-NativeInteger RoundqScaleAlter(const NativeInteger& v, const NativeInteger& q, const double& scFactor,
-                               const NativeInteger& p) {
-    return NativeInteger((BasicInteger)std::floor(0.5 + v.ConvertToDouble() / scFactor *
-                                                            (q.ConvertToDouble() / p.ConvertToDouble())))
-        .Mod(q);
-}
-
 EvalKey<DCRTPoly> switchingKeyGenRLWE(
     const PrivateKey<DCRTPoly>& ckksSK,
     ConstLWEPrivateKey& LWEsk) {  // This function is without the intermediate ModSwitch

--- a/src/pke/unittest/utckksrns/UnitTestSchemeSwitch.cpp
+++ b/src/pke/unittest/utckksrns/UnitTestSchemeSwitch.cpp
@@ -320,18 +320,9 @@ protected:
             auto ccLWE          = cc->GetBinCCForSchemeSwitch();
             cc->EvalCKKStoFHEWKeyGen(keyPair, privateKeyFHEW);
 
-            const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersCKKSRNS>(cc->GetCryptoParameters());
-            ILDCRTParams<Element::Integer> elementParams = *(cryptoParams->GetElementParams());
-            auto paramsQ                                 = elementParams.GetParams();
-            auto modulus_CKKS_from                       = paramsQ[0]->GetModulus();
-            auto modulus_LWE                             = 1 << testData.logQ;
-            auto pLWE                                    = modulus_LWE / (2 * ccLWE->GetBeta().ConvertToInt());
-
-            double scFactor = cryptoParams->GetScalingFactorReal(0);
-            if (cryptoParams->GetScalingTechnique() == FLEXIBLEAUTOEXT)
-                scFactor = cryptoParams->GetScalingFactorReal(1);
-            double scale = modulus_CKKS_from.ConvertToInt() / (scFactor * pLWE);
-
+            auto modulus_LWE = 1 << testData.logQ;
+            auto pLWE        = modulus_LWE / (2 * ccLWE->GetBeta().ConvertToInt());
+            double scale     = 1.0 / pLWE;
             cc->EvalCKKStoFHEWPrecompute(scale);
 
             std::vector<std::complex<double>> input(
@@ -476,16 +467,10 @@ protected:
 
             auto cDiff = cc->EvalSub(c1, c2);
 
-            auto modulus_LWE = 1 << testData.logQ;
-            auto pLWE        = modulus_LWE / (2 * ccLWE->GetBeta().ConvertToInt());
-
-            const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersCKKSRNS>(cc->GetCryptoParameters());
-            uint32_t init_level     = testData.params.multiplicativeDepth;
-            if (cryptoParams->GetScalingTechnique() == FLEXIBLEAUTOEXT)
-                init_level++;
+            auto modulus_LWE     = 1 << testData.logQ;
+            auto pLWE            = modulus_LWE / (2 * ccLWE->GetBeta().ConvertToInt());
             double scaleSignFHEW = 8.0;
-
-            cc->EvalCompareSwitchPrecompute(pLWE, init_level, scaleSignFHEW);
+            cc->EvalCompareSwitchPrecompute(pLWE, scaleSignFHEW);
 
             Plaintext pDiff;
             cc->Decrypt(keyPair.secretKey, cDiff, &pDiff);
@@ -549,13 +534,7 @@ protected:
 
             auto modulus_LWE = 1 << testData.logQ;
             auto pLWE        = modulus_LWE / (2 * ccLWE->GetBeta().ConvertToInt());
-
-            const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersCKKSRNS>(cc->GetCryptoParameters());
-
-            uint32_t init_level = testData.params.multiplicativeDepth;
-            if (cryptoParams->GetScalingTechnique() == FLEXIBLEAUTOEXT)
-                init_level++;
-            cc->EvalCompareSwitchPrecompute(pLWE, init_level, scaleSign);
+            cc->EvalCompareSwitchPrecompute(pLWE, scaleSign);
 
             std::vector<double> x1 = {-1.1, -1.05, 5.0, 6.0, -1.0, 2.0, 8.0, -1.0};
             auto xmin              = *std::min_element(x1.begin(), x1.begin() + testData.numValues);
@@ -658,13 +637,7 @@ protected:
 
             auto modulus_LWE = 1 << testData.logQ;
             auto pLWE        = modulus_LWE / (2 * ccLWE->GetBeta().ConvertToInt());
-
-            const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersCKKSRNS>(cc->GetCryptoParameters());
-
-            uint32_t init_level = testData.params.multiplicativeDepth;
-            if (cryptoParams->GetScalingTechnique() == FLEXIBLEAUTOEXT)
-                init_level++;
-            cc->EvalCompareSwitchPrecompute(pLWE, init_level, scaleSign);
+            cc->EvalCompareSwitchPrecompute(pLWE, scaleSign);
 
             std::vector<double> x1 = {-1.1, -1.05, 5.0, 6.0, -1.0, 2.0, 8.0, -1.0};
             auto xmin              = *std::min_element(x1.begin(), x1.begin() + testData.numValues);
@@ -803,14 +776,7 @@ protected:
             double scaleSign = 128.0;
             auto modulus_LWE = 1 << testData.logQ;
             auto pLWE        = modulus_LWE / (2 * ccLWE->GetBeta().ConvertToInt());
-
-            const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersCKKSRNS>(cc->GetCryptoParameters());
-
-            uint32_t init_level = testData.params.multiplicativeDepth;
-            if (cryptoParams->GetScalingTechnique() == FLEXIBLEAUTOEXT)
-                init_level++;
-
-            cc->EvalCompareSwitchPrecompute(pLWE, init_level, scaleSign);
+            cc->EvalCompareSwitchPrecompute(pLWE, scaleSign);
 
             auto result = cc->EvalMinSchemeSwitching(clientC, clientPublicKey, testData.numValues, testData.slots);
 

--- a/src/pke/unittest/utckksrns/UnitTestSchemeSwitch.cpp
+++ b/src/pke/unittest/utckksrns/UnitTestSchemeSwitch.cpp
@@ -480,9 +480,9 @@ protected:
             auto pLWE        = modulus_LWE / (2 * ccLWE->GetBeta().ConvertToInt());
 
             const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersCKKSRNS>(cc->GetCryptoParameters());
-            uint32_t init_level     = 0;
+            uint32_t init_level     = testData.params.multiplicativeDepth;
             if (cryptoParams->GetScalingTechnique() == FLEXIBLEAUTOEXT)
-                init_level = 1;
+                init_level++;
             double scaleSignFHEW = 8.0;
 
             cc->EvalCompareSwitchPrecompute(pLWE, init_level, scaleSignFHEW);
@@ -552,9 +552,9 @@ protected:
 
             const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersCKKSRNS>(cc->GetCryptoParameters());
 
-            uint32_t init_level = 0;
+            uint32_t init_level = testData.params.multiplicativeDepth;
             if (cryptoParams->GetScalingTechnique() == FLEXIBLEAUTOEXT)
-                init_level = 1;
+                init_level++;
             cc->EvalCompareSwitchPrecompute(pLWE, init_level, scaleSign);
 
             std::vector<double> x1 = {-1.1, -1.05, 5.0, 6.0, -1.0, 2.0, 8.0, -1.0};
@@ -661,9 +661,9 @@ protected:
 
             const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersCKKSRNS>(cc->GetCryptoParameters());
 
-            uint32_t init_level = 0;
+            uint32_t init_level = testData.params.multiplicativeDepth;
             if (cryptoParams->GetScalingTechnique() == FLEXIBLEAUTOEXT)
-                init_level = 1;
+                init_level++;
             cc->EvalCompareSwitchPrecompute(pLWE, init_level, scaleSign);
 
             std::vector<double> x1 = {-1.1, -1.05, 5.0, 6.0, -1.0, 2.0, 8.0, -1.0};
@@ -806,9 +806,10 @@ protected:
 
             const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersCKKSRNS>(cc->GetCryptoParameters());
 
-            uint32_t init_level = 0;
+            uint32_t init_level = testData.params.multiplicativeDepth;
             if (cryptoParams->GetScalingTechnique() == FLEXIBLEAUTOEXT)
-                init_level = 1;
+                init_level++;
+
             cc->EvalCompareSwitchPrecompute(pLWE, init_level, scaleSign);
 
             auto result = cc->EvalMinSchemeSwitching(clientC, clientPublicKey, testData.numValues, testData.slots);


### PR DESCRIPTION
- Corrected the scaling factors for the FLEXIBLE modes
- Moved the initial scaling by the final scaling factor from the user's side to internal functions. This changes the examples and removes one argument from EvalCompareSwitchPrecompute.
- Clean-up

Closes #629