### PR TITLE
Return m_errorMessage instead of m_errorDescription from what() in OpenFHEException

### DIFF
--- a/src/core/include/utils/exception.h
+++ b/src/core/include/utils/exception.h
@@ -182,7 +182,7 @@ public:
     OpenFHEException(const OpenFHEException& ex) = default;
 
     const char* what() const noexcept {
-        return m_errorDescription.c_str();
+        return m_errorMessage.c_str();
     }
 
     std::vector<std::string> getCallStackAsVector() {


### PR DESCRIPTION
Shows more information when an exception is throw, including the file and line where it is thrown.