### PR TITLE
Moved check on optional argument before it is used in EvalCKKStoFHEW

### DIFF
--- a/src/pke/examples/scheme-switching.cpp
+++ b/src/pke/examples/scheme-switching.cpp
@@ -53,14 +53,14 @@ std::vector<int32_t> RotateInt(const std::vector<int32_t>&, int32_t);
 int main() {
     SwitchCKKSToFHEW();
     SwitchFHEWtoCKKS();
-    // FloorViaSchemeSwitching();
-    // FuncViaSchemeSwitching();
-    // PolyViaSchemeSwitching();
+    FloorViaSchemeSwitching();
+    FuncViaSchemeSwitching();
+    PolyViaSchemeSwitching();
     ComparisonViaSchemeSwitching();
     ArgminViaSchemeSwitching();
     ArgminViaSchemeSwitchingAlt();
-    // ArgminViaSchemeSwitchingUnit();
-    // ArgminViaSchemeSwitchingAltUnit();
+    ArgminViaSchemeSwitchingUnit();
+    ArgminViaSchemeSwitchingAltUnit();
 
     return 0;
 }

--- a/src/pke/lib/scheme/ckksrns/ckksrns-schemeswitching.cpp
+++ b/src/pke/lib/scheme/ckksrns/ckksrns-schemeswitching.cpp
@@ -1382,6 +1382,10 @@ std::vector<std::shared_ptr<LWECiphertextImpl>> SWITCHCKKSRNS::EvalCKKStoFHEW(Co
     auto ccCKKS    = ciphertext->GetCryptoContext();
     uint32_t slots = m_numSlotsCKKS;
 
+    if (numCtxts == 0 || numCtxts > slots) {
+        numCtxts = slots;
+    }
+
     // Step 1. Homomorphic decoding
     auto ctxtDecoded = EvalSlotsToCoeffsSwitch(*ccCKKS, ciphertext);
     ccCKKS->GetScheme()->ModReduceInternalInPlace(ctxtDecoded, 1);
@@ -1400,10 +1404,6 @@ std::vector<std::shared_ptr<LWECiphertextImpl>> SWITCHCKKSRNS::EvalCKKStoFHEW(Co
     uint32_t n = m_ccLWE->GetParams()->GetLWEParams()->Getn();  // lattice parameter for additive LWE
     std::vector<std::shared_ptr<LWECiphertextImpl>> LWEciphertexts(numCtxts);
     auto AandB = ExtractLWEpacked(ctSwitched);
-
-    if (numCtxts == 0 || numCtxts > slots) {
-        numCtxts = slots;
-    }
 
     uint32_t gap = ccKS->GetRingDimension() / (2 * slots);
 


### PR DESCRIPTION
In https://github.com/openfheorg/openfhe-development/pull/665 numCtxts was used before its value (default= 0) was checked. This was causing a segfault in some scheme-switching examples which didn't specify numCtxts.

Closes #711.