### PR TITLE
Added support for modulus switching to BFV

### DIFF
--- a/src/pke/examples/simple-integers.cpp
+++ b/src/pke/examples/simple-integers.cpp
@@ -99,8 +99,9 @@ int main() {
     auto ciphertextptAddResult = cryptoContext->EvalAdd(ciphertextptAdd12, plaintext2);
 
     // Homomorphic multiplications
-    auto ciphertextMul12      = cryptoContext->EvalMult(ciphertext1, ciphertext2);
-    auto ciphertextMultResult = cryptoContext->EvalMult(ciphertextMul12, ciphertext3);
+    auto ciphertextMul12        = cryptoContext->EvalMult(ciphertext1, ciphertext2);
+    auto ciphertextMultResult   = cryptoContext->EvalMult(ciphertextMul12, ciphertext3);
+    auto ciphertextSquareResult = cryptoContext->EvalSquare(ciphertext1);
 
     // Homomorphic rotations
     auto ciphertextRot1 = cryptoContext->EvalRotate(ciphertext1, 1);
@@ -132,7 +133,12 @@ int main() {
     Plaintext plaintextMultResult;
     cryptoContext->Decrypt(keyPair.secretKey, ciphertextMultResult, &plaintextMultResult);
     std::cout << "#1*#2*#3: " << plaintextMultResult << std::endl;
-    //
+
+    // Decrypt the result of squaring
+    Plaintext plaintextSquareResult;
+    cryptoContext->Decrypt(keyPair.secretKey, ciphertextSquareResult, &plaintextSquareResult);
+    std::cout << "#1*#1: " << plaintextSquareResult << std::endl;
+
     // Decrypt the result of rotations
     Plaintext plaintextRot1;
     cryptoContext->Decrypt(keyPair.secretKey, ciphertextRot1, &plaintextRot1);

--- a/src/pke/examples/simple-integers.cpp
+++ b/src/pke/examples/simple-integers.cpp
@@ -44,6 +44,7 @@ int main() {
     parameters.SetMultiplicativeDepth(8);
     parameters.SetKeySwitchTechnique(HYBRID);
     parameters.SetMultiplicationTechnique(HPSPOVERQ);
+    parameters.SetEncryptionTechnique(STANDARD);
     parameters.SetSecurityLevel(HEStd_NotSet);
     parameters.SetRingDim(64);
 

--- a/src/pke/examples/simple-integers.cpp
+++ b/src/pke/examples/simple-integers.cpp
@@ -107,7 +107,11 @@ int main() {
     auto ciphertextRot1 = cryptoContext->EvalRotate(ciphertext1, 1);
     auto ciphertextRot2 = cryptoContext->EvalRotate(ciphertext1, 2);
     auto ciphertextRot3 = cryptoContext->EvalRotate(ciphertext1, -1);
-    auto ciphertextRot4 = cryptoContext->EvalRotate(ciphertext1, -2);
+    // auto ciphertextRot4 = cryptoContext->EvalRotate(ciphertext1, -2);
+
+    auto digits         = cryptoContext->EvalFastRotationPrecompute(ciphertext1);
+    const uint32_t M    = cryptoContext->GetCyclotomicOrder();
+    auto ciphertextRot4 = cryptoContext->EvalFastRotation(ciphertext1, -2, M, digits);
 
     std::cout << "Plaintext #1: " << plaintext1 << std::endl;
     std::cout << "Plaintext #2: " << plaintext2 << std::endl;

--- a/src/pke/examples/simple-integers.cpp
+++ b/src/pke/examples/simple-integers.cpp
@@ -69,13 +69,13 @@ int main() {
 
     // First plaintext vector is encoded
     std::vector<int64_t> vectorOfInts1 = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
-    Plaintext plaintext1               = cryptoContext->MakePackedPlaintext(vectorOfInts1, 1, 2);
+    Plaintext plaintext1               = cryptoContext->MakePackedPlaintext(vectorOfInts1, 1, 1);
     // Second plaintext vector is encoded
     std::vector<int64_t> vectorOfInts2 = {3, 2, 1, 4, 5, 6, 7, 8, 9, 10, 11, 12};
-    Plaintext plaintext2               = cryptoContext->MakePackedPlaintext(vectorOfInts2, 1, 2);
+    Plaintext plaintext2               = cryptoContext->MakePackedPlaintext(vectorOfInts2, 1, 1);
     // Third plaintext vector is encoded
     std::vector<int64_t> vectorOfInts3 = {1, 2, 5, 2, 5, 6, 7, 8, 9, 10, 11, 12};
-    Plaintext plaintext3               = cryptoContext->MakePackedPlaintext(vectorOfInts3, 1, 2);
+    Plaintext plaintext3               = cryptoContext->MakePackedPlaintext(vectorOfInts3, 1, 1);
 
     std::cerr << "crypto params = " << *cryptoContext->GetCryptoParameters() << std::endl;
     std::cerr << "params = " << *plaintext3->GetElement<DCRTPoly>().GetParams() << std::endl;
@@ -84,7 +84,7 @@ int main() {
     auto ciphertext1 = cryptoContext->Encrypt(keyPair.publicKey, plaintext1);
 
     auto ciphertext2 = cryptoContext->Encrypt(keyPair.publicKey, plaintext2);
-    //auto ciphertext3 = cryptoContext->Encrypt(keyPair.publicKey, plaintext3);
+    // auto ciphertext3 = cryptoContext->Encrypt(keyPair.publicKey, plaintext3);
     auto ciphertext3 = cryptoContext->Encrypt(keyPair.secretKey, plaintext3);
 
     // Sample Program: Step 4: Evaluation
@@ -113,7 +113,7 @@ int main() {
     // Sample Program: Step 5: Decryption
 
     // Decrypt the result of additions
-    ciphertextAddResult = cryptoContext->Compress(ciphertextAddResult);
+    ciphertextAddResult = cryptoContext->Compress(ciphertextAddResult, 2);
     Plaintext plaintextAddResult;
     cryptoContext->Decrypt(keyPair.secretKey, ciphertextAddResult, &plaintextAddResult);
 
@@ -121,7 +121,7 @@ int main() {
     std::cout << "#1 + #2 + #3: " << plaintextAddResult << std::endl;
 
     // Decrypt the result of additions
-    ciphertextptAddResult = cryptoContext->Compress(ciphertextptAddResult);
+    ciphertextptAddResult = cryptoContext->Compress(ciphertextptAddResult, 2);
     Plaintext plaintextptAddResult;
     cryptoContext->Decrypt(keyPair.secretKey, ciphertextptAddResult, &plaintextptAddResult);
     std::cout << "(plaintext)#1 + #2 + #2: " << plaintextptAddResult << std::endl;
@@ -130,26 +130,26 @@ int main() {
     //    Plaintext plaintextMultResult;
     //    cryptoContext->Decrypt(keyPair.secretKey, ciphertextMultResult, &plaintextMultResult);
     //
-	// Decrypt the result of rotations
-	Plaintext plaintextRot1;
-	cryptoContext->Decrypt(keyPair.secretKey, ciphertextRot1, &plaintextRot1);
-	Plaintext plaintextRot2;
-	cryptoContext->Decrypt(keyPair.secretKey, ciphertextRot2, &plaintextRot2);
-	Plaintext plaintextRot3;
-	cryptoContext->Decrypt(keyPair.secretKey, ciphertextRot3, &plaintextRot3);
-	Plaintext plaintextRot4;
-	cryptoContext->Decrypt(keyPair.secretKey, ciphertextRot4, &plaintextRot4);
+    // Decrypt the result of rotations
+    Plaintext plaintextRot1;
+    cryptoContext->Decrypt(keyPair.secretKey, ciphertextRot1, &plaintextRot1);
+    Plaintext plaintextRot2;
+    cryptoContext->Decrypt(keyPair.secretKey, ciphertextRot2, &plaintextRot2);
+    Plaintext plaintextRot3;
+    cryptoContext->Decrypt(keyPair.secretKey, ciphertextRot3, &plaintextRot3);
+    Plaintext plaintextRot4;
+    cryptoContext->Decrypt(keyPair.secretKey, ciphertextRot4, &plaintextRot4);
     //
-	plaintextRot1->SetLength(vectorOfInts1.size());
-	plaintextRot2->SetLength(vectorOfInts1.size());
-	plaintextRot3->SetLength(vectorOfInts1.size());
-	plaintextRot4->SetLength(vectorOfInts1.size());
+    plaintextRot1->SetLength(vectorOfInts1.size());
+    plaintextRot2->SetLength(vectorOfInts1.size());
+    plaintextRot3->SetLength(vectorOfInts1.size());
+    plaintextRot4->SetLength(vectorOfInts1.size());
 
     //    std::cout << "#1 * #2 * #3: " << plaintextMultResult << std::endl;
-	std::cout << "Left rotation of #1 by 1: " << plaintextRot1 << std::endl;
-	std::cout << "Left rotation of #1 by 2: " << plaintextRot2 << std::endl;
-	std::cout << "Right rotation of #1 by 1: " << plaintextRot3 << std::endl;
-	std::cout << "Right rotation of #1 by 2: " << plaintextRot4 << std::endl;
+    std::cout << "Left rotation of #1 by 1: " << plaintextRot1 << std::endl;
+    std::cout << "Left rotation of #1 by 2: " << plaintextRot2 << std::endl;
+    std::cout << "Right rotation of #1 by 1: " << plaintextRot3 << std::endl;
+    std::cout << "Right rotation of #1 by 2: " << plaintextRot4 << std::endl;
 
     return 0;
 }

--- a/src/pke/examples/simple-integers.cpp
+++ b/src/pke/examples/simple-integers.cpp
@@ -41,9 +41,11 @@ int main() {
     // Sample Program: Step 1: Set CryptoContext
     CCParams<CryptoContextBFVRNS> parameters;
     parameters.SetPlaintextModulus(65537);
-    parameters.SetMultiplicativeDepth(5);
+    parameters.SetMultiplicativeDepth(8);
     parameters.SetKeySwitchTechnique(HYBRID);
     parameters.SetMultiplicationTechnique(HPSPOVERQ);
+    parameters.SetSecurityLevel(HEStd_NotSet);
+    parameters.SetRingDim(64);
 
     CryptoContext<DCRTPoly> cryptoContext = GenCryptoContext(parameters);
     // Enable features that you wish to use
@@ -97,8 +99,8 @@ int main() {
     auto ciphertextptAddResult = cryptoContext->EvalAdd(ciphertextptAdd12, plaintext2);
 
     // Homomorphic multiplications
-    //    auto ciphertextMul12      = cryptoContext->EvalMult(ciphertext1, ciphertext2);
-    //    auto ciphertextMultResult = cryptoContext->EvalMult(ciphertextMul12, ciphertext3);
+    auto ciphertextMul12      = cryptoContext->EvalMult(ciphertext1, ciphertext2);
+    auto ciphertextMultResult = cryptoContext->EvalMult(ciphertextMul12, ciphertext3);
 
     // Homomorphic rotations
     auto ciphertextRot1 = cryptoContext->EvalRotate(ciphertext1, 1);
@@ -126,9 +128,10 @@ int main() {
     cryptoContext->Decrypt(keyPair.secretKey, ciphertextptAddResult, &plaintextptAddResult);
     std::cout << "(plaintext)#1 + #2 + #2: " << plaintextptAddResult << std::endl;
 
-    //    // Decrypt the result of multiplications
-    //    Plaintext plaintextMultResult;
-    //    cryptoContext->Decrypt(keyPair.secretKey, ciphertextMultResult, &plaintextMultResult);
+    // Decrypt the result of multiplications
+    Plaintext plaintextMultResult;
+    cryptoContext->Decrypt(keyPair.secretKey, ciphertextMultResult, &plaintextMultResult);
+    std::cout << "#1*#2*#3: " << plaintextMultResult << std::endl;
     //
     // Decrypt the result of rotations
     Plaintext plaintextRot1;

--- a/src/pke/examples/simple-integers.cpp
+++ b/src/pke/examples/simple-integers.cpp
@@ -41,7 +41,7 @@ int main() {
     // Sample Program: Step 1: Set CryptoContext
     CCParams<CryptoContextBFVRNS> parameters;
     parameters.SetPlaintextModulus(65537);
-    parameters.SetMultiplicativeDepth(2);
+    parameters.SetMultiplicativeDepth(4);
 
     CryptoContext<DCRTPoly> cryptoContext = GenCryptoContext(parameters);
     // Enable features that you wish to use
@@ -67,34 +67,50 @@ int main() {
 
     // First plaintext vector is encoded
     std::vector<int64_t> vectorOfInts1 = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
-    Plaintext plaintext1               = cryptoContext->MakePackedPlaintext(vectorOfInts1);
+    Plaintext plaintext1               = cryptoContext->MakePackedPlaintext(vectorOfInts1, 1, 1);
     // Second plaintext vector is encoded
     std::vector<int64_t> vectorOfInts2 = {3, 2, 1, 4, 5, 6, 7, 8, 9, 10, 11, 12};
-    Plaintext plaintext2               = cryptoContext->MakePackedPlaintext(vectorOfInts2);
+    Plaintext plaintext2               = cryptoContext->MakePackedPlaintext(vectorOfInts2, 1, 1);
     // Third plaintext vector is encoded
     std::vector<int64_t> vectorOfInts3 = {1, 2, 5, 2, 5, 6, 7, 8, 9, 10, 11, 12};
-    Plaintext plaintext3               = cryptoContext->MakePackedPlaintext(vectorOfInts3);
+    Plaintext plaintext3               = cryptoContext->MakePackedPlaintext(vectorOfInts3, 1, 1);
+
+    std::cerr << "crypto params = " << *cryptoContext->GetCryptoParameters() << std::endl;
+    std::cerr << "params = " << *plaintext3->GetElement<DCRTPoly>().GetParams() << std::endl;
+
+    std::cerr << "step 0.1" << std::endl;
 
     // The encoded vectors are encrypted
     auto ciphertext1 = cryptoContext->Encrypt(keyPair.publicKey, plaintext1);
+
+    std::cerr << "step 0.2" << std::endl;
+
     auto ciphertext2 = cryptoContext->Encrypt(keyPair.publicKey, plaintext2);
     auto ciphertext3 = cryptoContext->Encrypt(keyPair.publicKey, plaintext3);
 
     // Sample Program: Step 4: Evaluation
 
+    std::cerr << "step 1" << std::endl;
+
     // Homomorphic additions
     auto ciphertextAdd12     = cryptoContext->EvalAdd(ciphertext1, ciphertext2);
     auto ciphertextAddResult = cryptoContext->EvalAdd(ciphertextAdd12, ciphertext3);
 
+    std::cerr << "step 2" << std::endl;
+
     // Homomorphic multiplications
     auto ciphertextMul12      = cryptoContext->EvalMult(ciphertext1, ciphertext2);
     auto ciphertextMultResult = cryptoContext->EvalMult(ciphertextMul12, ciphertext3);
+
+    std::cerr << "step 3" << std::endl;
 
     // Homomorphic rotations
     auto ciphertextRot1 = cryptoContext->EvalRotate(ciphertext1, 1);
     auto ciphertextRot2 = cryptoContext->EvalRotate(ciphertext1, 2);
     auto ciphertextRot3 = cryptoContext->EvalRotate(ciphertext1, -1);
     auto ciphertextRot4 = cryptoContext->EvalRotate(ciphertext1, -2);
+
+    std::cerr << "step 4" << std::endl;
 
     // Sample Program: Step 5: Decryption
 

--- a/src/pke/examples/simple-integers.cpp
+++ b/src/pke/examples/simple-integers.cpp
@@ -69,13 +69,13 @@ int main() {
 
     // First plaintext vector is encoded
     std::vector<int64_t> vectorOfInts1 = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
-    Plaintext plaintext1               = cryptoContext->MakePackedPlaintext(vectorOfInts1, 1, 3);
+    Plaintext plaintext1               = cryptoContext->MakePackedPlaintext(vectorOfInts1, 1, 2);
     // Second plaintext vector is encoded
     std::vector<int64_t> vectorOfInts2 = {3, 2, 1, 4, 5, 6, 7, 8, 9, 10, 11, 12};
-    Plaintext plaintext2               = cryptoContext->MakePackedPlaintext(vectorOfInts2, 1, 3);
+    Plaintext plaintext2               = cryptoContext->MakePackedPlaintext(vectorOfInts2, 1, 2);
     // Third plaintext vector is encoded
     std::vector<int64_t> vectorOfInts3 = {1, 2, 5, 2, 5, 6, 7, 8, 9, 10, 11, 12};
-    Plaintext plaintext3               = cryptoContext->MakePackedPlaintext(vectorOfInts3, 1, 3);
+    Plaintext plaintext3               = cryptoContext->MakePackedPlaintext(vectorOfInts3, 1, 2);
 
     std::cerr << "crypto params = " << *cryptoContext->GetCryptoParameters() << std::endl;
     std::cerr << "params = " << *plaintext3->GetElement<DCRTPoly>().GetParams() << std::endl;
@@ -93,6 +93,9 @@ int main() {
     auto ciphertextAdd12     = cryptoContext->EvalAdd(ciphertext1, ciphertext2);
     auto ciphertextAddResult = cryptoContext->EvalAdd(ciphertextAdd12, ciphertext3);
 
+    auto ciphertextptAdd12     = cryptoContext->EvalAdd(ciphertext1, plaintext2);
+    auto ciphertextptAddResult = cryptoContext->EvalAdd(ciphertextptAdd12, plaintext2);
+
     // Homomorphic multiplications
     //    auto ciphertextMul12      = cryptoContext->EvalMult(ciphertext1, ciphertext2);
     //    auto ciphertextMultResult = cryptoContext->EvalMult(ciphertextMul12, ciphertext3);
@@ -103,12 +106,25 @@ int main() {
     auto ciphertextRot3 = cryptoContext->EvalRotate(ciphertext1, -1);
     auto ciphertextRot4 = cryptoContext->EvalRotate(ciphertext1, -2);
 
+    std::cout << "Plaintext #1: " << plaintext1 << std::endl;
+    std::cout << "Plaintext #2: " << plaintext2 << std::endl;
+    std::cout << "Plaintext #3: " << plaintext3 << std::endl;
+
     // Sample Program: Step 5: Decryption
 
     // Decrypt the result of additions
     ciphertextAddResult = cryptoContext->Compress(ciphertextAddResult);
     Plaintext plaintextAddResult;
     cryptoContext->Decrypt(keyPair.secretKey, ciphertextAddResult, &plaintextAddResult);
+
+    std::cout << "\nResults of homomorphic computations" << std::endl;
+    std::cout << "#1 + #2 + #3: " << plaintextAddResult << std::endl;
+
+    // Decrypt the result of additions
+    ciphertextptAddResult = cryptoContext->Compress(ciphertextptAddResult);
+    Plaintext plaintextptAddResult;
+    cryptoContext->Decrypt(keyPair.secretKey, ciphertextptAddResult, &plaintextptAddResult);
+    std::cout << "(plaintext)#1 + #2 + #2: " << plaintextptAddResult << std::endl;
 
     //    // Decrypt the result of multiplications
     //    Plaintext plaintextMultResult;
@@ -129,13 +145,6 @@ int main() {
 	plaintextRot3->SetLength(vectorOfInts1.size());
 	plaintextRot4->SetLength(vectorOfInts1.size());
 
-    std::cout << "Plaintext #1: " << plaintext1 << std::endl;
-    std::cout << "Plaintext #2: " << plaintext2 << std::endl;
-    std::cout << "Plaintext #3: " << plaintext3 << std::endl;
-
-    // Output results
-    std::cout << "\nResults of homomorphic computations" << std::endl;
-    std::cout << "#1 + #2 + #3: " << plaintextAddResult << std::endl;
     //    std::cout << "#1 * #2 * #3: " << plaintextMultResult << std::endl;
 	std::cout << "Left rotation of #1 by 1: " << plaintextRot1 << std::endl;
 	std::cout << "Left rotation of #1 by 2: " << plaintextRot2 << std::endl;

--- a/src/pke/examples/simple-integers.cpp
+++ b/src/pke/examples/simple-integers.cpp
@@ -99,16 +99,16 @@ int main() {
     std::cerr << "step 2" << std::endl;
 
     // Homomorphic multiplications
-    auto ciphertextMul12      = cryptoContext->EvalMult(ciphertext1, ciphertext2);
-    auto ciphertextMultResult = cryptoContext->EvalMult(ciphertextMul12, ciphertext3);
+    //    auto ciphertextMul12      = cryptoContext->EvalMult(ciphertext1, ciphertext2);
+    //    auto ciphertextMultResult = cryptoContext->EvalMult(ciphertextMul12, ciphertext3);
 
     std::cerr << "step 3" << std::endl;
 
     // Homomorphic rotations
-    auto ciphertextRot1 = cryptoContext->EvalRotate(ciphertext1, 1);
-    auto ciphertextRot2 = cryptoContext->EvalRotate(ciphertext1, 2);
-    auto ciphertextRot3 = cryptoContext->EvalRotate(ciphertext1, -1);
-    auto ciphertextRot4 = cryptoContext->EvalRotate(ciphertext1, -2);
+    //    auto ciphertextRot1 = cryptoContext->EvalRotate(ciphertext1, 1);
+    //    auto ciphertextRot2 = cryptoContext->EvalRotate(ciphertext1, 2);
+    //    auto ciphertextRot3 = cryptoContext->EvalRotate(ciphertext1, -1);
+    //    auto ciphertextRot4 = cryptoContext->EvalRotate(ciphertext1, -2);
 
     std::cerr << "step 4" << std::endl;
 
@@ -118,24 +118,24 @@ int main() {
     Plaintext plaintextAddResult;
     cryptoContext->Decrypt(keyPair.secretKey, ciphertextAddResult, &plaintextAddResult);
 
-    // Decrypt the result of multiplications
-    Plaintext plaintextMultResult;
-    cryptoContext->Decrypt(keyPair.secretKey, ciphertextMultResult, &plaintextMultResult);
-
-    // Decrypt the result of rotations
-    Plaintext plaintextRot1;
-    cryptoContext->Decrypt(keyPair.secretKey, ciphertextRot1, &plaintextRot1);
-    Plaintext plaintextRot2;
-    cryptoContext->Decrypt(keyPair.secretKey, ciphertextRot2, &plaintextRot2);
-    Plaintext plaintextRot3;
-    cryptoContext->Decrypt(keyPair.secretKey, ciphertextRot3, &plaintextRot3);
-    Plaintext plaintextRot4;
-    cryptoContext->Decrypt(keyPair.secretKey, ciphertextRot4, &plaintextRot4);
-
-    plaintextRot1->SetLength(vectorOfInts1.size());
-    plaintextRot2->SetLength(vectorOfInts1.size());
-    plaintextRot3->SetLength(vectorOfInts1.size());
-    plaintextRot4->SetLength(vectorOfInts1.size());
+    //    // Decrypt the result of multiplications
+    //    Plaintext plaintextMultResult;
+    //    cryptoContext->Decrypt(keyPair.secretKey, ciphertextMultResult, &plaintextMultResult);
+    //
+    //    // Decrypt the result of rotations
+    //    Plaintext plaintextRot1;
+    //    cryptoContext->Decrypt(keyPair.secretKey, ciphertextRot1, &plaintextRot1);
+    //    Plaintext plaintextRot2;
+    //    cryptoContext->Decrypt(keyPair.secretKey, ciphertextRot2, &plaintextRot2);
+    //    Plaintext plaintextRot3;
+    //    cryptoContext->Decrypt(keyPair.secretKey, ciphertextRot3, &plaintextRot3);
+    //    Plaintext plaintextRot4;
+    //    cryptoContext->Decrypt(keyPair.secretKey, ciphertextRot4, &plaintextRot4);
+    //
+    //    plaintextRot1->SetLength(vectorOfInts1.size());
+    //    plaintextRot2->SetLength(vectorOfInts1.size());
+    //    plaintextRot3->SetLength(vectorOfInts1.size());
+    //    plaintextRot4->SetLength(vectorOfInts1.size());
 
     std::cout << "Plaintext #1: " << plaintext1 << std::endl;
     std::cout << "Plaintext #2: " << plaintext2 << std::endl;
@@ -144,11 +144,11 @@ int main() {
     // Output results
     std::cout << "\nResults of homomorphic computations" << std::endl;
     std::cout << "#1 + #2 + #3: " << plaintextAddResult << std::endl;
-    std::cout << "#1 * #2 * #3: " << plaintextMultResult << std::endl;
-    std::cout << "Left rotation of #1 by 1: " << plaintextRot1 << std::endl;
-    std::cout << "Left rotation of #1 by 2: " << plaintextRot2 << std::endl;
-    std::cout << "Right rotation of #1 by 1: " << plaintextRot3 << std::endl;
-    std::cout << "Right rotation of #1 by 2: " << plaintextRot4 << std::endl;
+    //    std::cout << "#1 * #2 * #3: " << plaintextMultResult << std::endl;
+    //    std::cout << "Left rotation of #1 by 1: " << plaintextRot1 << std::endl;
+    //    std::cout << "Left rotation of #1 by 2: " << plaintextRot2 << std::endl;
+    //    std::cout << "Right rotation of #1 by 1: " << plaintextRot3 << std::endl;
+    //    std::cout << "Right rotation of #1 by 2: " << plaintextRot4 << std::endl;
 
     return 0;
 }

--- a/src/pke/include/cryptocontext.h
+++ b/src/pke/include/cryptocontext.h
@@ -213,33 +213,45 @@ class CryptoContextImpl : public Serializable {
         const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersRNS>(GetCryptoParameters());
 
         if (level > 0) {
-			size_t numModuli = cryptoParams->GetElementParams()->GetParams().size();
-        	if (getSchemeId() != SCHEME::BFVRNS_SCHEME) {
-				// validation of level: We need to compare it to multiplicativeDepth, but multiplicativeDepth is not
-				// readily available. so, what we get is numModuli and use it for calculations
-				uint32_t multiplicativeDepth =
-					(cryptoParams->GetScalingTechnique() == FLEXIBLEAUTOEXT) ? (numModuli - 2) : (numModuli - 1);
-				// we throw an exception if level >= numModuli. however, we use multiplicativeDepth in the error message,
-				// so the user can understand the error more easily.
-				if (level >= numModuli) {
-					std::string errorMsg;
-					if (cryptoParams->GetScalingTechnique() == FLEXIBLEAUTOEXT)
-						errorMsg = "The level value should be less than or equal to (multiplicativeDepth + 1).";
-					else
-						errorMsg = "The level value should be less than or equal to multiplicativeDepth.";
+            size_t numModuli = cryptoParams->GetElementParams()->GetParams().size();
+            if (getSchemeId() != SCHEME::BFVRNS_SCHEME) {
+                // validation of level: We need to compare it to multiplicativeDepth, but multiplicativeDepth is not
+                // readily available. so, what we get is numModuli and use it for calculations
+                uint32_t multiplicativeDepth =
+                    (cryptoParams->GetScalingTechnique() == FLEXIBLEAUTOEXT) ? (numModuli - 2) : (numModuli - 1);
+                // we throw an exception if level >= numModuli. however, we use multiplicativeDepth in the error message,
+                // so the user can understand the error more easily.
+                if (level >= numModuli) {
+                    std::string errorMsg;
+                    if (cryptoParams->GetScalingTechnique() == FLEXIBLEAUTOEXT)
+                        errorMsg = "The level value should be less than or equal to (multiplicativeDepth + 1).";
+                    else
+                        errorMsg = "The level value should be less than or equal to multiplicativeDepth.";
 
-					errorMsg += " Currently: level is [" + std::to_string(level) + "] and multiplicativeDepth is [" +
-								std::to_string(multiplicativeDepth) + "]";
-					OPENFHE_THROW(errorMsg);
-				}
-        	} else {
-				if (level >= numModuli) {
-					std::string errorMsg = "The level value should be less the current number of RNS limbs in the cryptocontext.";
-					errorMsg += " Currently: level is [" + std::to_string(level) + "] and number of RNS limbs is [" +
-								std::to_string(numModuli) + "]";
-					OPENFHE_THROW(errorMsg);
-				}
-        	}
+                    errorMsg += " Currently: level is [" + std::to_string(level) + "] and multiplicativeDepth is [" +
+                                std::to_string(multiplicativeDepth) + "]";
+                    OPENFHE_THROW(errorMsg);
+                }
+            }
+            else {
+                if ((cryptoParams->GetMultiplicationTechnique() == BEHZ) ||
+                    (cryptoParams->GetMultiplicationTechnique() == HPS)) {
+                    OPENFHE_THROW(
+                        "BFV: Encoding at level > 0 is not currently supported for BEHZ or HPS. Use one of the HPSPOVERQ* methods instead.");
+                }
+
+                if ((cryptoParams->GetEncryptionTechnique() == EXTENDED)) {
+                    OPENFHE_THROW(
+                        "BFV: Encoding at level > 0 is not currently supported for the EXTENDED encryption method. Use the STANDARD encryption method instead.");
+                }
+                if (level >= numModuli) {
+                    std::string errorMsg =
+                        "The level value should be less the current number of RNS limbs in the cryptocontext.";
+                    errorMsg += " Currently: level is [" + std::to_string(level) + "] and number of RNS limbs is [" +
+                                std::to_string(numModuli) + "]";
+                    OPENFHE_THROW(errorMsg);
+                }
+            }
         }
 
         // uses a parameter set with a reduced number of RNS limbs corresponding to the level

--- a/src/pke/include/cryptocontext.h
+++ b/src/pke/include/cryptocontext.h
@@ -214,14 +214,12 @@ class CryptoContextImpl : public Serializable {
 
         if (level > 0) {
             size_t numModuli = cryptoParams->GetElementParams()->GetParams().size();
-            if (getSchemeId() != SCHEME::BFVRNS_SCHEME) {
-                // validation of level: We need to compare it to multiplicativeDepth, but multiplicativeDepth is not
-                // readily available. so, what we get is numModuli and use it for calculations
-                uint32_t multiplicativeDepth =
-                    (cryptoParams->GetScalingTechnique() == FLEXIBLEAUTOEXT) ? (numModuli - 2) : (numModuli - 1);
-                // we throw an exception if level >= numModuli. however, we use multiplicativeDepth in the error message,
+            if (!isBFVRNS(m_schemeId)) {
+                // we throw an exception if level >= numModuli. However, we use multiplicativeDepth in the error message,
                 // so the user can understand the error more easily.
                 if (level >= numModuli) {
+                    uint32_t multiplicativeDepth =
+                        (cryptoParams->GetScalingTechnique() == FLEXIBLEAUTOEXT) ? (numModuli - 2) : (numModuli - 1);
                     std::string errorMsg;
                     if (cryptoParams->GetScalingTechnique() == FLEXIBLEAUTOEXT)
                         errorMsg = "The level value should be less than or equal to (multiplicativeDepth + 1).";
@@ -268,8 +266,8 @@ class CryptoContextImpl : public Serializable {
         }
 
         Plaintext p;
-        if (getSchemeId() == SCHEME::BGVRNS_SCHEME && (cryptoParams->GetScalingTechnique() == FLEXIBLEAUTO ||
-                                                       cryptoParams->GetScalingTechnique() == FLEXIBLEAUTOEXT)) {
+        if (isBGVRNS(m_schemeId) && (cryptoParams->GetScalingTechnique() == FLEXIBLEAUTO ||
+                                     cryptoParams->GetScalingTechnique() == FLEXIBLEAUTOEXT)) {
             NativeInteger scf;
             if (cryptoParams->GetScalingTechnique() == FLEXIBLEAUTOEXT && level == 0) {
                 scf = cryptoParams->GetScalingFactorIntBig(level);

--- a/src/pke/include/schemerns/rns-cryptoparameters.h
+++ b/src/pke/include/schemerns/rns-cryptoparameters.h
@@ -731,6 +731,14 @@ public:
         return m_negRlQHatInvModqPrecon[l];
     }
 
+    const std::vector<NativeInteger>& GetmNegRlQlHatInvModq(usint l = 0) const {
+        return m_negRlQlHatInvModq[l];
+    }
+
+    const std::vector<NativeInteger>& GetmNegRlQlHatInvModqPrecon(usint l = 0) const {
+        return m_negRlQlHatInvModqPrecon[l];
+    }
+
     const std::vector<std::vector<NativeInteger>>& GetqInvModr() const {
         return m_qInvModr;
     }
@@ -1580,6 +1588,10 @@ protected:
 
     std::vector<std::vector<NativeInteger>> m_negRlQHatInvModqPrecon;
 
+    std::vector<std::vector<NativeInteger>> m_negRlQlHatInvModq;
+
+    std::vector<std::vector<NativeInteger>> m_negRlQlHatInvModqPrecon;
+
     std::vector<std::vector<NativeInteger>> m_qInvModr;
 
     /////////////////////////////////////
@@ -1774,8 +1786,9 @@ public:
         // m_MPIntBootCiphertextCompressionLevel was added in v1.1.0
         try {
             ar(cereal::make_nvp("ccl", m_MPIntBootCiphertextCompressionLevel));
-        } catch(cereal::Exception&) {
-        	m_MPIntBootCiphertextCompressionLevel = COMPRESSION_LEVEL::SLACK;
+        }
+        catch (cereal::Exception&) {
+            m_MPIntBootCiphertextCompressionLevel = COMPRESSION_LEVEL::SLACK;
         }
     }
 

--- a/src/pke/include/schemerns/rns-cryptoparameters.h
+++ b/src/pke/include/schemerns/rns-cryptoparameters.h
@@ -625,12 +625,12 @@ public:
     // BFVrns : Encrypt : POverQ
     /////////////////////////////////////
 
-    const NativeInteger GetNegQModt() const {
-        return m_negQModt;
+    const NativeInteger GetNegQModt(uint32_t i = 0) const {
+        return m_negQModt[i];
     }
 
-    const NativeInteger GetNegQModtPrecon() const {
-        return m_negQModtPrecon;
+    const NativeInteger GetNegQModtPrecon(uint32_t i = 0) const {
+        return m_negQModtPrecon[i];
     }
 
     const NativeInteger GetNegQrModt() const {
@@ -1464,8 +1464,8 @@ protected:
     // BFVrns : Encrypt
     /////////////////////////////////////
 
-    NativeInteger m_negQModt;
-    NativeInteger m_negQModtPrecon;
+    std::vector<NativeInteger> m_negQModt;
+    std::vector<NativeInteger> m_negQModtPrecon;
     std::vector<NativeInteger> m_tInvModq;
     std::vector<NativeInteger> m_tInvModqPrecon;
     std::vector<NativeInteger> m_tInvModqr;

--- a/src/pke/lib/scheme/bfvrns/bfvrns-cryptoparameters.cpp
+++ b/src/pke/lib/scheme/bfvrns/bfvrns-cryptoparameters.cpp
@@ -78,6 +78,8 @@ void CryptoParametersBFVRNS::PrecomputeCRTTables(KeySwitchTechnique ksTech, Scal
 
     BigInteger tmpModulusQ = modulusQ;
 
+    m_negQModt.clear();
+    m_negQModtPrecon.clear();
     m_negQModt.resize(sizeQ);
     m_negQModtPrecon.resize(sizeQ);
     for (size_t l = 0; l < sizeQ; l++) {

--- a/src/pke/lib/scheme/bfvrns/bfvrns-cryptoparameters.cpp
+++ b/src/pke/lib/scheme/bfvrns/bfvrns-cryptoparameters.cpp
@@ -76,9 +76,18 @@ void CryptoParametersBFVRNS::PrecomputeCRTTables(KeySwitchTechnique ksTech, Scal
     NativeInteger modulusr = PreviousPrime<NativeInteger>(moduliQ[sizeQ - 1], 2 * n);
     NativeInteger rootr    = RootOfUnity<NativeInteger>(2 * n, modulusr);
 
-    m_negQModt       = modulusQ.Mod(BigInteger(GetPlaintextModulus())).ConvertToInt();
-    m_negQModt       = t.Sub(m_negQModt);
-    m_negQModtPrecon = m_negQModt.PrepModMulConst(t);
+    BigInteger tmpModulusQ = modulusQ;
+
+	m_negQModt.resize(sizeQ);
+	m_negQModtPrecon.resize(sizeQ);
+    for (size_t l = 0; l < sizeQ; l++) {
+        if (l > 0)
+            tmpModulusQ = tmpModulusQ / BigInteger(moduliQ[sizeQ - l]);
+
+		m_negQModt[l]       = tmpModulusQ.Mod(BigInteger(GetPlaintextModulus())).ConvertToInt();
+		m_negQModt[l]       = t.Sub(m_negQModt[l]);
+		m_negQModtPrecon[l] = m_negQModt[l].PrepModMulConst(t);
+    }
 
     // BFVrns : Encrypt : With extra
     if (encTech == EXTENDED) {
@@ -134,7 +143,7 @@ void CryptoParametersBFVRNS::PrecomputeCRTTables(KeySwitchTechnique ksTech, Scal
         // Pre-compute values [Ql/q_i]_{r_j}
         // Pre-compute values [(Ql/q_i)^{-1}]_{q_i}
 
-        BigInteger tmpModulusQ = modulusQ;
+        tmpModulusQ = modulusQ;
 
         if (multTech == HPSPOVERQLEVELED || multTech == HPSPOVERQ) {
             m_QlHatInvModq.resize(sizeQ);

--- a/src/pke/lib/scheme/bfvrns/bfvrns-leveledshe.cpp
+++ b/src/pke/lib/scheme/bfvrns/bfvrns-leveledshe.cpp
@@ -52,9 +52,9 @@ void LeveledSHEBFVRNS::EvalAddInPlace(Ciphertext<DCRTPoly>& ciphertext, ConstPla
     pt.SetFormat(COEFFICIENT);
 
     const auto elementParams = cryptoParams->GetElementParams();
-    size_t sizeQ = elementParams->GetParams().size();
-    auto encParams = pt.GetParams();
-    size_t sizeP = encParams->GetParams().size();
+    size_t sizeQ             = elementParams->GetParams().size();
+    auto encParams           = pt.GetParams();
+    size_t sizeP             = encParams->GetParams().size();
     // enables encoding of plaintexts using a smaller number of RNS limbs
     size_t level = sizeQ - sizeP;
 
@@ -75,9 +75,9 @@ void LeveledSHEBFVRNS::EvalSubInPlace(Ciphertext<DCRTPoly>& ciphertext, ConstPla
     pt.SetFormat(COEFFICIENT);
 
     const auto elementParams = cryptoParams->GetElementParams();
-    size_t sizeQ = elementParams->GetParams().size();
-    auto encParams = pt.GetParams();
-    size_t sizeP = encParams->GetParams().size();
+    size_t sizeQ             = elementParams->GetParams().size();
+    auto encParams           = pt.GetParams();
+    size_t sizeP             = encParams->GetParams().size();
     // enables encoding of plaintexts using a smaller number of RNS limbs
     size_t level = sizeQ - sizeP;
 
@@ -921,11 +921,6 @@ void LeveledSHEBFVRNS::RelinearizeCore(Ciphertext<DCRTPoly>& ciphertext, const E
 }
 
 Ciphertext<DCRTPoly> LeveledSHEBFVRNS::Compress(ConstCiphertext<DCRTPoly> ciphertext, size_t towersLeft) const {
-    if (towersLeft != 1) {
-        OPENFHE_THROW(
-            "BFV Compress is currently supported only for the case when one RNS tower is left after compression.");
-    }
-
     const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersBFVRNS>(ciphertext->GetCryptoParameters());
 
     if (cryptoParams->GetMultiplicationTechnique() == BEHZ) {

--- a/src/pke/lib/scheme/bfvrns/bfvrns-leveledshe.cpp
+++ b/src/pke/lib/scheme/bfvrns/bfvrns-leveledshe.cpp
@@ -942,8 +942,14 @@ void LeveledSHEBFVRNS::RelinearizeCore(Ciphertext<DCRTPoly>& ciphertext, const E
 Ciphertext<DCRTPoly> LeveledSHEBFVRNS::Compress(ConstCiphertext<DCRTPoly> ciphertext, size_t towersLeft) const {
     const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersBFVRNS>(ciphertext->GetCryptoParameters());
 
-    if (cryptoParams->GetMultiplicationTechnique() == BEHZ) {
-        OPENFHE_THROW("BFV Compress is not currently supported for BEHZ. Use one of the HPS* methods instead.");
+    if ((cryptoParams->GetMultiplicationTechnique() == BEHZ) || (cryptoParams->GetMultiplicationTechnique() == HPS)) {
+        OPENFHE_THROW(
+            "BFV Compress is not currently supported for BEHZ or HPS. Use one of the HPSPOVERQ* methods instead.");
+    }
+
+    if ((cryptoParams->GetEncryptionTechnique() == EXTENDED)) {
+        OPENFHE_THROW(
+            "BFV Compress is not currently supported for the EXTENDED encryption method. Use the STANDARD encryption method instead.");
     }
 
     Ciphertext<DCRTPoly> result = std::make_shared<CiphertextImpl<DCRTPoly>>(*ciphertext);

--- a/src/pke/lib/scheme/bfvrns/bfvrns-leveledshe.cpp
+++ b/src/pke/lib/scheme/bfvrns/bfvrns-leveledshe.cpp
@@ -52,11 +52,11 @@ void LeveledSHEBFVRNS::EvalAddInPlace(Ciphertext<DCRTPoly>& ciphertext, ConstPla
     pt.SetFormat(COEFFICIENT);
 
     const auto elementParams = cryptoParams->GetElementParams();
-    uint32_t sizeQ = elementParams->GetParams().size();
+    size_t sizeQ = elementParams->GetParams().size();
     auto encParams = pt.GetParams();
-    uint32_t sizeP = encParams->GetParams().size();
+    size_t sizeP = encParams->GetParams().size();
     // enables encoding of plaintexts using a smaller number of RNS limbs
-    uint32_t level = sizeQ - sizeP;
+    size_t level = sizeQ - sizeP;
 
     const NativeInteger& NegQModt              = cryptoParams->GetNegQModt(level);
     const NativeInteger& NegQModtPrecon        = cryptoParams->GetNegQModtPrecon(level);
@@ -75,11 +75,11 @@ void LeveledSHEBFVRNS::EvalSubInPlace(Ciphertext<DCRTPoly>& ciphertext, ConstPla
     pt.SetFormat(COEFFICIENT);
 
     const auto elementParams = cryptoParams->GetElementParams();
-    uint32_t sizeQ = elementParams->GetParams().size();
+    size_t sizeQ = elementParams->GetParams().size();
     auto encParams = pt.GetParams();
-    uint32_t sizeP = encParams->GetParams().size();
+    size_t sizeP = encParams->GetParams().size();
     // enables encoding of plaintexts using a smaller number of RNS limbs
-    uint32_t level = sizeQ - sizeP;
+    size_t level = sizeQ - sizeP;
 
     const NativeInteger& NegQModt              = cryptoParams->GetNegQModt(level);
     const NativeInteger& NegQModtPrecon        = cryptoParams->GetNegQModtPrecon(level);

--- a/src/pke/lib/scheme/bfvrns/bfvrns-leveledshe.cpp
+++ b/src/pke/lib/scheme/bfvrns/bfvrns-leveledshe.cpp
@@ -50,8 +50,16 @@ void LeveledSHEBFVRNS::EvalAddInPlace(Ciphertext<DCRTPoly>& ciphertext, ConstPla
 
     DCRTPoly pt = plaintext->GetElement<DCRTPoly>();
     pt.SetFormat(COEFFICIENT);
-    const NativeInteger& NegQModt              = cryptoParams->GetNegQModt();
-    const NativeInteger& NegQModtPrecon        = cryptoParams->GetNegQModtPrecon();
+
+    const auto elementParams = cryptoParams->GetElementParams();
+    uint32_t sizeQ = elementParams->GetParams().size();
+    auto encParams = pt.GetParams();
+    uint32_t sizeP = encParams->GetParams().size();
+    // enables encoding of plaintexts using a smaller number of RNS limbs
+    uint32_t level = sizeQ - sizeP;
+
+    const NativeInteger& NegQModt              = cryptoParams->GetNegQModt(level);
+    const NativeInteger& NegQModtPrecon        = cryptoParams->GetNegQModtPrecon(level);
     const std::vector<NativeInteger>& tInvModq = cryptoParams->GettInvModq();
     const NativeInteger t                      = cryptoParams->GetPlaintextModulus();
     pt.TimesQovert(cryptoParams->GetElementParams(), tInvModq, t, NegQModt, NegQModtPrecon);
@@ -65,8 +73,16 @@ void LeveledSHEBFVRNS::EvalSubInPlace(Ciphertext<DCRTPoly>& ciphertext, ConstPla
 
     DCRTPoly pt = plaintext->GetElement<DCRTPoly>();
     pt.SetFormat(COEFFICIENT);
-    const NativeInteger& NegQModt              = cryptoParams->GetNegQModt();
-    const NativeInteger& NegQModtPrecon        = cryptoParams->GetNegQModtPrecon();
+
+    const auto elementParams = cryptoParams->GetElementParams();
+    uint32_t sizeQ = elementParams->GetParams().size();
+    auto encParams = pt.GetParams();
+    uint32_t sizeP = encParams->GetParams().size();
+    // enables encoding of plaintexts using a smaller number of RNS limbs
+    uint32_t level = sizeQ - sizeP;
+
+    const NativeInteger& NegQModt              = cryptoParams->GetNegQModt(level);
+    const NativeInteger& NegQModtPrecon        = cryptoParams->GetNegQModtPrecon(level);
     const std::vector<NativeInteger>& tInvModq = cryptoParams->GettInvModq();
     const NativeInteger t                      = cryptoParams->GetPlaintextModulus();
     pt.TimesQovert(cryptoParams->GetElementParams(), tInvModq, t, NegQModt, NegQModtPrecon);

--- a/src/pke/lib/scheme/bfvrns/bfvrns-pke.cpp
+++ b/src/pke/lib/scheme/bfvrns/bfvrns-pke.cpp
@@ -154,7 +154,8 @@ Ciphertext<DCRTPoly> PKEBFVRNS::Encrypt(DCRTPoly ptxt, const PublicKey<DCRTPoly>
     const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersBFVRNS>(publicKey->GetCryptoParameters());
 
     const auto elementParams = cryptoParams->GetElementParams();
-    auto encParams           = elementParams;
+    // auto encParams           = elementParams;
+    auto encParams = ptxt.GetParams();
 
     std::vector<NativeInteger> tInvModq = cryptoParams->GettInvModq();
     if (cryptoParams->GetEncryptionTechnique() == EXTENDED) {
@@ -167,6 +168,8 @@ Ciphertext<DCRTPoly> PKEBFVRNS::Encrypt(DCRTPoly ptxt, const PublicKey<DCRTPoly>
     }
     ptxt.SetFormat(Format::COEFFICIENT);
 
+    std::cerr << "test 1" << std::endl;
+
     std::shared_ptr<std::vector<DCRTPoly>> ba = EncryptZeroCore(publicKey, encParams);
 
     NativeInteger NegQModt       = cryptoParams->GetNegQModt();
@@ -177,6 +180,8 @@ Ciphertext<DCRTPoly> PKEBFVRNS::Encrypt(DCRTPoly ptxt, const PublicKey<DCRTPoly>
         NegQModtPrecon = cryptoParams->GetNegQrModtPrecon();
     }
 
+    std::cerr << "test 2" << std::endl;
+
     const NativeInteger t = cryptoParams->GetPlaintextModulus();
 
     ptxt.TimesQovert(encParams, tInvModq, t, NegQModt, NegQModtPrecon);
@@ -185,6 +190,8 @@ Ciphertext<DCRTPoly> PKEBFVRNS::Encrypt(DCRTPoly ptxt, const PublicKey<DCRTPoly>
 
     (*ba)[0].SetFormat(Format::COEFFICIENT);
     (*ba)[1].SetFormat(Format::COEFFICIENT);
+
+    std::cerr << "test 3" << std::endl;
 
     if (cryptoParams->GetEncryptionTechnique() == EXTENDED) {
         (*ba)[0].ScaleAndRoundPOverQ(elementParams, cryptoParams->GetrInvModq());

--- a/src/pke/lib/scheme/bfvrns/bfvrns-pke.cpp
+++ b/src/pke/lib/scheme/bfvrns/bfvrns-pke.cpp
@@ -102,13 +102,13 @@ Ciphertext<DCRTPoly> PKEBFVRNS::Encrypt(DCRTPoly ptxt, const PrivateKey<DCRTPoly
     const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersBFVRNS>(privateKey->GetCryptoParameters());
 
     const auto elementParams = cryptoParams->GetElementParams();
-    uint32_t sizeQ = elementParams->GetParams().size();
+    size_t sizeQ = elementParams->GetParams().size();
 
     auto encParams = ptxt.GetParams();
-    uint32_t sizeP = encParams->GetParams().size();
+    size_t sizeP = encParams->GetParams().size();
 
     // enables encoding of plaintexts using a smaller number of RNS limbs
-    uint32_t level = sizeQ - sizeP;
+    size_t level = sizeQ - sizeP;
 
     std::vector<NativeInteger> tInvModq = cryptoParams->GettInvModq();
     if (cryptoParams->GetEncryptionTechnique() == EXTENDED) {
@@ -160,13 +160,13 @@ Ciphertext<DCRTPoly> PKEBFVRNS::Encrypt(DCRTPoly ptxt, const PublicKey<DCRTPoly>
     const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersBFVRNS>(publicKey->GetCryptoParameters());
 
     const auto elementParams = cryptoParams->GetElementParams();
-    uint32_t sizeQ = elementParams->GetParams().size();
+    size_t sizeQ = elementParams->GetParams().size();
 
     auto encParams = ptxt.GetParams();
-    uint32_t sizeP = encParams->GetParams().size();
+    size_t sizeP = encParams->GetParams().size();
 
     // enables encoding of plaintexts using a smaller number of RNS limbs
-    uint32_t level = sizeQ - sizeP;
+    size_t level = sizeQ - sizeP;
 
     std::vector<NativeInteger> tInvModq = cryptoParams->GettInvModq();
     if (cryptoParams->GetEncryptionTechnique() == EXTENDED) {
@@ -218,12 +218,15 @@ DecryptResult PKEBFVRNS::Decrypt(ConstCiphertext<DCRTPoly> ciphertext, const Pri
 
     const std::vector<DCRTPoly>& cv = ciphertext->GetElements();
     DCRTPoly b                      = DecryptCore(cv, privateKey);
-    b.SetFormat(Format::COEFFICIENT);
 
     size_t sizeQl = b.GetNumOfElements();
 
-    // use RNS procedures only if the number of RNS limbs is larger than 1
-    if (sizeQl > 1) {
+    const auto elementParams = cryptoParams->GetElementParams();
+    size_t sizeQ = elementParams->GetParams().size();
+
+    // use RNS procedures only if the number of RNS limbs is the same as for fresh ciphertexts
+    if (sizeQl == sizeQ) {
+        b.SetFormat(Format::COEFFICIENT);
         if (cryptoParams->GetMultiplicationTechnique() == HPS ||
             cryptoParams->GetMultiplicationTechnique() == HPSPOVERQ ||
             cryptoParams->GetMultiplicationTechnique() == HPSPOVERQLEVELED) {
@@ -241,6 +244,16 @@ DecryptResult PKEBFVRNS::Decrypt(ConstCiphertext<DCRTPoly> ciphertext, const Pri
         }
     }
     else {
+    	// for the case when compress was called, we automatically reduce the polynomial to 1 RNS limb
+        size_t diffQl = sizeQ - sizeQl;
+        size_t levels = sizeQl - 1;
+        for (size_t l = 0; l < levels; ++l) {
+			b.DropLastElementAndScale(cryptoParams->GetQlQlInvModqlDivqlModq(diffQl + l),
+										  cryptoParams->GetqlInvModq(diffQl + l));
+        }
+
+        b.SetFormat(Format::COEFFICIENT);
+
         const NativeInteger t = cryptoParams->GetPlaintextModulus();
         NativePoly element    = b.GetElementAtIndex(0);
         const NativeInteger q = element.GetModulus();

--- a/src/pke/lib/scheme/bfvrns/bfvrns-pke.cpp
+++ b/src/pke/lib/scheme/bfvrns/bfvrns-pke.cpp
@@ -102,7 +102,13 @@ Ciphertext<DCRTPoly> PKEBFVRNS::Encrypt(DCRTPoly ptxt, const PrivateKey<DCRTPoly
     const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersBFVRNS>(privateKey->GetCryptoParameters());
 
     const auto elementParams = cryptoParams->GetElementParams();
-    auto encParams           = elementParams;
+    uint32_t sizeQ = elementParams->GetParams().size();
+
+    auto encParams = ptxt.GetParams();
+    uint32_t sizeP = encParams->GetParams().size();
+
+    // enables encoding of plaintexts using a smaller number of RNS limbs
+    uint32_t level = sizeQ - sizeP;
 
     std::vector<NativeInteger> tInvModq = cryptoParams->GettInvModq();
     if (cryptoParams->GetEncryptionTechnique() == EXTENDED) {
@@ -117,8 +123,8 @@ Ciphertext<DCRTPoly> PKEBFVRNS::Encrypt(DCRTPoly ptxt, const PrivateKey<DCRTPoly
 
     std::shared_ptr<std::vector<DCRTPoly>> ba = EncryptZeroCore(privateKey, encParams);
 
-    NativeInteger NegQModt       = cryptoParams->GetNegQModt();
-    NativeInteger NegQModtPrecon = cryptoParams->GetNegQModtPrecon();
+    NativeInteger NegQModt       = cryptoParams->GetNegQModt(level);
+    NativeInteger NegQModtPrecon = cryptoParams->GetNegQModtPrecon(level);
 
     if (cryptoParams->GetEncryptionTechnique() == EXTENDED) {
         NegQModt       = cryptoParams->GetNegQrModt();
@@ -154,8 +160,13 @@ Ciphertext<DCRTPoly> PKEBFVRNS::Encrypt(DCRTPoly ptxt, const PublicKey<DCRTPoly>
     const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersBFVRNS>(publicKey->GetCryptoParameters());
 
     const auto elementParams = cryptoParams->GetElementParams();
-    // auto encParams           = elementParams;
+    uint32_t sizeQ = elementParams->GetParams().size();
+
     auto encParams = ptxt.GetParams();
+    uint32_t sizeP = encParams->GetParams().size();
+
+    // enables encoding of plaintexts using a smaller number of RNS limbs
+    uint32_t level = sizeQ - sizeP;
 
     std::vector<NativeInteger> tInvModq = cryptoParams->GettInvModq();
     if (cryptoParams->GetEncryptionTechnique() == EXTENDED) {
@@ -168,19 +179,15 @@ Ciphertext<DCRTPoly> PKEBFVRNS::Encrypt(DCRTPoly ptxt, const PublicKey<DCRTPoly>
     }
     ptxt.SetFormat(Format::COEFFICIENT);
 
-    std::cerr << "test 1" << std::endl;
-
     std::shared_ptr<std::vector<DCRTPoly>> ba = EncryptZeroCore(publicKey, encParams);
 
-    NativeInteger NegQModt       = cryptoParams->GetNegQModt();
-    NativeInteger NegQModtPrecon = cryptoParams->GetNegQModtPrecon();
+    NativeInteger NegQModt       = cryptoParams->GetNegQModt(level);
+    NativeInteger NegQModtPrecon = cryptoParams->GetNegQModtPrecon(level);
 
     if (cryptoParams->GetEncryptionTechnique() == EXTENDED) {
         NegQModt       = cryptoParams->GetNegQrModt();
         NegQModtPrecon = cryptoParams->GetNegQrModtPrecon();
     }
-
-    std::cerr << "test 2" << std::endl;
 
     const NativeInteger t = cryptoParams->GetPlaintextModulus();
 
@@ -190,8 +197,6 @@ Ciphertext<DCRTPoly> PKEBFVRNS::Encrypt(DCRTPoly ptxt, const PublicKey<DCRTPoly>
 
     (*ba)[0].SetFormat(Format::COEFFICIENT);
     (*ba)[1].SetFormat(Format::COEFFICIENT);
-
-    std::cerr << "test 3" << std::endl;
 
     if (cryptoParams->GetEncryptionTechnique() == EXTENDED) {
         (*ba)[0].ScaleAndRoundPOverQ(elementParams, cryptoParams->GetrInvModq());

--- a/src/pke/unittest/UnitTestSHE.cpp
+++ b/src/pke/unittest/UnitTestSHE.cpp
@@ -652,8 +652,12 @@ protected:
             EXPECT_EQ(intArrayExpected->GetPackedValue(), results->GetPackedValue()) << failmsg << " EvalMult fails";
 
             if (!((cc->getSchemeId() == SCHEME::BFVRNS_SCHEME) &&
-                  (std::dynamic_pointer_cast<CryptoParametersBFVRNS>(cc->GetCryptoParameters())
-                       ->GetMultiplicationTechnique() == BEHZ))) {
+                  ((std::dynamic_pointer_cast<CryptoParametersBFVRNS>(cc->GetCryptoParameters())
+                        ->GetMultiplicationTechnique() == BEHZ) ||
+                   (std::dynamic_pointer_cast<CryptoParametersBFVRNS>(cc->GetCryptoParameters())
+                        ->GetMultiplicationTechnique() == HPS) ||
+                   (std::dynamic_pointer_cast<CryptoParametersBFVRNS>(cc->GetCryptoParameters())
+                        ->GetEncryptionTechnique() == EXTENDED)))) {
                 cResult = cc->Compress(cResult, 1);
                 cc->Decrypt(kp.secretKey, cResult, &results);
                 results->SetLength(intArrayExpected->GetLength());
@@ -668,8 +672,12 @@ protected:
             EXPECT_EQ(intArrayExpected->GetPackedValue(), results->GetPackedValue()) << failmsg << " operator* fails";
 
             if (!((cc->getSchemeId() == SCHEME::BFVRNS_SCHEME) &&
-                  (std::dynamic_pointer_cast<CryptoParametersBFVRNS>(cc->GetCryptoParameters())
-                       ->GetMultiplicationTechnique() == BEHZ))) {
+                  ((std::dynamic_pointer_cast<CryptoParametersBFVRNS>(cc->GetCryptoParameters())
+                        ->GetMultiplicationTechnique() == BEHZ) ||
+                   (std::dynamic_pointer_cast<CryptoParametersBFVRNS>(cc->GetCryptoParameters())
+                        ->GetMultiplicationTechnique() == HPS) ||
+                   (std::dynamic_pointer_cast<CryptoParametersBFVRNS>(cc->GetCryptoParameters())
+                        ->GetEncryptionTechnique() == EXTENDED)))) {
                 cResult = cc->Compress(cResult, 1);
                 cc->Decrypt(kp.secretKey, cResult, &results);
                 results->SetLength(intArrayExpected->GetLength());


### PR DESCRIPTION
High-level summary: 

- All operations on compressed ciphertexts are supported for HPSPOVERQ and HPSOVERQLEVELED. 
- As soon as a ciphertext is compressed, HPSOVERQLEVELED switches to HPSPOVERQ (to avoid correctness issues due to two competing mechanisms for compressing ciphertexts). When ciphertexts are not compressed, HPSOVERQLEVELED operates the same way as before.
- Compress and encode at level > 0 throw exceptions for BEHZ, HPS; and EXTENDED encryption. 
- I did not add any special logic for ciphertexts/plaintexts with mismatched levels (it can actually be somewhat tricky as the message lives in MSD); so the existing (lower-level) exceptions are thrown. 
- This BFV mode is currently only for FHE experts or compilers. We can make it more usable later (when we add noise estimation).
- Also fixed a bug in BFV where setting level > 0 did not do anything during encoding.
- Fixed a bug causing the HYBRID key switching mode not to work for EvalFastRotation in HPSPOVERQ, HPS, and BEHZ

More details on the changes:

- Added support for encoding at a desired level
- Added support for encryption from reduced plaintexts (some precomputed parameters were extended to a vector)
- Added support for adding/subtracting plaintexts at a given level
- Fixed decryption (single-key and threshold FHE) to support the scenarios with intermediate levels
- Fixed compression to leave more than 1 RNS limb after compression
- Fixed EvalMult
- Fixed EvalSquare
- Fixed EvalFastRotation
- Disabled BFV modulus switching for BEHZ and HPS multiplication modes and EXTENDED encryption mode
- Added unit tests