### PR TITLE
Minor improvements for better Rust compatibility

### DIFF
--- a/src/pke/include/constants-fwd.h
+++ b/src/pke/include/constants-fwd.h
@@ -1,0 +1,136 @@
+//==================================================================================
+// BSD 2-Clause License
+//
+// Copyright (c) 2014-2022, NJIT, Duality Technologies Inc. and other contributors
+//
+// All rights reserved.
+//
+// Author TPOC: contact@openfhe.org
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//==================================================================================
+
+#ifndef _CONSTANTS_FWD_H_
+#define _CONSTANTS_FWD_H_
+
+namespace lbcrypto {
+
+/**
+ * @brief Lists all features supported by public key encryption schemes
+ */
+enum PKESchemeFeature {
+    PKE          = 0x01,
+    KEYSWITCH    = 0x02,
+    PRE          = 0x04,
+    LEVELEDSHE   = 0x08,
+    ADVANCEDSHE  = 0x10,
+    MULTIPARTY   = 0x20,
+    FHE          = 0x40,
+    SCHEMESWITCH = 0x80,
+};
+
+enum ScalingTechnique {
+    FIXEDMANUAL = 0,
+    FIXEDAUTO,
+    FLEXIBLEAUTO,
+    FLEXIBLEAUTOEXT,
+    NORESCALE,
+    INVALID_RS_TECHNIQUE,  // TODO (dsuponit): make this the first value
+};
+
+enum ProxyReEncryptionMode {
+    NOT_SET = 0,
+    INDCPA,
+    FIXED_NOISE_HRA,
+    NOISE_FLOODING_HRA,
+    DIVIDE_AND_ROUND_HRA,
+};
+
+enum MultipartyMode {
+    INVALID_MULTIPARTY_MODE = 0,
+    FIXED_NOISE_MULTIPARTY,
+    NOISE_FLOODING_MULTIPARTY,
+};
+
+enum ExecutionMode {
+    EXEC_EVALUATION = 0,
+    EXEC_NOISE_ESTIMATION,
+};
+
+enum DecryptionNoiseMode {
+    FIXED_NOISE_DECRYPT = 0,
+    NOISE_FLOODING_DECRYPT,
+};
+
+enum KeySwitchTechnique {
+    INVALID_KS_TECH = 0,
+    BV,
+    HYBRID,
+};
+
+enum EncryptionTechnique {
+    STANDARD = 0,
+    EXTENDED,
+};
+
+enum MultiplicationTechnique {
+    BEHZ = 0,
+    HPS,
+    HPSPOVERQ,
+    HPSPOVERQLEVELED,
+};
+
+enum PlaintextEncodings {
+    INVALID_ENCODING = 0,
+    COEF_PACKED_ENCODING,
+    PACKED_ENCODING,
+    STRING_ENCODING,
+    CKKS_PACKED_ENCODING,
+};
+
+enum LargeScalingFactorConstants {
+    MAX_BITS_IN_WORD = 61,
+    MAX_LOG_STEP     = 60,
+};
+
+/**
+ * @brief  BASE_NUM_LEVELS_TO_DROP is the most common value for levels/towers to drop (do not make it a default argument
+ * as default arguments work differently for virtual functions)
+ */
+// TODO (dsuponit): remove BASE_NUM_LEVELS_TO_DROP
+enum {
+    BASE_NUM_LEVELS_TO_DROP = 1,
+};
+
+// Defining the level to which the input ciphertext is brought to before
+// interactive multi-party bootstrapping
+enum COMPRESSION_LEVEL {
+    // we don't support 0 or 1 compression levels
+    // do not change values here
+
+    COMPACT = 2,  // more efficient with stronger security assumption
+    SLACK   = 3   // less efficient with weaker security assumption
+};
+
+}  // namespace lbcrypto
+
+#endif  // _CONSTANTS_FWD_H_

--- a/src/pke/include/constants.h
+++ b/src/pke/include/constants.h
@@ -32,6 +32,8 @@
 #ifndef _CONSTANTS_H_
 #define _CONSTANTS_H_
 
+#include "constants-fwd.h"
+
 // #include "math/hal/basicint.h"
 #include "math/math-hal.h"
 #include "lattice/constants-lattice.h"
@@ -40,119 +42,51 @@
 #include <string>
 
 namespace lbcrypto {
-
-/**
- * @brief Lists all features supported by public key encryption schemes
- */
-enum PKESchemeFeature {
-    PKE          = 0x01,
-    KEYSWITCH    = 0x02,
-    PRE          = 0x04,
-    LEVELEDSHE   = 0x08,
-    ADVANCEDSHE  = 0x10,
-    MULTIPARTY   = 0x20,
-    FHE          = 0x40,
-    SCHEMESWITCH = 0x80,
-};
+// PKESchemeFeature helper functions
 std::ostream& operator<<(std::ostream& s, PKESchemeFeature f);
 
-enum ScalingTechnique {
-    FIXEDMANUAL = 0,
-    FIXEDAUTO,
-    FLEXIBLEAUTO,
-    FLEXIBLEAUTOEXT,
-    NORESCALE,
-    INVALID_RS_TECHNIQUE,  // TODO (dsuponit): make this the first value
-};
+// PKESchemeFeature helper functions
 ScalingTechnique convertToScalingTechnique(const std::string& str);
 ScalingTechnique convertToScalingTechnique(uint32_t num);
 std::ostream& operator<<(std::ostream& s, ScalingTechnique t);
 
-enum ProxyReEncryptionMode {
-    NOT_SET = 0,
-    INDCPA,
-    FIXED_NOISE_HRA,
-    NOISE_FLOODING_HRA,
-    DIVIDE_AND_ROUND_HRA,
-};
+// ProxyReEncryptionMode helper functions
 ProxyReEncryptionMode convertToProxyReEncryptionMode(const std::string& str);
 ProxyReEncryptionMode convertToProxyReEncryptionMode(uint32_t num);
 std::ostream& operator<<(std::ostream& s, ProxyReEncryptionMode p);
 
-enum MultipartyMode {
-    INVALID_MULTIPARTY_MODE = 0,
-    FIXED_NOISE_MULTIPARTY,
-    NOISE_FLOODING_MULTIPARTY,
-};
+// MultipartyMode helper functions
 MultipartyMode convertToMultipartyMode(const std::string& str);
 MultipartyMode convertToMultipartyMode(uint32_t num);
 std::ostream& operator<<(std::ostream& s, MultipartyMode t);
 
-enum ExecutionMode {
-    EXEC_EVALUATION = 0,
-    EXEC_NOISE_ESTIMATION,
-};
+// ExecutionMode helper functions
 ExecutionMode convertToExecutionMode(const std::string& str);
 ExecutionMode convertToExecutionMode(uint32_t num);
 std::ostream& operator<<(std::ostream& s, ExecutionMode t);
 
-enum DecryptionNoiseMode {
-    FIXED_NOISE_DECRYPT = 0,
-    NOISE_FLOODING_DECRYPT,
-};
+// DecryptionNoiseMode helper functions
 DecryptionNoiseMode convertToDecryptionNoiseMode(const std::string& str);
 DecryptionNoiseMode convertToDecryptionNoiseMode(uint32_t num);
 std::ostream& operator<<(std::ostream& s, DecryptionNoiseMode t);
 
-enum KeySwitchTechnique {
-    INVALID_KS_TECH = 0,
-    BV,
-    HYBRID,
-};
+// KeySwitchTechnique helper functions
 KeySwitchTechnique convertToKeySwitchTechnique(const std::string& str);
 KeySwitchTechnique convertToKeySwitchTechnique(uint32_t num);
 std::ostream& operator<<(std::ostream& s, KeySwitchTechnique t);
 
-enum EncryptionTechnique {
-    STANDARD = 0,
-    EXTENDED,
-};
+// EncryptionTechnique helper functions
 EncryptionTechnique convertToEncryptionTechnique(const std::string& str);
 EncryptionTechnique convertToEncryptionTechnique(uint32_t num);
 std::ostream& operator<<(std::ostream& s, EncryptionTechnique t);
 
-enum MultiplicationTechnique {
-    BEHZ = 0,
-    HPS,
-    HPSPOVERQ,
-    HPSPOVERQLEVELED,
-};
+// MultiplicationTechnique helper functions
 MultiplicationTechnique convertToMultiplicationTechnique(const std::string& str);
 MultiplicationTechnique convertToMultiplicationTechnique(uint32_t num);
 std::ostream& operator<<(std::ostream& s, MultiplicationTechnique t);
 
-enum PlaintextEncodings {
-    INVALID_ENCODING = 0,
-    COEF_PACKED_ENCODING,
-    PACKED_ENCODING,
-    STRING_ENCODING,
-    CKKS_PACKED_ENCODING,
-};
+// PlaintextEncodings helper functions
 std::ostream& operator<<(std::ostream& s, PlaintextEncodings p);
-
-enum LargeScalingFactorConstants {
-    MAX_BITS_IN_WORD = 61,
-    MAX_LOG_STEP     = 60,
-};
-
-/**
- * @brief  BASE_NUM_LEVELS_TO_DROP is the most common value for levels/towers to drop (do not make it a default argument
- * as default arguments work differently for virtual functions)
- */
-// TODO (dsuponit): remove BASE_NUM_LEVELS_TO_DROP
-enum {
-    BASE_NUM_LEVELS_TO_DROP = 1,
-};
 
 enum NOISE_FLOODING {
     // noise flooding distribution parameter for distributed decryption in threshold FHE
@@ -169,15 +103,7 @@ enum NOISE_FLOODING {
 #endif
 };  // namespace NOISE_FLOODING
 
-// Defining the level to which the input ciphertext is brought to before
-// interactive multi-party bootstrapping
-enum COMPRESSION_LEVEL {
-    // we don't support 0 or 1 compression levels
-    // do not change values here
-
-    COMPACT = 2,  // more efficient with stronger security assumption
-    SLACK   = 3   // less efficient with weaker security assumption
-};
+// COMPRESSION_LEVEL helper functions
 COMPRESSION_LEVEL convertToCompressionLevel(const std::string& str);
 COMPRESSION_LEVEL convertToCompressionLevel(uint32_t num);
 std::ostream& operator<<(std::ostream& s, COMPRESSION_LEVEL t);

--- a/src/pke/include/cryptocontext.h
+++ b/src/pke/include/cryptocontext.h
@@ -1079,7 +1079,7 @@ public:
    * KeyGen generates a key pair using this algorithm's KeyGen method
    * @return a public/secret key pair
    */
-    KeyPair<Element> KeyGen() {
+    KeyPair<Element> KeyGen() const {
         return GetScheme()->KeyGen(GetContextForPointer(this), false);
     }
 
@@ -1089,7 +1089,7 @@ public:
    * entropy, for use in special cases like Ring Reduction
    * @return a public/secret key pair
    */
-    KeyPair<Element> SparseKeyGen() {
+    KeyPair<Element> SparseKeyGen() const {
         return GetScheme()->KeyGen(GetContextForPointer(this), true);
     }
 

--- a/src/pke/include/key/keypair.h
+++ b/src/pke/include/key/keypair.h
@@ -52,8 +52,12 @@ public:
     explicit KeyPair(PublicKeyImpl<Element>* a = nullptr, PrivateKeyImpl<Element>* b = nullptr)
         : publicKey(a), secretKey(b) {}
 
-    bool good() {
+    bool is_allocated() const {
         return publicKey && secretKey;
+    }
+
+    bool good() const {
+        return is_allocated();
     }
 };
 

--- a/src/pke/include/scheme/bfvrns/gen-cryptocontext-bfvrns-params.h
+++ b/src/pke/include/scheme/bfvrns/gen-cryptocontext-bfvrns-params.h
@@ -56,6 +56,7 @@ class CCParams<CryptoContextBFVRNS> : public Params {
 public:
     CCParams() : Params(BFVRNS_SCHEME) {}
     explicit CCParams(const std::vector<std::string>& vals) : Params(vals) {}
+    explicit CCParams(const Params& params) : Params(params) {}
     CCParams(const CCParams& obj) = default;
     CCParams(CCParams&& obj)      = default;
 };

--- a/src/pke/include/scheme/bgvrns/gen-cryptocontext-bgvrns-params.h
+++ b/src/pke/include/scheme/bgvrns/gen-cryptocontext-bgvrns-params.h
@@ -56,6 +56,7 @@ class CCParams<CryptoContextBGVRNS> : public Params {
 public:
     CCParams() : Params(BGVRNS_SCHEME) {}
     explicit CCParams(const std::vector<std::string>& vals) : Params(vals) {}
+    explicit CCParams(const Params& params) : Params(params) {}
     CCParams(const CCParams& obj) = default;
     CCParams(CCParams&& obj)      = default;
 };

--- a/src/pke/include/scheme/ckksrns/gen-cryptocontext-ckksrns-params.h
+++ b/src/pke/include/scheme/ckksrns/gen-cryptocontext-ckksrns-params.h
@@ -56,6 +56,7 @@ class CCParams<CryptoContextCKKSRNS> : public Params {
 public:
     CCParams() : Params(CKKSRNS_SCHEME) {}
     explicit CCParams(const std::vector<std::string>& vals) : Params(vals) {}
+    explicit CCParams(const Params& params) : Params(params) {}
     CCParams(const CCParams& obj) = default;
     CCParams(CCParams&& obj)      = default;
 };


### PR DESCRIPTION
In this PR, we bring minor interface improvements in order to achieve better compatibility with the [Rust binding](https://github.com/fairmath/openfhe-rs) we are building.

The changes brought by this PR:
- Closes #723 
- Closes #726 
- We added additional `explicit` constuctor to the `CCParams` classes. This allows for the creation of instances of these classes using only the `Params` class.