### PR TITLE
Introduce VectorLWECipherText with cached validation flag

### DIFF
--- a/src/binfhe/include/binfhe-base-scheme.h
+++ b/src/binfhe/include/binfhe-base-scheme.h
@@ -68,7 +68,7 @@ class VecLWECiphertext {
     bool validate() const;
 
     private:
-        mutable std::optional<bool> m_independent;
+        mutable std::optional<bool> m_independent = std::nullopt;
 };
 
 

--- a/src/binfhe/include/binfhe-base-scheme.h
+++ b/src/binfhe/include/binfhe-base-scheme.h
@@ -44,6 +44,7 @@
 #include <map>
 #include <memory>
 #include <vector>
+#include <optional>
 
 namespace lbcrypto {
 
@@ -56,6 +57,20 @@ typedef struct {
     // public key
     LWEPublicKey Pkey;
 } RingGSWBTKey;
+
+class VecLWECiphertext {
+    public:
+    std::vector<LWECiphertext> m_ctvector;
+    
+    VecLWECiphertext() = default;
+    ~VecLWECiphertext() = default;
+
+    bool validate() const;
+
+    private:
+        mutable std::optional<bool> m_independent;
+};
+
 
 /**
  * @brief Ring GSW accumulator schemes described in
@@ -112,8 +127,7 @@ public:
    * @return a shared pointer to the resulting ciphertext
    */
     LWECiphertext EvalBinGate(const std::shared_ptr<BinFHECryptoParams>& params, BINGATE gate, const RingGSWBTKey& EK,
-                              const std::vector<LWECiphertext>& ctvector) const;
-
+                              const VecLWECiphertext& ctvector) const;
     /**
    * Evaluates NOT gate
    *

--- a/src/binfhe/lib/binfhecontext.cpp
+++ b/src/binfhe/lib/binfhecontext.cpp
@@ -301,7 +301,9 @@ LWECiphertext BinFHEContext::EvalBinGate(const BINGATE gate, ConstLWECiphertext&
 }
 
 LWECiphertext BinFHEContext::EvalBinGate(const BINGATE gate, const std::vector<LWECiphertext>& ctvector) const {
-    return m_binfhescheme->EvalBinGate(m_params, gate, m_BTKey, ctvector);
+    VecLWECiphertext ctvec;
+    ctvec.m_ctvector = std::move(ctvector);
+    return m_binfhescheme->EvalBinGate(m_params, gate, m_BTKey, ctvec);
 }
 
 LWECiphertext BinFHEContext::Bootstrap(ConstLWECiphertext& ct) const {

--- a/src/core/examples/parallel.cpp
+++ b/src/core/examples/parallel.cpp
@@ -49,6 +49,7 @@ void verify(float* foo, uint32_t array_size) {
     for (size_t i = 1; i < array_size; ++i) {
         if ((foo[i] - foo[i - 1]) != 1) {
             goodflag = goodflag & false;
+            break;
         }
     }
     if (goodflag) {


### PR DESCRIPTION
- Introduce VectorLWECipherText with cached validation flag
   - this has potential to speedup the evaluation of binary operators etc.
- early exit when possible