### PR TITLE
fixed a bug with mult depth = 0 for CKKS FLEXIBLEAUTO* modes

### DIFF
--- a/src/pke/lib/scheme/ckksrns/ckksrns-cryptoparameters.cpp
+++ b/src/pke/lib/scheme/ckksrns/ckksrns-cryptoparameters.cpp
@@ -100,35 +100,19 @@ void CryptoParametersCKKSRNS::PrecomputeCRTTables(KeySwitchTechnique ksTech, Sca
         }
         else {
             m_scalingFactorsReal[0] = moduliQ[sizeQ - 1].ConvertToDouble();
-
-            if (extraBits == 0) {
-                for (uint32_t k = 1; k < sizeQ; k++) {
-                    double prevSF           = m_scalingFactorsReal[k - 1];
-                    m_scalingFactorsReal[k] = prevSF * prevSF / moduliQ[sizeQ - k].ConvertToDouble();
-                    double ratio            = m_scalingFactorsReal[k] / m_scalingFactorsReal[0];
-
-                    if (ratio <= 0.5 || ratio >= 2.0)
-                        OPENFHE_THROW(
-                            "CryptoParametersCKKSRNS::PrecomputeCRTTables "
-                            "- FLEXIBLEAUTO cannot support this "
-                            "number of levels in this parameter setting. Please use "
-                            "FIXEDMANUAL.");
-                }
-            }
-            else {
+            if (extraBits > 0)
                 m_scalingFactorsReal[1] = moduliQ[sizeQ - 2].ConvertToDouble();
-                for (uint32_t k = 2; k < sizeQ; k++) {
-                    double prevSF           = m_scalingFactorsReal[k - 1];
-                    m_scalingFactorsReal[k] = prevSF * prevSF / moduliQ[sizeQ - k].ConvertToDouble();
-                    double ratio            = m_scalingFactorsReal[k] / m_scalingFactorsReal[1];
+            const double lastPresetFactor = (extraBits == 0) ? m_scalingFactorsReal[0] : m_scalingFactorsReal[1];
+            // number of levels with pre-calculated factors
+            const size_t numPresetFactors = (extraBits == 0) ? 1 : 2;
 
-                    if (ratio <= 0.5 || ratio >= 2.0)
-                        OPENFHE_THROW(
-                            "CryptoParametersCKKSRNS::PrecomputeCRTTables "
-                            "- FLEXIBLEAUTO cannot support this "
-                            "number of levels in this parameter setting. Please use "
-                            "FIXEDMANUAL.");
-                }
+            for (size_t k = numPresetFactors; k < sizeQ; k++) {
+                double prevSF           = m_scalingFactorsReal[k - 1];
+                m_scalingFactorsReal[k] = prevSF * prevSF / moduliQ[sizeQ - k].ConvertToDouble();
+                double ratio            = m_scalingFactorsReal[k] / lastPresetFactor;
+                if (ratio <= 0.5 || ratio >= 2.0)
+                    OPENFHE_THROW(
+                        "FLEXIBLEAUTO cannot support this number of levels in this parameter setting. Please use FIXEDMANUAL.");
             }
         }
 

--- a/src/pke/lib/scheme/ckksrns/ckksrns-cryptoparameters.cpp
+++ b/src/pke/lib/scheme/ckksrns/ckksrns-cryptoparameters.cpp
@@ -112,7 +112,7 @@ void CryptoParametersCKKSRNS::PrecomputeCRTTables(KeySwitchTechnique ksTech, Sca
                 double ratio            = m_scalingFactorsReal[k] / lastPresetFactor;
                 if (ratio <= 0.5 || ratio >= 2.0)
                     OPENFHE_THROW(
-                        "FLEXIBLEAUTO cannot support this number of levels in this parameter setting. Please use FIXEDMANUAL.");
+                        "FLEXIBLEAUTO cannot support this number of levels in this parameter setting. Please use FIXEDMANUAL or FIXEDAUTO instead.");
             }
         }
 

--- a/src/pke/lib/scheme/ckksrns/ckksrns-cryptoparameters.cpp
+++ b/src/pke/lib/scheme/ckksrns/ckksrns-cryptoparameters.cpp
@@ -81,38 +81,54 @@ void CryptoParametersCKKSRNS::PrecomputeCRTTables(KeySwitchTechnique ksTech, Sca
         }
     }
 
-    // Pre-compute scaling factors for each level (used in EXACT scaling technique)
+    // Pre-compute scaling factors for each level (used in FLEXIBLE* scaling techniques)
     if (m_scalTechnique == FLEXIBLEAUTO || m_scalTechnique == FLEXIBLEAUTOEXT) {
         m_scalingFactorsReal.resize(sizeQ);
-        m_scalingFactorsReal[0] = moduliQ[sizeQ - 1].ConvertToDouble();
 
-        if (extraBits == 0) {
-            for (uint32_t k = 1; k < sizeQ; k++) {
-                double prevSF           = m_scalingFactorsReal[k - 1];
-                m_scalingFactorsReal[k] = prevSF * prevSF / moduliQ[sizeQ - k].ConvertToDouble();
-                double ratio            = m_scalingFactorsReal[k] / m_scalingFactorsReal[0];
-
-                if (ratio <= 0.5 || ratio >= 2.0)
-                    OPENFHE_THROW(
-                        "CryptoParametersCKKSRNS::PrecomputeCRTTables "
-                        "- FLEXIBLEAUTO cannot support this "
-                        "number of levels in this parameter setting. Please use "
-                        "FIXEDMANUAL.");
-            }
+        if ((sizeQ == 1) && (extraBits == 0)) {
+            // mult depth = 0 and FLEXIBLEAUTO
+            // when multiplicative depth = 0, we use the scaling mod size instead of modulus size
+            // Plaintext modulus is used in EncodingParamsImpl to store the exponent p of the scaling factor
+            m_scalingFactorsReal[0] = pow(2, GetPlaintextModulus());
+        }
+        else if ((sizeQ == 2) && (extraBits > 0)) {
+            // mult depth = 0 and FLEXIBLEAUTOEXT
+            // when multiplicative depth = 0, we use the scaling mod size instead of modulus size
+            // Plaintext modulus is used in EncodingParamsImpl to store the exponent p of the scaling factor
+            m_scalingFactorsReal[0] = moduliQ[sizeQ - 1].ConvertToDouble();
+            m_scalingFactorsReal[1] = pow(2, GetPlaintextModulus());
         }
         else {
-            m_scalingFactorsReal[1] = moduliQ[sizeQ - 2].ConvertToDouble();
-            for (uint32_t k = 2; k < sizeQ; k++) {
-                double prevSF           = m_scalingFactorsReal[k - 1];
-                m_scalingFactorsReal[k] = prevSF * prevSF / moduliQ[sizeQ - k].ConvertToDouble();
-                double ratio            = m_scalingFactorsReal[k] / m_scalingFactorsReal[1];
+            m_scalingFactorsReal[0] = moduliQ[sizeQ - 1].ConvertToDouble();
 
-                if (ratio <= 0.5 || ratio >= 2.0)
-                    OPENFHE_THROW(
-                        "CryptoParametersCKKSRNS::PrecomputeCRTTables "
-                        "- FLEXIBLEAUTO cannot support this "
-                        "number of levels in this parameter setting. Please use "
-                        "FIXEDMANUAL.");
+            if (extraBits == 0) {
+                for (uint32_t k = 1; k < sizeQ; k++) {
+                    double prevSF           = m_scalingFactorsReal[k - 1];
+                    m_scalingFactorsReal[k] = prevSF * prevSF / moduliQ[sizeQ - k].ConvertToDouble();
+                    double ratio            = m_scalingFactorsReal[k] / m_scalingFactorsReal[0];
+
+                    if (ratio <= 0.5 || ratio >= 2.0)
+                        OPENFHE_THROW(
+                            "CryptoParametersCKKSRNS::PrecomputeCRTTables "
+                            "- FLEXIBLEAUTO cannot support this "
+                            "number of levels in this parameter setting. Please use "
+                            "FIXEDMANUAL.");
+                }
+            }
+            else {
+                m_scalingFactorsReal[1] = moduliQ[sizeQ - 2].ConvertToDouble();
+                for (uint32_t k = 2; k < sizeQ; k++) {
+                    double prevSF           = m_scalingFactorsReal[k - 1];
+                    m_scalingFactorsReal[k] = prevSF * prevSF / moduliQ[sizeQ - k].ConvertToDouble();
+                    double ratio            = m_scalingFactorsReal[k] / m_scalingFactorsReal[1];
+
+                    if (ratio <= 0.5 || ratio >= 2.0)
+                        OPENFHE_THROW(
+                            "CryptoParametersCKKSRNS::PrecomputeCRTTables "
+                            "- FLEXIBLEAUTO cannot support this "
+                            "number of levels in this parameter setting. Please use "
+                            "FIXEDMANUAL.");
+                }
             }
         }
 

--- a/src/pke/unittest/utckksrns/UnitTestCKKSrns.cpp
+++ b/src/pke/unittest/utckksrns/UnitTestCKKSrns.cpp
@@ -184,6 +184,9 @@ static std::vector<TEST_CASE_UTCKKSRNS> testCases = {
     // TestType,            Descr, Scheme,         RDim,      MultDepth, SModSize, DSize, BatchSz, SecKeyDist, MaxRelinSkDeg, FModSize, SecLvl,       KSTech, ScalTech, LDigits, PtMod, StdDev, EvalAddCt, KSCt, MultTech, EncTech, PREMode, Slots, LowPrec,      HighPrec
     { ADD_PACKED_PRECISION, "01", {CKKSRNS_SCHEME, RING_DIM_PREC, 7,     DFLT,     DSIZE, BATCH,   DFLT,       DFLT,          DFLT,     HEStd_NotSet, HYBRID, DFLT,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT},   0,     FLEXIBLEAUTO, FLEXIBLEAUTOEXT},
     { ADD_PACKED_PRECISION, "02", {CKKSRNS_SCHEME, RING_DIM_PREC, 7,     DFLT,     DSIZE, BATCH,   DFLT,       DFLT,          DFLT,     HEStd_NotSet, BV,     DFLT,     DFLT,    DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT},   0,     FLEXIBLEAUTO, FLEXIBLEAUTOEXT},
+    // Special cases when mult depth = 0 and FLEXIBLEAUTO* modes are used; checks that the scaling factor set correctly
+    { ADD_PACKED, "11", {CKKSRNS_SCHEME, RING_DIM, 0,     DFLT,     DSIZE, BATCH,   DFLT,       DFLT,          DFLT,     HEStd_NotSet, BV,     FLEXIBLEAUTO,    DFLT,    DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT},   0},
+    { ADD_PACKED, "12", {CKKSRNS_SCHEME, RING_DIM, 0,     DFLT,     DSIZE, BATCH,   DFLT,       DFLT,          DFLT,     HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT},   0},
 #endif
     // ==========================================
     // TestType,  Descr, Scheme,         RDim, MultDepth, SModSize, DSize, BatchSz, SecKeyDist, MaxRelinSkDeg, FModSize, SecLvl,       KSTech, ScalTech,        LDigits, PtMod, StdDev, EvalAddCt, KSCt, MultTech, EncTech, PREMode, Slots
@@ -765,13 +768,14 @@ protected:
                           failmsg + " EvalSub Ct and negative double fails");
             approximationErrors.emplace_back(CalculateApproximationError<T>(plaintext1AddScalar->GetCKKSPackedValue(),
                                                                             results->GetCKKSPackedValue()));
-
-            // Testing EvalAdd ciphertext + large double
-            cResult = cc->EvalAdd(ciphertext1, factor);
-            cc->Decrypt(kp.secretKey, cResult, &results);
-            results->SetLength(plaintext1AddLargeScalar->GetLength());
-            checkEquality(plaintext1AddLargeScalar->GetCKKSPackedValue(), results->GetCKKSPackedValue(), factor * eps,
-                          failmsg + " EvalAdd Ct and large double fails");
+            if (testData.params.multiplicativeDepth > 0) {
+                // Testing EvalAdd ciphertext + large double
+                cResult = cc->EvalAdd(ciphertext1, factor);
+                cc->Decrypt(kp.secretKey, cResult, &results);
+                results->SetLength(plaintext1AddLargeScalar->GetLength());
+                checkEquality(plaintext1AddLargeScalar->GetCKKSPackedValue(), results->GetCKKSPackedValue(),
+                              factor * eps, failmsg + " EvalAdd Ct and large double fails");
+            }
 
             // Testing EvalNegate
             cResult = cc->EvalNegate(ciphertext1);


### PR DESCRIPTION
The wrong scaling factor was used for FLEXIBLEAUTO* modes at multiplicative depth = 0. It was using the first modulus size instead of the scaling factor. Now it is corrected.