### PR TITLE
blake2engine: Use .data() to get pointer to data and not .begin()

### DIFF
--- a/src/core/include/utils/prng/blake2engine.h
+++ b/src/core/include/utils/prng/blake2engine.h
@@ -142,8 +142,8 @@ class Blake2Engine {
   void Generate() {
     // m_counter is the input to the hash function
     // m_buffer is the output
-    if (blake2xb(m_buffer.begin(), m_buffer.size() * sizeof(result_type),
-                 &m_counter, sizeof(m_counter), m_seed.cbegin(),
+    if (blake2xb(m_buffer.data(), m_buffer.size() * sizeof(result_type),
+                 &m_counter, sizeof(m_counter), m_seed.data(),
                  m_seed.size() * sizeof(result_type)) != 0) {
       OPENFHE_THROW("PRNG: blake2xb failed");
     }


### PR DESCRIPTION
`.begin()` could return an iterator object depending on the build context 