### PR TITLE
demoData folder: Only create folder and don't use bash

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -649,7 +649,8 @@ set(BINDEMODATAPATH ${CMAKE_CURRENT_BINARY_DIR}/demoData)
 
 # copies demoData folder from the root of the repo to build/demoData if the folder does not exist
 add_custom_target(third-party ALL
-    COMMAND [ ! -d ${BINDEMODATAPATH} ] && cp -R ${DEMODATAPATH} ${BINDEMODATAPATH} && echo "-- Copied demoData files" || echo "-- demoData folder already exists" )
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${BINDEMODATAPATH}
+)
 
 # when running "make clean", additionally deletes the demoData folder and CMake cache file
 set(ADDITIONAL_CLEAN_FILES "")

--- a/demoData/.gitignore
+++ b/demoData/.gitignore
@@ -1,5 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore
-!*.csv


### PR DESCRIPTION
As far as i understand the folder is only used by the examples. The target is there so that the example applications don't have to create the folder first if they are run from the build folder. This can be done by native cmake commands without relying on bash. 