### PR TITLE
Minor noise estimation fixes for BGV and BFV

### DIFF
--- a/src/pke/include/scheme/bgvrns/bgvrns-parametergeneration.h
+++ b/src/pke/include/scheme/bgvrns/bgvrns-parametergeneration.h
@@ -127,7 +127,7 @@ private:
 
     BGVNoiseEstimates computeNoiseEstimates(std::shared_ptr<CryptoParametersBase<DCRTPoly>> cryptoParams,
                                             uint32_t ringDimension, uint32_t evalAddCount, uint32_t keySwitchCount,
-                                            uint32_t auxBits, usint numPrimes) const;
+                                            uint32_t auxTowers, usint numPrimes) const;
 
     uint64_t getCyclicOrder(const uint32_t ringDimension, const int plainModulus,
                             const ScalingTechnique scalTech) const;
@@ -139,13 +139,13 @@ private:
    * @param ringDimension is the dimension of the ring (n)
    * @param evalAddCount is the maximum number of additions per level.
    * @param keySwitchCount is the maximum number of key switches per level.
-   * @param auxBits is the size of the additional modulus P, used for hybrid key-switching.
+   * @param auxTowers is the number of RNS limbs in the additional modulus P, used for hybrid key-switching.
    * @param numPrimes Number of CRT moduli.
    * @return A pair containing: 1) a vector with the CRT moduli and 2) the total modulus size to be used for ensuring security compliance.
    */
     std::pair<std::vector<NativeInteger>, uint32_t> computeModuli(
         std::shared_ptr<CryptoParametersBase<DCRTPoly>> cryptoParams, uint32_t ringDimension, uint32_t evalAddCount,
-        uint32_t keySwitchCount, uint32_t auxBits, usint numPrimes) const;
+        uint32_t keySwitchCount, uint32_t auxTowers, usint numPrimes) const;
 
     /*
    * Method that initializes the Discrete Gaussian Generator with flooding for PRE.

--- a/src/pke/lib/scheme/bfvrns/bfvrns-leveledshe.cpp
+++ b/src/pke/lib/scheme/bfvrns/bfvrns-leveledshe.cpp
@@ -112,7 +112,7 @@ uint32_t FindLevelsToDrop(usint multiplicativeDepth, std::shared_ptr<CryptoParam
     const double Bkey =
         (cryptoParamsBFVrns->GetSecretKeyDist() == GAUSSIAN) ? sqrt(thresholdParties) * Berr : thresholdParties;
 
-    double w = relinWindow == 0 ? pow(2, dcrtBits) : pow(2, relinWindow);
+    double w = (relinWindow == 0) ? pow(2, dcrtBits) : pow(2, relinWindow);
 
     // expansion factor delta
     auto delta = [](uint32_t n) -> double {
@@ -131,7 +131,7 @@ uint32_t FindLevelsToDrop(usint multiplicativeDepth, std::shared_ptr<CryptoParam
         if (scalTechnique == HYBRID)
             return k * (numPartQ * delta(n) * Berr + delta(n) * Bkey + 1.0) / 2;
         else {
-            double numDigitsPerTower = relinWindow == 0 ? 1 : floor(dcrtBits / relinWindow) + 1;
+            double numDigitsPerTower = (relinWindow == 0) ? 1 : ((dcrtBits / relinWindow) + 1);
             return delta(n) * numDigitsPerTower * (floor(logqPrev / (log(2) * dcrtBits)) + 1) * w * Berr;
         }
     };

--- a/src/pke/lib/scheme/bfvrns/bfvrns-leveledshe.cpp
+++ b/src/pke/lib/scheme/bfvrns/bfvrns-leveledshe.cpp
@@ -130,8 +130,10 @@ uint32_t FindLevelsToDrop(usint multiplicativeDepth, std::shared_ptr<CryptoParam
     auto noiseKS = [&](uint32_t n, double logqPrev, double w) -> double {
         if (scalTechnique == HYBRID)
             return k * (numPartQ * delta(n) * Berr + delta(n) * Bkey + 1.0) / 2;
-        else
-            return delta(n) * (floor(logqPrev / (log(2) * dcrtBits)) + 1) * w * Berr;
+        else {
+            double numDigitsPerTower = relinWindow == 0 ? 1 : floor(dcrtBits / relinWindow) + 1;
+            return delta(n) * numDigitsPerTower * (floor(logqPrev / (log(2) * dcrtBits)) + 1) * w * Berr;
+        }
     };
 
     // function used in the EvalMult constraint

--- a/src/pke/lib/scheme/bfvrns/bfvrns-parametergeneration.cpp
+++ b/src/pke/lib/scheme/bfvrns/bfvrns-parametergeneration.cpp
@@ -129,7 +129,7 @@ bool ParameterGenerationBFVRNS::ParamsGenBFVRNS(std::shared_ptr<CryptoParameters
             return numTowers * (delta(n) * Berr + delta(n) * Bkey + 1.0) / 2.0;
         }
         else {
-            double numDigitsPerTower = digitSize == 0 ? 1 : floor(dcrtBits / digitSize) + 1;
+            double numDigitsPerTower = (digitSize == 0) ? 1 : ((dcrtBits / digitSize) + 1);
             return delta(n) * numDigitsPerTower * (floor(logqPrev / (std::log(2) * dcrtBits)) + 1) * w * Berr / 2.0;
         }
     };

--- a/src/pke/lib/scheme/bfvrns/bfvrns-parametergeneration.cpp
+++ b/src/pke/lib/scheme/bfvrns/bfvrns-parametergeneration.cpp
@@ -121,15 +121,17 @@ bool ParameterGenerationBFVRNS::ParamsGenBFVRNS(std::shared_ptr<CryptoParameters
     };
 
     auto noiseKS = [&](uint32_t n, double logqPrev, double w, bool mult) -> double {
-        if ((ksTech == HYBRID) && (!mult))
-            return (delta(n) * Berr + delta(n) * Bkey + 1.0) / 2;
-        else if ((ksTech == HYBRID) && (mult))
+        if (ksTech == HYBRID) {
             // conservative estimate for HYBRID to avoid the use of method of
             // iterative approximations; we do not know the number
-            // of moduli at this point and use an upper bound for numDigits
-            return (multiplicativeDepth + 1) * delta(n) * Berr;
-        else
-            return delta(n) * (floor(logqPrev / (std::log(2) * dcrtBits)) + 1) * w * Berr;
+            // of digits and moduli at this point and use upper bounds
+            double numTowers = ceil(static_cast<double>(logqPrev) / dcrtBits);
+            return numTowers * (delta(n) * Berr + delta(n) * Bkey + 1.0) / 2.0;
+        }
+        else {
+            double numDigitsPerTower = digitSize == 0 ? 1 : floor(dcrtBits / digitSize) + 1;
+            return delta(n) * numDigitsPerTower * (floor(logqPrev / (std::log(2) * dcrtBits)) + 1) * w * Berr / 2.0;
+        }
     };
 
     // initial values

--- a/src/pke/lib/scheme/bgvrns/bgvrns-parametergeneration.cpp
+++ b/src/pke/lib/scheme/bgvrns/bgvrns-parametergeneration.cpp
@@ -109,10 +109,10 @@ BGVNoiseEstimates ParameterGenerationBGVRNS::computeNoiseEstimates(
         if (digitSize == 0) {
             OPENFHE_THROW("digitSize is not allowed to be 0 for BV key switching in BGV when scalingModSize = 0.");
         }
-        int relinBase       = pow(2.0, digitSize);
-        int modSizeEstimate = DCRT_MODULUS::MAX_SIZE;
-        int numWindows      = floor(modSizeEstimate / digitSize) + 1;
-        keySwitchingNoise   = numWindows * numPrimes * expansionFactor * relinBase * Berr / 2.0;
+        uint64_t relinBase       = pow(2.0, digitSize);
+        uint32_t modSizeEstimate = DCRT_MODULUS::MAX_SIZE;
+        uint32_t numWindows      = (modSizeEstimate / digitSize) + 1;
+        keySwitchingNoise        = numWindows * numPrimes * expansionFactor * relinBase * Berr / 2.0;
     }
     else {
         double numTowersPerDigit = cryptoParamsBGVRNS->GetNumPerPartQ();


### PR DESCRIPTION
Refines BGV and BFV key switching estimates to correspond to Appendix B of https://eprint.iacr.org/2021/204