### PR TITLE
No repeated primes in the limb moduli for CKKS

### DIFF
--- a/src/pke/lib/scheme/ckksrns/ckksrns-parametergeneration.cpp
+++ b/src/pke/lib/scheme/ckksrns/ckksrns-parametergeneration.cpp
@@ -219,22 +219,31 @@ bool ParameterGenerationCKKSRNS::ParamsGenCKKSRNS(std::shared_ptr<CryptoParamete
         const auto pos = std::find(moduliQ.begin() + 1, moduliQ.end(), moduliQ[0]);
         if (pos != moduliQ.end()) {
             moduliQ[0] = NextPrime<NativeInteger>(maxPrime, cyclOrder);
-            maxPrime   = moduliQ[0];
         }
     }
+    if (moduliQ[0] > maxPrime)
+        maxPrime = moduliQ[0];
+
     rootsQ[0] = RootOfUnity(cyclOrder, moduliQ[0]);
 
     if (scalTech == FLEXIBLEAUTOEXT) {
-        // find if the value of moduliQ[0] is already in the vector starting with moduliQ[1] and
-        // if there is, then get another prime for moduliQ[0]
-        const auto pos = std::find(moduliQ.begin(), moduliQ.end(), moduliQ[numPrimes]);
-        if (pos == moduliQ.end()) {
+        // find if the value of moduliQ[numPrimes] is already in the vector.
+        // in this case we must redefine the position of "end()" as "end()-1"
+        // currently "moduliQ[numPrimes] == 0" as it is not set up anywhere in this code yet
+        const auto endPos = moduliQ.end() - 1;
+        auto pos          = std::find(moduliQ.begin(), endPos, moduliQ[numPrimes]);
+        if (pos == endPos) {
             // no need for extra checking as extraModSize is automatically chosen by the library
             moduliQ[numPrimes] = FirstPrime<NativeInteger>(extraModSize - 1, cyclOrder);
         }
         else {
             moduliQ[numPrimes] = NextPrime<NativeInteger>(maxPrime, cyclOrder);
-            // maxPrime   = moduliQ[numPrimes];
+            maxPrime           = moduliQ[numPrimes];
+        }
+
+        pos = std::find(moduliQ.begin(), endPos, moduliQ[numPrimes]);
+        if (pos != endPos) {
+            moduliQ[numPrimes] = NextPrime<NativeInteger>(maxPrime, cyclOrder);
         }
 
         rootsQ[numPrimes] = RootOfUnity(cyclOrder, moduliQ[numPrimes]);

--- a/src/pke/lib/scheme/ckksrns/ckksrns-parametergeneration.cpp
+++ b/src/pke/lib/scheme/ckksrns/ckksrns-parametergeneration.cpp
@@ -231,8 +231,6 @@ bool ParameterGenerationCKKSRNS::ParamsGenCKKSRNS(std::shared_ptr<CryptoParamete
 
         // no need for extra checking as extraModSize is automatically chosen by the library
         auto tempMod = FirstPrime<NativeInteger>(extraModSize - 1, cyclOrder);
-        if (tempMod > maxPrime)
-            maxPrime = tempMod;
         // check if tempMod has a duplicate in the vector (exclude moduliQ[numPrimes] from this operation):
         const auto endPos = moduliQ.end() - 1;
         auto pos          = std::find(moduliQ.begin(), endPos, tempMod);

--- a/src/pke/lib/scheme/ckksrns/ckksrns-parametergeneration.cpp
+++ b/src/pke/lib/scheme/ckksrns/ckksrns-parametergeneration.cpp
@@ -209,28 +209,29 @@ bool ParameterGenerationCKKSRNS::ParamsGenCKKSRNS(std::shared_ptr<CryptoParamete
     }
 
     if (firstModSize == dcrtBits) {  // this requires dcrtBits < 60
-        moduliQ[0] = PreviousPrime<NativeInteger>(minPrime, cyclOrder);
+        moduliQ[0] = NextPrime<NativeInteger>(maxPrime, cyclOrder);
     }
     else {
         moduliQ[0] = LastPrime<NativeInteger>(firstModSize, cyclOrder);
-    }
-    // find if the value of moduliQ[0] is already in the vector starting with moduliQ[1] and
-    // if there is, then get another prime for moduliQ[0]
-    const auto pos = std::find(moduliQ.begin() + 1, moduliQ.end(), moduliQ[0]);
-    if (pos != moduliQ.end()) {
-        moduliQ[0] = NextPrime<NativeInteger>(maxPrime, cyclOrder);
-        maxPrime   = moduliQ[0];
+
+        // find if the value of moduliQ[0] is already in the vector starting with moduliQ[1] and
+        // if there is, then get another prime for moduliQ[0]
+        const auto pos = std::find(moduliQ.begin() + 1, moduliQ.end(), moduliQ[0]);
+        if (pos != moduliQ.end()) {
+            moduliQ[0] = NextPrime<NativeInteger>(maxPrime, cyclOrder);
+            maxPrime   = moduliQ[0];
+        }
     }
     rootsQ[0] = RootOfUnity(cyclOrder, moduliQ[0]);
 
     if (scalTech == FLEXIBLEAUTOEXT) {
-        // no need for extra checking as extraModSize is automatically chosen by the library
-        NativeInteger temp_moduliQ = FirstPrime<NativeInteger>(extraModSize - 1, cyclOrder);
         // find if the value of moduliQ[0] is already in the vector starting with moduliQ[1] and
         // if there is, then get another prime for moduliQ[0]
         const auto pos = std::find(moduliQ.begin(), moduliQ.end(), moduliQ[numPrimes]);
-        if (pos == moduliQ.end())
-            moduliQ[numPrimes] = temp_moduliQ;
+        if (pos == moduliQ.end()) {
+            // no need for extra checking as extraModSize is automatically chosen by the library
+            moduliQ[numPrimes] = FirstPrime<NativeInteger>(extraModSize - 1, cyclOrder);
+        }
         else {
             moduliQ[numPrimes] = NextPrime<NativeInteger>(maxPrime, cyclOrder);
             // maxPrime   = moduliQ[numPrimes];

--- a/src/pke/lib/scheme/ckksrns/ckksrns-parametergeneration.cpp
+++ b/src/pke/lib/scheme/ckksrns/ckksrns-parametergeneration.cpp
@@ -227,24 +227,17 @@ bool ParameterGenerationCKKSRNS::ParamsGenCKKSRNS(std::shared_ptr<CryptoParamete
     rootsQ[0] = RootOfUnity(cyclOrder, moduliQ[0]);
 
     if (scalTech == FLEXIBLEAUTOEXT) {
-        // find if the value of moduliQ[numPrimes] is already in the vector.
-        // in this case we must redefine the position of "end()" as "end()-1"
-        // currently "moduliQ[numPrimes] == 0" as it is not set up anywhere in this code yet
-        const auto endPos = moduliQ.end() - 1;
-        auto pos          = std::find(moduliQ.begin(), endPos, moduliQ[numPrimes]);
-        if (pos == endPos) {
-            // no need for extra checking as extraModSize is automatically chosen by the library
-            moduliQ[numPrimes] = FirstPrime<NativeInteger>(extraModSize - 1, cyclOrder);
-        }
-        else {
-            moduliQ[numPrimes] = NextPrime<NativeInteger>(maxPrime, cyclOrder);
-            maxPrime           = moduliQ[numPrimes];
-        }
+        // moduliQ[numPrimes] must still be 0, so it has to be populated now
 
-        pos = std::find(moduliQ.begin(), endPos, moduliQ[numPrimes]);
-        if (pos != endPos) {
-            moduliQ[numPrimes] = NextPrime<NativeInteger>(maxPrime, cyclOrder);
-        }
+        // no need for extra checking as extraModSize is automatically chosen by the library
+        auto tempMod = FirstPrime<NativeInteger>(extraModSize - 1, cyclOrder);
+        if (tempMod > maxPrime)
+            maxPrime = tempMod;
+        // check if tempMod has a duplicate in the vector (exclude moduliQ[numPrimes] from this operation):
+        const auto endPos = moduliQ.end() - 1;
+        auto pos          = std::find(moduliQ.begin(), endPos, tempMod);
+        // if there is a duplicate, then we call NextPrime()
+        moduliQ[numPrimes] = (pos != endPos) ? NextPrime<NativeInteger>(maxPrime, cyclOrder) : tempMod;
 
         rootsQ[numPrimes] = RootOfUnity(cyclOrder, moduliQ[numPrimes]);
     }

--- a/src/pke/unittest/utckksrns/UnitTestCKKSrns.cpp
+++ b/src/pke/unittest/utckksrns/UnitTestCKKSrns.cpp
@@ -64,6 +64,7 @@ enum TEST_CASE_TYPE {
     ADD_PACKED_PRECISION,
     MULT_PACKED_PRECISION,
     EVALSQUARE,
+    SMALL_SCALING_MOD_SIZE,
 };
 
 static std::ostream& operator<<(std::ostream& os, const TEST_CASE_TYPE& type) {
@@ -113,6 +114,9 @@ static std::ostream& operator<<(std::ostream& os, const TEST_CASE_TYPE& type) {
             break;
         case EVALSQUARE:
             typeName = "EVALSQUARE";
+            break;
+        case SMALL_SCALING_MOD_SIZE:
+            typeName = "SMALL_SCALING_MOD_SIZE";
             break;
         default:
             typeName = "UNKNOWN";
@@ -517,6 +521,10 @@ static std::vector<TEST_CASE_UTCKKSRNS> testCases = {
     { EVALSQUARE, "07", {CKKSRNS_SCHEME, RING_DIM, 7,     DFLT,     DSIZE, BATCH,   DFLT,       DFLT,          DFLT,     HEStd_NotSet, BV,     FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT}, },
     { EVALSQUARE, "08", {CKKSRNS_SCHEME, RING_DIM, 7,     DFLT,     DSIZE, BATCH,   DFLT,       DFLT,          DFLT,     HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, DFLT,    DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT}, },
 #endif
+    // ==========================================
+    // TestType,              Descr, Scheme,        RDim,   MultDepth, SModSize, DSize, BatchSz, SecKeyDist, MaxRelinSkDeg, FModSize, SecLvl,       KSTech, ScalTech,    LDigits, PtMod, StdDev, EvalAddCt, KSCt, MultTech, EncTech, PREMode
+    { SMALL_SCALING_MOD_SIZE, "01", {CKKSRNS_SCHEME, 32768, 19,        22,       DFLT,  DFLT,    DFLT,       DFLT,          23,       DFLT,         DFLT,   FIXEDMANUAL, DFLT,    DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT}, },
+    { SMALL_SCALING_MOD_SIZE, "02", {CKKSRNS_SCHEME, 32768, 16,        50,       DFLT,  DFLT,    DFLT,       DFLT,          50,       HEStd_NotSet, DFLT,   DFLT,        DFLT,    DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT}, },
 #endif
     // ==========================================
 };
@@ -2149,6 +2157,28 @@ protected:
             EXPECT_TRUE(0 == 1) << failmsg;
         }
     }
+
+    void UnitTest_Small_ScalingModSize(const TEST_CASE_UTCKKSRNS& testData,
+                                       const std::string& failmsg = std::string()) {
+        try {
+            CryptoContext<Element> cc(UnitTestGenerateContext(testData.params));
+        }
+        catch (std::exception& e) {
+            std::cerr << "Exception thrown from " << __func__ << "(): " << e.what() << std::endl;
+            // make it fail
+            EXPECT_TRUE(0 == 1) << failmsg;
+        }
+        catch (...) {
+#if defined EMSCRIPTEN
+            std::string name("EMSCRIPTEN_UNKNOWN");
+#else
+            std::string name(demangle(__cxxabiv1::__cxa_current_exception_type()->name()));
+#endif
+            std::cerr << "Unknown exception of type \"" << name << "\" thrown from " << __func__ << "()" << std::endl;
+            // make it fail
+            EXPECT_TRUE(0 == 1) << failmsg;
+        }
+    }
 };
 
 template <>
@@ -2226,6 +2256,10 @@ TEST_P(UTCKKSRNS, CKKSRNS) {
             break;
         case EVALSQUARE:
             UnitTest_EvalSquare(test, test.buildTestName());
+            break;
+        case SMALL_SCALING_MOD_SIZE:
+            UnitTest_Small_ScalingModSize(test, test.buildTestName());
+            break;
         default:
             break;
     }


### PR DESCRIPTION
1. Make sure that the vector of moduliQ in ParamsGenCKKSRNS() has no duplicate values.
2. Push error handling to the top of the function
3. Reorganize code and replace usint with uint32_t
4. Add unit tests