### PR TITLE
Fix logQ(P) estimation used for finding the minimum ring dimension

### DIFF
--- a/src/pke/include/schemerns/rns-cryptoparameters.h
+++ b/src/pke/include/schemerns/rns-cryptoparameters.h
@@ -160,7 +160,7 @@ public:
     static std::pair<double, uint32_t> EstimateLogP(uint32_t numPartQ, double firstModulusSize, double dcrtBits,
                                                     double extraModulusSize, uint32_t numPrimes, uint32_t auxBits);
 
-    double EstimateMultipartyFloodingLogQ() const {
+    static double EstimateMultipartyFloodingLogQ() {
         return NoiseFlooding::MULTIPARTY_MOD_SIZE * NoiseFlooding::MULTIPARTY_MOD_SIZE;
     }
 

--- a/src/pke/include/schemerns/rns-cryptoparameters.h
+++ b/src/pke/include/schemerns/rns-cryptoparameters.h
@@ -157,6 +157,13 @@ public:
 
     virtual uint64_t FindAuxPrimeStep() const;
 
+    static std::pair<double, uint32_t> EstimateLogP(uint32_t numPartQ, double firstModulusSize, double dcrtBits,
+                                                    double extraModulusSize, uint32_t numPrimes, uint32_t auxBits);
+
+    double EstimateMultipartyFloodingLogQ() const {
+        return NoiseFlooding::MULTIPARTY_MOD_SIZE * NoiseFlooding::MULTIPARTY_MOD_SIZE;
+    }
+
     /**
    * == operator to compare to this instance of CryptoParametersBase object.
    *

--- a/src/pke/include/schemerns/rns-cryptoparameters.h
+++ b/src/pke/include/schemerns/rns-cryptoparameters.h
@@ -161,7 +161,7 @@ public:
                                                     double extraModulusSize, uint32_t numPrimes, uint32_t auxBits);
 
     static double EstimateMultipartyFloodingLogQ() {
-        return NoiseFlooding::MULTIPARTY_MOD_SIZE * NoiseFlooding::MULTIPARTY_MOD_SIZE;
+        return NoiseFlooding::MULTIPARTY_MOD_SIZE * NoiseFlooding::NUM_MODULI_MULTIPARTY;
     }
 
     /**

--- a/src/pke/include/schemerns/rns-cryptoparameters.h
+++ b/src/pke/include/schemerns/rns-cryptoparameters.h
@@ -177,8 +177,8 @@ public:
    *
    * @return number of extra bits needed for noise flooding
    */
-    static double EstimateMultipartyFloodingLogQ() {
-        return NoiseFlooding::MULTIPARTY_MOD_SIZE * NoiseFlooding::NUM_MODULI_MULTIPARTY;
+    static constexpr double EstimateMultipartyFloodingLogQ() {
+        return static_cast<double>(NoiseFlooding::MULTIPARTY_MOD_SIZE * NoiseFlooding::NUM_MODULI_MULTIPARTY);
     }
 
     /**

--- a/src/pke/include/schemerns/rns-cryptoparameters.h
+++ b/src/pke/include/schemerns/rns-cryptoparameters.h
@@ -157,9 +157,26 @@ public:
 
     virtual uint64_t FindAuxPrimeStep() const;
 
+    /*
+   * Estimates the extra modulus bitsize needed for hybrid key swithing (used for finding the minimum secure ring dimension).
+   *
+   * @param numPartQ number of digits in hybrid key switching
+   * @param firstModulusSize bit size of first modulus
+   * @param dcrtBits bit size for other moduli
+   * @param extraModulusSize bit size for extra modulus in FLEXIBLEAUTOEXT (CKKS and BGV only)
+   * @param numPrimes number of moduli witout extraModulus
+   * @param auxBits size of auxiliar moduli used for hybrid key switching
+   *
+   * @return log2 of the modulus and number of RNS limbs.
+   */
     static std::pair<double, uint32_t> EstimateLogP(uint32_t numPartQ, double firstModulusSize, double dcrtBits,
                                                     double extraModulusSize, uint32_t numPrimes, uint32_t auxBits);
 
+    /*
+   * Estimates the extra modulus bitsize needed for threshold FHE noise flooding (only for BGV and BFV)
+   *
+   * @return number of extra bits needed for noise flooding
+   */
     static double EstimateMultipartyFloodingLogQ() {
         return NoiseFlooding::MULTIPARTY_MOD_SIZE * NoiseFlooding::NUM_MODULI_MULTIPARTY;
     }

--- a/src/pke/lib/scheme/bfvrns/bfvrns-parametergeneration.cpp
+++ b/src/pke/lib/scheme/bfvrns/bfvrns-parametergeneration.cpp
@@ -117,7 +117,7 @@ bool ParameterGenerationBFVRNS::ParamsGenBFVRNS(std::shared_ptr<CryptoParameters
         }
         else {
             // takes into account the noise added during the threshold FHE instantiation of BFV
-            if ((multipartyMode == NOISE_FLOODING_MULTIPARTY))
+            if (multipartyMode == NOISE_FLOODING_MULTIPARTY)
                 logq += cryptoParamsBFVRNS->EstimateMultipartyFloodingLogQ();
             // adds logP in the case of HYBRID key switching
             if (ksTech == HYBRID) {
@@ -129,7 +129,7 @@ bool ParameterGenerationBFVRNS::ParamsGenBFVRNS(std::shared_ptr<CryptoParameters
                 logq += std::get<0>(hybridKSInfo);
             }
             return static_cast<double>(
-                StdLatticeParm::FindRingDim(distType, stdLevel, static_cast<usint>(std::ceil(logq))));
+                StdLatticeParm::FindRingDim(distType, stdLevel, static_cast<uint32_t>(std::ceil(logq))));
         }
     };
 
@@ -138,7 +138,7 @@ bool ParameterGenerationBFVRNS::ParamsGenBFVRNS(std::shared_ptr<CryptoParameters
             // conservative estimate for HYBRID to avoid the use of method of
             // iterative approximations; we do not know the number
             // of digits and moduli at this point and use upper bounds
-            double numTowers = ceil(static_cast<double>(logqPrev) / dcrtBits);
+            double numTowers = ceil(logqPrev / dcrtBits);
             return numTowers * (delta(n) * Berr + delta(n) * Bkey + 1.0) / 2.0;
         }
         else {

--- a/src/pke/lib/scheme/bfvrns/bfvrns-parametergeneration.cpp
+++ b/src/pke/lib/scheme/bfvrns/bfvrns-parametergeneration.cpp
@@ -373,6 +373,27 @@ bool ParameterGenerationBFVRNS::ParamsGenBFVRNS(std::shared_ptr<CryptoParameters
 
     cryptoParamsBFVRNS->PrecomputeCRTTables(ksTech, scalTech, encTech, multTech, numPartQ, auxBits, 0);
 
+    // Validate the ring dimension found using estimated logQ(P) against actual logQ(P)
+    if (stdLevel != HEStd_NotSet) {
+        uint32_t logActualQ = 0;
+        if (ksTech == HYBRID) {
+            logActualQ = cryptoParamsBFVRNS->GetParamsQP()->GetModulus().GetMSB();
+        }
+        else {
+            logActualQ = cryptoParamsBFVRNS->GetElementParams()->GetModulus().GetMSB();
+        }
+
+        uint32_t nActual = StdLatticeParm::FindRingDim(distType, stdLevel, logActualQ);
+        if (n < nActual) {
+            std::string errMsg("The ring dimension found using estimated logQ(P) [");
+            errMsg += std::to_string(n) + "] does does not meet security requirements. ";
+            errMsg += "Report this problem to OpenFHE developers and set the ring dimension manually to ";
+            errMsg += std::to_string(nActual) + ".";
+
+            OPENFHE_THROW(errMsg);
+        }
+    }
+
     return true;
 }
 

--- a/src/pke/lib/scheme/bgvrns/bgvrns-parametergeneration.cpp
+++ b/src/pke/lib/scheme/bgvrns/bgvrns-parametergeneration.cpp
@@ -455,12 +455,15 @@ bool ParameterGenerationBGVRNS::ParamsGenBGVRNS(std::shared_ptr<CryptoParameters
         auxTowers = std::get<1>(hybridKSInfo);
     }
 
-    // when the scaling technique is not FIXED_MANUAL, set a small value so that the rest of the logic could go through
+    // when the scaling technique is not FIXEDMANUAL (and not FLEXIBLEAUTOEXT),
+    // set a small value so that the rest of the logic could go through (this is a workaround)
+    // TODO we should uncouple the logic of FIXEDMANUAL and all FLEXIBLE MODES; some of the code above should be moved
+    // to the branch for FIXEDMANUAL
     if (qBound == 0)
         qBound = 20;
 
+    // HE Standards compliance logic/check
     uint32_t n = computeRingDimension(cryptoParams, qBound, cyclOrder);
-    // End HE Standards compliance logic/check
 
     uint32_t vecSize = (scalTech != FLEXIBLEAUTOEXT) ? numPrimes : numPrimes + 1;
     std::vector<NativeInteger> moduliQ(vecSize);
@@ -471,7 +474,10 @@ bool ParameterGenerationBGVRNS::ParamsGenBGVRNS(std::shared_ptr<CryptoParameters
         auto moduliInfo    = computeModuli(cryptoParams, n, evalAddCount, keySwitchCount, auxTowers, numPrimes);
         moduliQ            = std::get<0>(moduliInfo);
         uint32_t newQBound = std::get<1>(moduliInfo);
-        while (qBound < newQBound) {
+
+        // the counter makes sure the first iteration of the while loop is always run
+        uint32_t counter = 0;
+        while ((counter == 0) || (qBound < newQBound)) {
             qBound          = newQBound;
             n               = computeRingDimension(cryptoParams, newQBound, cyclOrder);
             auto moduliInfo = computeModuli(cryptoParams, n, evalAddCount, keySwitchCount, auxTowers, numPrimes);
@@ -487,6 +493,7 @@ bool ParameterGenerationBGVRNS::ParamsGenBGVRNS(std::shared_ptr<CryptoParameters
                     (scalTech == FLEXIBLEAUTOEXT) ? moduliQ.size() - 1 : moduliQ.size(), auxBits);
                 newQBound += std::get<0>(hybridKSInfo);
             }
+            counter++;
         }
         cyclOrder    = 2 * n;
         modulusOrder = getCyclicOrder(n, ptm, scalTech);
@@ -496,6 +503,7 @@ bool ParameterGenerationBGVRNS::ParamsGenBGVRNS(std::shared_ptr<CryptoParameters
         }
     }
     else {
+        // FIXEDMANUAL mode
         cyclOrder = 2 * n;
         // For ModulusSwitching to work we need the moduli to be also congruent to 1 modulo ptm
         usint plaintextModulus = ptm;

--- a/src/pke/lib/scheme/bgvrns/bgvrns-parametergeneration.cpp
+++ b/src/pke/lib/scheme/bgvrns/bgvrns-parametergeneration.cpp
@@ -445,7 +445,7 @@ bool ParameterGenerationBGVRNS::ParamsGenBGVRNS(std::shared_ptr<CryptoParameters
     uint32_t qBound    = firstModSize + (numPrimes - 1) * dcrtBits + extraModSize;
 
     // estimate the extra modulus Q needed for threshold FHE flooding
-    if ((multipartyMode == NOISE_FLOODING_MULTIPARTY))
+    if (multipartyMode == NOISE_FLOODING_MULTIPARTY)
         qBound += cryptoParamsBGVRNS->EstimateMultipartyFloodingLogQ();
     uint32_t auxTowers = 0;
     if (ksTech == HYBRID) {
@@ -475,15 +475,14 @@ bool ParameterGenerationBGVRNS::ParamsGenBGVRNS(std::shared_ptr<CryptoParameters
         moduliQ            = std::get<0>(moduliInfo);
         uint32_t newQBound = std::get<1>(moduliInfo);
 
-        // the counter makes sure the first iteration of the while loop is always run
-        uint32_t counter = 0;
-        while ((counter == 0) || (qBound < newQBound)) {
+        // the loop must be executed at least once
+        do {
             qBound          = newQBound;
             n               = computeRingDimension(cryptoParams, newQBound, cyclOrder);
             auto moduliInfo = computeModuli(cryptoParams, n, evalAddCount, keySwitchCount, auxTowers, numPrimes);
             moduliQ         = std::get<0>(moduliInfo);
             newQBound       = std::get<1>(moduliInfo);
-            if ((multipartyMode == NOISE_FLOODING_MULTIPARTY))
+            if (multipartyMode == NOISE_FLOODING_MULTIPARTY)
                 newQBound += cryptoParamsBGVRNS->EstimateMultipartyFloodingLogQ();
             if (ksTech == HYBRID) {
                 auto hybridKSInfo = CryptoParametersRNS::EstimateLogP(
@@ -493,8 +492,8 @@ bool ParameterGenerationBGVRNS::ParamsGenBGVRNS(std::shared_ptr<CryptoParameters
                     (scalTech == FLEXIBLEAUTOEXT) ? moduliQ.size() - 1 : moduliQ.size(), auxBits);
                 newQBound += std::get<0>(hybridKSInfo);
             }
-            counter++;
-        }
+        } while (qBound < newQBound);
+
         cyclOrder    = 2 * n;
         modulusOrder = getCyclicOrder(n, ptm, scalTech);
 

--- a/src/pke/lib/scheme/bgvrns/bgvrns-parametergeneration.cpp
+++ b/src/pke/lib/scheme/bgvrns/bgvrns-parametergeneration.cpp
@@ -608,6 +608,31 @@ bool ParameterGenerationBGVRNS::ParamsGenBGVRNS(std::shared_ptr<CryptoParameters
         cryptoParamsBGVRNS->SetEncodingParams(encodingParamsNew);
     }
     cryptoParamsBGVRNS->PrecomputeCRTTables(ksTech, scalTech, encTech, multTech, numPartQ, auxBits, 0);
+
+    // Validate the ring dimension found using estimated logQ(P) against actual logQ(P)
+    SecurityLevel stdLevel = cryptoParamsBGVRNS->GetStdLevel();
+    if (stdLevel != HEStd_NotSet) {
+        uint32_t logActualQ = 0;
+        if (ksTech == HYBRID) {
+            logActualQ = cryptoParamsBGVRNS->GetParamsQP()->GetModulus().GetMSB();
+        }
+        else {
+            logActualQ = cryptoParamsBGVRNS->GetElementParams()->GetModulus().GetMSB();
+        }
+
+        DistributionType distType = (cryptoParamsBGVRNS->GetSecretKeyDist() == GAUSSIAN) ? HEStd_error : HEStd_ternary;
+        uint32_t nActual          = StdLatticeParm::FindRingDim(distType, stdLevel, logActualQ);
+
+        if (n < nActual) {
+            std::string errMsg("The ring dimension found using estimated logQ(P) [");
+            errMsg += std::to_string(n) + "] does does not meet security requirements. ";
+            errMsg += "Report this problem to OpenFHE developers and set the ring dimension manually to ";
+            errMsg += std::to_string(nActual) + ".";
+
+            OPENFHE_THROW(errMsg);
+        }
+    }
+
     return true;
 }
 

--- a/src/pke/lib/scheme/ckksrns/ckksrns-parametergeneration.cpp
+++ b/src/pke/lib/scheme/ckksrns/ckksrns-parametergeneration.cpp
@@ -76,9 +76,12 @@ bool ParameterGenerationCKKSRNS::ParamsGenCKKSRNS(std::shared_ptr<CryptoParamete
     uint32_t auxBits       = AUXMODSIZE;
     uint32_t n             = cyclOrder / 2;
     uint32_t qBound        = firstModSize + (numPrimes - 1) * scalingModSize + extraModSize;
-    // Estimate ciphertext modulus Q bound (in case of GHS/HYBRID P*Q)
+
+    // Estimate ciphertext modulus Q*P bound (in case of HYBRID P*Q)
     if (ksTech == HYBRID) {
-        qBound += ceil(ceil(static_cast<double>(qBound) / numPartQ) / auxBits) * auxBits;
+        auto hybridKSInfo =
+            CryptoParametersRNS::EstimateLogP(numPartQ, firstModSize, scalingModSize, extraModSize, numPrimes, auxBits);
+        qBound += std::get<0>(hybridKSInfo);
     }
 
     // GAUSSIAN security constraint

--- a/src/pke/lib/scheme/ckksrns/ckksrns-parametergeneration.cpp
+++ b/src/pke/lib/scheme/ckksrns/ckksrns-parametergeneration.cpp
@@ -235,6 +235,27 @@ bool ParameterGenerationCKKSRNS::ParamsGenCKKSRNS(std::shared_ptr<CryptoParamete
 
     cryptoParamsCKKSRNS->PrecomputeCRTTables(ksTech, scalTech, encTech, multTech, numPartQ, auxBits, extraModSize);
 
+    // Validate the ring dimension found using estimated logQ(P) against actual logQ(P)
+    if (stdLevel != HEStd_NotSet) {
+        uint32_t logActualQ = 0;
+        if (ksTech == HYBRID) {
+            logActualQ = cryptoParamsCKKSRNS->GetParamsQP()->GetModulus().GetMSB();
+        }
+        else {
+            logActualQ = cryptoParamsCKKSRNS->GetElementParams()->GetModulus().GetMSB();
+        }
+
+        uint32_t nActual = StdLatticeParm::FindRingDim(distType, stdLevel, logActualQ);
+        if (n < nActual) {
+            std::string errMsg("The ring dimension found using estimated logQ(P) [");
+            errMsg += std::to_string(n) + "] does does not meet security requirements. ";
+            errMsg += "Report this problem to OpenFHE developers and set the ring dimension manually to ";
+            errMsg += std::to_string(nActual) + ".";
+
+            OPENFHE_THROW(errMsg);
+        }
+    }
+
     return true;
 }
 

--- a/src/pke/lib/schemerns/rns-cryptoparameters.cpp
+++ b/src/pke/lib/schemerns/rns-cryptoparameters.cpp
@@ -416,7 +416,7 @@ std::pair<double, uint32_t> CryptoParametersRNS::EstimateLogP(uint32_t numPartQ,
     if (extraModulusSize > 0)
         qi[sizeQ - 1] = extraModulusSize;
 
-    // std::cerr << "numPerPartQ = " << numPerPartQ << std::endl;
+    std::cerr << "numPerPartQ = " << numPerPartQ << std::endl;
 
     // Compute partitions of Q into numPartQ digits
     double maxBits = 0;
@@ -431,13 +431,13 @@ std::pair<double, uint32_t> CryptoParametersRNS::EstimateLogP(uint32_t numPartQ,
             maxBits = bits;
     }
 
-    // std::cerr << "maxBits = " << maxBits << std::endl;
+    std::cerr << "maxBits = " << maxBits << std::endl;
 
     // Select number of primes in auxiliary CRT basis
     uint32_t sizeP;
     sizeP = std::ceil(static_cast<double>(maxBits) / auxBits);
 
-    // std::cerr << "log P = " << sizeP * auxBits << std::endl;
+    std::cerr << "log P = " << sizeP * auxBits << std::endl;
 
     return std::make_pair(sizeP * auxBits, sizeP);
 }

--- a/src/pke/lib/schemerns/rns-cryptoparameters.cpp
+++ b/src/pke/lib/schemerns/rns-cryptoparameters.cpp
@@ -416,8 +416,6 @@ std::pair<double, uint32_t> CryptoParametersRNS::EstimateLogP(uint32_t numPartQ,
     if (extraModulusSize > 0)
         qi[sizeQ - 1] = extraModulusSize;
 
-    std::cerr << "numPerPartQ = " << numPerPartQ << std::endl;
-
     // Compute partitions of Q into numPartQ digits
     double maxBits = 0;
     for (uint32_t j = 0; j < numPartQ; j++) {
@@ -431,13 +429,9 @@ std::pair<double, uint32_t> CryptoParametersRNS::EstimateLogP(uint32_t numPartQ,
             maxBits = bits;
     }
 
-    std::cerr << "maxBits = " << maxBits << std::endl;
-
     // Select number of primes in auxiliary CRT basis
     uint32_t sizeP;
     sizeP = std::ceil(static_cast<double>(maxBits) / auxBits);
-
-    std::cerr << "log P = " << sizeP * auxBits << std::endl;
 
     return std::make_pair(sizeP * auxBits, sizeP);
 }

--- a/src/pke/lib/schemerns/rns-cryptoparameters.cpp
+++ b/src/pke/lib/schemerns/rns-cryptoparameters.cpp
@@ -394,8 +394,7 @@ std::pair<double, uint32_t> CryptoParametersRNS::EstimateLogP(uint32_t numPartQ,
     uint32_t sizeQ = numPrimes;
     if (extraModulusSize > 0)
         sizeQ++;
-    // std::cerr << "sizeQ = " << sizeQ << std::endl;
-    // std::cerr << "numPartQ = " << numPartQ << std::endl;
+
     // Compute ceil(sizeQ/m_numPartQ), the # of towers per digit
     uint32_t numPerPartQ = ceil(static_cast<double>(sizeQ) / numPartQ);
     if ((int32_t)(sizeQ - numPerPartQ * (numPartQ - 1)) <= 0) {

--- a/src/pke/lib/schemerns/rns-cryptoparameters.cpp
+++ b/src/pke/lib/schemerns/rns-cryptoparameters.cpp
@@ -395,9 +395,9 @@ std::pair<double, uint32_t> CryptoParametersRNS::EstimateLogP(uint32_t numPartQ,
     if (extraModulusSize > 0)
         sizeQ++;
 
-    // Compute ceil(sizeQ/m_numPartQ), the # of towers per digit
+    // Compute ceil(sizeQ/numPartQ), the # of towers per digit
     uint32_t numPerPartQ = ceil(static_cast<double>(sizeQ) / numPartQ);
-    if ((int32_t)(sizeQ - numPerPartQ * (numPartQ - 1)) <= 0) {
+    if ((uint32_t)(sizeQ - numPerPartQ * (numPartQ - 1)) <= 0) {
         auto str =
             "CryptoParametersRNS::EstimateLogP - HYBRID key "
             "switching parameters: Can't appropriately distribute " +

--- a/src/pke/lib/schemerns/rns-cryptoparameters.cpp
+++ b/src/pke/lib/schemerns/rns-cryptoparameters.cpp
@@ -70,14 +70,16 @@ void CryptoParametersRNS::PrecomputeCRTTables(KeySwitchTechnique ksTech, Scaling
     DiscreteFourierTransform::Initialize(n * 2, n / 2);
     ChineseRemainderTransformFTT<NativeVector>().PreCompute(rootsQ, 2 * n, moduliQ);
     if (m_ksTechnique == HYBRID) {
-        // Compute ceil(sizeQ/m_numPartQ), the # of towers per digit
-        uint32_t a = ceil(static_cast<double>(sizeQ) / numPartQ);
-        if ((int32_t)(sizeQ - a * (numPartQ - 1)) <= 0) {
-            auto str =
-                "CryptoParametersRNS::PrecomputeCRTTables - HYBRID key "
-                "switching parameters: Can't appropriately distribute " +
-                std::to_string(sizeQ) + " towers into " + std::to_string(numPartQ) +
-                " digits. Please select different number of digits.";
+        // numPartQ can not be zero as there is a division by numPartQ
+        if (numPartQ == 0)
+            OPENFHE_THROW("numPartQ is zero");
+
+        // Compute ceil(sizeQ/numPartQ), the # of towers per digit
+        uint32_t a = static_cast<uint32_t>(ceil(static_cast<double>(sizeQ) / numPartQ));
+        if (sizeQ <= (a * (numPartQ - 1))) {
+            auto str = "HYBRID key switching parameters: Can't appropriately distribute " + std::to_string(sizeQ) +
+                       " towers into " + std::to_string(numPartQ) +
+                       " digits. Please select different number of digits.";
             OPENFHE_THROW(str);
         }
 
@@ -122,16 +124,15 @@ void CryptoParametersRNS::PrecomputeCRTTables(KeySwitchTechnique ksTech, Scaling
                 std::make_shared<ILDCRTParams<BigInteger>>(params[0]->GetCyclotomicOrder(), moduli, roots);
         }
 
-        uint32_t sizeP;
         // Find number and size of individual special primes.
         uint32_t maxBits = moduliPartQ[0].GetLengthForBase(2);
-        for (usint j = 1; j < m_numPartQ; j++) {
+        for (uint32_t j = 1; j < m_numPartQ; j++) {
             uint32_t bits = moduliPartQ[j].GetLengthForBase(2);
             if (bits > maxBits)
                 maxBits = bits;
         }
         // Select number of primes in auxiliary CRT basis
-        sizeP              = ceil(static_cast<double>(maxBits) / auxBits);
+        uint32_t sizeP     = static_cast<uint32_t>(ceil(static_cast<double>(maxBits) / auxBits));
         uint64_t primeStep = FindAuxPrimeStep();
 
         // Choose special primes in auxiliary basis and compute their roots
@@ -143,7 +144,7 @@ void CryptoParametersRNS::PrecomputeCRTTables(KeySwitchTechnique ksTech, Scaling
         NativeInteger firstP = FirstPrime<NativeInteger>(auxBits, primeStep);
         NativeInteger pPrev  = firstP;
         BigInteger modulusP(1);
-        for (usint i = 0; i < sizeP; i++) {
+        for (uint32_t i = 0; i < sizeP; i++) {
             // The following loop makes sure that moduli in
             // P and Q are different
             bool foundInQ = false;
@@ -234,11 +235,11 @@ void CryptoParametersRNS::PrecomputeCRTTables(KeySwitchTechnique ksTech, Scaling
         }
 
         // Pre-compute compementary partitions for ModUp
-        uint32_t alpha = ceil(static_cast<double>(sizeQ) / m_numPartQ);
+        uint32_t alpha = static_cast<uint32_t>(ceil(static_cast<double>(sizeQ) / m_numPartQ));
         m_paramsComplPartQ.resize(sizeQ);
         m_modComplPartqBarrettMu.resize(sizeQ);
         for (int32_t l = sizeQ - 1; l >= 0; l--) {
-            uint32_t beta = ceil(static_cast<double>(l + 1) / alpha);
+            uint32_t beta = static_cast<uint32_t>(ceil(static_cast<double>(l + 1) / alpha));
             m_paramsComplPartQ[l].resize(beta);
             m_modComplPartqBarrettMu[l].resize(beta);
             for (uint32_t j = 0; j < beta; j++) {
@@ -305,8 +306,8 @@ void CryptoParametersRNS::PrecomputeCRTTables(KeySwitchTechnique ksTech, Scaling
         // Pre-compute QHat mod complementary partition qi's
         m_PartQlHatModp.resize(sizeQ);
         for (uint32_t l = 0; l < sizeQ; l++) {
-            uint32_t alpha = ceil(static_cast<double>(sizeQ) / m_numPartQ);
-            uint32_t beta  = ceil(static_cast<double>(l + 1) / alpha);
+            uint32_t alpha = static_cast<uint32_t>(ceil(static_cast<double>(sizeQ) / m_numPartQ));
+            uint32_t beta  = static_cast<uint32_t>(ceil(static_cast<double>(l + 1) / alpha));
             m_PartQlHatModp[l].resize(beta);
             for (uint32_t k = 0; k < beta; k++) {
                 auto paramsPartQ   = GetParamsPartQ(k)->GetParams();
@@ -391,46 +392,42 @@ uint64_t CryptoParametersRNS::FindAuxPrimeStep() const {
 std::pair<double, uint32_t> CryptoParametersRNS::EstimateLogP(uint32_t numPartQ, double firstModulusSize,
                                                               double dcrtBits, double extraModulusSize,
                                                               uint32_t numPrimes, uint32_t auxBits) {
-    uint32_t sizeQ = numPrimes;
+    // numPartQ can not be zero as there is a division by numPartQ
+    if (numPartQ == 0)
+        OPENFHE_THROW("numPartQ is zero");
+
+    size_t sizeQ = numPrimes;
     if (extraModulusSize > 0)
         sizeQ++;
 
     // Compute ceil(sizeQ/numPartQ), the # of towers per digit
-    uint32_t numPerPartQ = ceil(static_cast<double>(sizeQ) / numPartQ);
-    if ((uint32_t)(sizeQ - numPerPartQ * (numPartQ - 1)) <= 0) {
-        auto str =
-            "CryptoParametersRNS::EstimateLogP - HYBRID key "
-            "switching parameters: Can't appropriately distribute " +
-            std::to_string(sizeQ) + " towers into " + std::to_string(numPartQ) +
-            " digits. Please select different number of digits.";
+    size_t numPerPartQ = static_cast<size_t>(ceil(static_cast<double>(sizeQ) / numPartQ));
+    if (sizeQ <= (numPerPartQ * (numPartQ - 1))) {
+        auto str = "HYBRID key switching parameters: Can't appropriately distribute " + std::to_string(sizeQ) +
+                   " towers into " + std::to_string(numPartQ) + " digits. Please select different number of digits.";
         OPENFHE_THROW(str);
     }
 
-    // create a vector with bit sizes
-    std::vector<double> qi(sizeQ);
+    // create a vector with the same value of bit sizes
+    std::vector<double> qi(sizeQ, dcrtBits);
     qi[0] = firstModulusSize;
-    for (uint32_t i = 1; i < numPrimes; i++) {
-        qi[i] = dcrtBits;
-    }
     if (extraModulusSize > 0)
         qi[sizeQ - 1] = extraModulusSize;
 
     // Compute partitions of Q into numPartQ digits
     double maxBits = 0;
-    for (uint32_t j = 0; j < numPartQ; j++) {
-        auto startTower = j * numPerPartQ;
-        auto endTower   = ((j + 1) * numPerPartQ - 1 < sizeQ) ? (j + 1) * numPerPartQ - 1 : sizeQ - 1;
-        double bits     = 0.0;
-        for (uint32_t i = startTower; i <= endTower; i++) {
-            bits += qi[i];
-        }
+    for (size_t j = 0; j < numPartQ; ++j) {
+        size_t startTower = j * numPerPartQ;
+        size_t endTower   = ((j + 1) * numPerPartQ - 1 < sizeQ) ? (j + 1) * numPerPartQ - 1 : sizeQ - 1;
+
+        // sum qi elements qi[startTower] + ... + qi[endTower] inclusive. the end element should be qi.begin()+(endTower+1)
+        double bits = std::accumulate(qi.begin() + startTower, qi.begin() + (endTower + 1), 0.0);
         if (bits > maxBits)
             maxBits = bits;
     }
 
     // Select number of primes in auxiliary CRT basis
-    uint32_t sizeP;
-    sizeP = std::ceil(static_cast<double>(maxBits) / auxBits);
+    auto sizeP = static_cast<uint32_t>(std::ceil(maxBits / auxBits));
 
     return std::make_pair(sizeP * auxBits, sizeP);
 }

--- a/src/pke/unittest/UnitTestCoexistingCryptocontexts.cpp
+++ b/src/pke/unittest/UnitTestCoexistingCryptocontexts.cpp
@@ -58,7 +58,7 @@ protected:
 TEST_F(UTGENERAL_CRYPTOCONTEXTS, coexisting_ckks_cryptocontexts) {
     // Setup crypto context 1
     CCParams<CryptoContextCKKSRNS> parameters1;
-    parameters1.SetMultiplicativeDepth(5);
+    parameters1.SetMultiplicativeDepth(4);
     parameters1.SetScalingModSize(40);
     parameters1.SetRingDim(4096 * 4);
     parameters1.SetBatchSize(32);

--- a/src/pke/unittest/UnitTestCoexistingCryptocontexts.cpp
+++ b/src/pke/unittest/UnitTestCoexistingCryptocontexts.cpp
@@ -58,7 +58,7 @@ protected:
 TEST_F(UTGENERAL_CRYPTOCONTEXTS, coexisting_ckks_cryptocontexts) {
     // Setup crypto context 1
     CCParams<CryptoContextCKKSRNS> parameters1;
-    parameters1.SetMultiplicativeDepth(4);
+    parameters1.SetMultiplicativeDepth(2);
     parameters1.SetScalingModSize(40);
     parameters1.SetRingDim(4096 * 4);
     parameters1.SetBatchSize(32);


### PR DESCRIPTION
1. Added EstimateLogP and EstimateMultipartyFloodingLogQ
2. Updated the logic for BGV, BFV, and CKKS to use these methods prior to checking (finding) the ring dimension based on the LWE security tables