### PR TITLE
778 fix lmkcdey parameter sets

### DIFF
--- a/benchmark/src/binfhe-paramsets.cpp
+++ b/benchmark/src/binfhe-paramsets.cpp
@@ -1,0 +1,136 @@
+//==================================================================================
+// BSD 2-Clause License
+//
+// Copyright (c) 2014-2024, NJIT, Duality Technologies Inc. and other contributors
+//
+// All rights reserved.
+//
+// Author TPOC: contact@openfhe.org
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//==================================================================================
+
+#include "benchmark/benchmark.h"
+#include "binfhecontext.h"
+
+#include <random>
+
+using namespace lbcrypto;
+
+[[maybe_unused]] static void FHEW_BTKEYGEN(benchmark::State& state, BINFHE_PARAMSET s, BINFHE_METHOD m) {
+    auto cc = BinFHEContext();
+    cc.GenerateBinFHEContext(s, m);
+    for (auto _ : state)
+        cc.BTKeyGen(cc.KeyGen());
+}
+
+[[maybe_unused]] static void FHEW_ENCRYPT(benchmark::State& state, BINFHE_PARAMSET s, BINFHE_METHOD m) {
+    auto cc = BinFHEContext();
+    cc.GenerateBinFHEContext(s, m);
+    auto sk = cc.KeyGen();
+    auto x  = std::bind(std::uniform_int_distribution<LWEPlaintext>(0, 1), std::default_random_engine());
+    for (auto _ : state)
+        auto ct = cc.Encrypt(sk, x());
+}
+
+[[maybe_unused]] static void FHEW_NOT(benchmark::State& state, BINFHE_PARAMSET s, BINFHE_METHOD m) {
+    auto cc = BinFHEContext();
+    cc.GenerateBinFHEContext(s, m);
+    auto sk = cc.KeyGen();
+    auto x  = std::bind(std::uniform_int_distribution<LWEPlaintext>(0, 1), std::default_random_engine());
+    for (auto _ : state)
+        auto ct = cc.EvalNOT(cc.Encrypt(sk, x()));
+}
+
+[[maybe_unused]] static void FHEW_BINGATE2(benchmark::State& state, BINFHE_PARAMSET s, BINFHE_METHOD m, BINGATE g) {
+    auto cc = BinFHEContext();
+    cc.GenerateBinFHEContext(s, m);
+    auto sk = cc.KeyGen();
+    cc.BTKeyGen(sk);
+    auto x = std::bind(std::uniform_int_distribution<LWEPlaintext>(0, 1), std::default_random_engine());
+    for (auto _ : state)
+        auto ct = cc.EvalBinGate(g, cc.Encrypt(sk, x(), SMALL_DIM, 4), cc.Encrypt(sk, x(), SMALL_DIM, 4));
+}
+
+[[maybe_unused]] static void FHEW_BINGATE3(benchmark::State& state, BINFHE_PARAMSET s, BINFHE_METHOD m, BINGATE g) {
+    auto cc = BinFHEContext();
+    cc.GenerateBinFHEContext(s, m);
+    auto sk = cc.KeyGen();
+    cc.BTKeyGen(sk);
+    auto x = std::bind(std::uniform_int_distribution<LWEPlaintext>(0, 1), std::default_random_engine());
+    for (auto _ : state)
+        auto ct = cc.EvalBinGate(
+            g, std::vector<LWECiphertext>{cc.Encrypt(sk, x(), SMALL_DIM, 6), cc.Encrypt(sk, x(), SMALL_DIM, 6),
+                                          cc.Encrypt(sk, x(), SMALL_DIM, 6)});
+}
+
+[[maybe_unused]] static void FHEW_BINGATE4(benchmark::State& state, BINFHE_PARAMSET s, BINFHE_METHOD m, BINGATE g) {
+    auto cc = BinFHEContext();
+    cc.GenerateBinFHEContext(s, m);
+    auto sk = cc.KeyGen();
+    cc.BTKeyGen(sk);
+    auto x = std::bind(std::uniform_int_distribution<LWEPlaintext>(0, 1), std::default_random_engine());
+    for (auto _ : state)
+        auto ct = cc.EvalBinGate(
+            g, std::vector<LWECiphertext>{cc.Encrypt(sk, x(), SMALL_DIM, 8), cc.Encrypt(sk, x(), SMALL_DIM, 8),
+                                          cc.Encrypt(sk, x(), SMALL_DIM, 8), cc.Encrypt(sk, x(), SMALL_DIM, 8)});
+}
+
+// clang-format off
+BENCHMARK_CAPTURE(FHEW_BINGATE2, TOY_2_GINX_OR, TOY, GINX, OR)->Unit(benchmark::kMillisecond);
+BENCHMARK_CAPTURE(FHEW_BINGATE2, MEDIUM_2_GINX_OR, MEDIUM, GINX, OR)->Unit(benchmark::kMillisecond);
+BENCHMARK_CAPTURE(FHEW_BINGATE2, STD128_2_AP_OR, STD128_AP, AP, OR)->Unit(benchmark::kMillisecond);
+BENCHMARK_CAPTURE(FHEW_BINGATE2, STD128_2_GINX_OR, STD128, GINX, OR)->Unit(benchmark::kMillisecond);
+BENCHMARK_CAPTURE(FHEW_BINGATE3, STD128_3_GINX_OR, STD128_3, GINX, OR3)->Unit(benchmark::kMillisecond);
+BENCHMARK_CAPTURE(FHEW_BINGATE4, STD128_4_GINX_OR, STD128_4, GINX, OR4)->Unit(benchmark::kMillisecond);
+BENCHMARK_CAPTURE(FHEW_BINGATE2, STD128Q_2_GINX_OR, STD128Q, GINX, OR)->Unit(benchmark::kMillisecond);
+#if NATIVEINT >= 64
+BENCHMARK_CAPTURE(FHEW_BINGATE3, STD128Q_3_GINX_OR, STD128Q_3, GINX, OR3)->Unit(benchmark::kMillisecond);
+BENCHMARK_CAPTURE(FHEW_BINGATE4, STD128Q_4_GINX_OR, STD128Q_4, GINX, OR4)->Unit(benchmark::kMillisecond);
+BENCHMARK_CAPTURE(FHEW_BINGATE2, STD192_2_GINX_OR, STD192, GINX, OR)->Unit(benchmark::kMillisecond);
+BENCHMARK_CAPTURE(FHEW_BINGATE3, STD192_3_GINX_OR, STD192_3, GINX, OR3)->Unit(benchmark::kMillisecond);
+BENCHMARK_CAPTURE(FHEW_BINGATE4, STD192_4_GINX_OR, STD192_4, GINX, OR4)->Unit(benchmark::kMillisecond);
+BENCHMARK_CAPTURE(FHEW_BINGATE2, STD192Q_2_GINX_OR, STD192Q, GINX, OR)->Unit(benchmark::kMillisecond);
+BENCHMARK_CAPTURE(FHEW_BINGATE3, STD192Q_3_GINX_OR, STD192Q_3, GINX, OR3)->Unit(benchmark::kMillisecond);
+BENCHMARK_CAPTURE(FHEW_BINGATE4, STD192Q_4_GINX_OR, STD192Q_4, GINX, OR4)->Unit(benchmark::kMillisecond);
+BENCHMARK_CAPTURE(FHEW_BINGATE2, STD256_2_GINX_OR, STD256, GINX, OR)->Unit(benchmark::kMillisecond);
+BENCHMARK_CAPTURE(FHEW_BINGATE3, STD256_3_GINX_OR, STD256_3, GINX, OR3)->Unit(benchmark::kMillisecond);
+BENCHMARK_CAPTURE(FHEW_BINGATE4, STD256_4_GINX_OR, STD256_4, GINX, OR4)->Unit(benchmark::kMillisecond);
+#endif
+BENCHMARK_CAPTURE(FHEW_BINGATE2, STD256Q_2_GINX_OR, STD256Q, GINX, OR)->Unit(benchmark::kMillisecond);
+BENCHMARK_CAPTURE(FHEW_BINGATE3, STD256Q_3_GINX_OR, STD256Q_3, GINX, OR3)->Unit(benchmark::kMillisecond);
+BENCHMARK_CAPTURE(FHEW_BINGATE4, STD256Q_4_GINX_OR, STD256Q_4, GINX, OR4)->Unit(benchmark::kMillisecond);
+BENCHMARK_CAPTURE(FHEW_BINGATE2, STD128_2_LMKCDEY_OR, STD128_LMKCDEY, LMKCDEY, OR)->Unit(benchmark::kMillisecond);
+BENCHMARK_CAPTURE(FHEW_BINGATE2, STD128Q_2_LMKCDEY_OR, STD128Q_LMKCDEY, LMKCDEY, OR)->Unit(benchmark::kMillisecond);
+#if NATIVEINT >= 64
+BENCHMARK_CAPTURE(FHEW_BINGATE2, STD192_2_LMKCDEY_OR, STD192_LMKCDEY, LMKCDEY, OR)->Unit(benchmark::kMillisecond);
+BENCHMARK_CAPTURE(FHEW_BINGATE2, STD192Q_2_LMKCDEY_OR, STD192Q_LMKCDEY, LMKCDEY, OR)->Unit(benchmark::kMillisecond);
+BENCHMARK_CAPTURE(FHEW_BINGATE2, STD256_2_LMKCDEY_OR, STD256_LMKCDEY, LMKCDEY, OR)->Unit(benchmark::kMillisecond);
+#endif
+BENCHMARK_CAPTURE(FHEW_BINGATE2, STD256Q_2_LMKCDEY_OR, STD256Q_LMKCDEY, LMKCDEY, OR)->Unit(benchmark::kMillisecond);
+BENCHMARK_CAPTURE(FHEW_BINGATE2, LPF_STD128_2_GINX_OR, LPF_STD128, GINX, OR)->Unit(benchmark::kMillisecond);
+BENCHMARK_CAPTURE(FHEW_BINGATE2, LPF_STD128Q_2_GINX_OR, LPF_STD128Q, GINX, OR)->Unit(benchmark::kMillisecond);
+BENCHMARK_CAPTURE(FHEW_BINGATE2, LPF_STD128_2_LMKCDEY_OR, LPF_STD128_LMKCDEY, LMKCDEY, OR)->Unit(benchmark::kMillisecond);
+BENCHMARK_CAPTURE(FHEW_BINGATE2, LPF_STD128Q_2_LMKCDEY_OR, LPF_STD128Q_LMKCDEY, LMKCDEY, OR)->Unit(benchmark::kMillisecond);
+// clang-format on
+
+BENCHMARK_MAIN();

--- a/src/binfhe/examples/boolean-multi-input.cpp
+++ b/src/binfhe/examples/boolean-multi-input.cpp
@@ -42,7 +42,7 @@ int main() {
 
     auto cc = BinFHEContext();
 
-    cc.GenerateBinFHEContext(STD128_4_LMKCDEY, LMKCDEY);
+    cc.GenerateBinFHEContext(STD128_4, GINX);
 
     // Sample Program: Step 2: Key Generation
 

--- a/src/binfhe/include/binfhe-constants.h
+++ b/src/binfhe/include/binfhe-constants.h
@@ -46,59 +46,51 @@ using LWEPlaintextModulus = uint64_t;
  * @brief Security levels for predefined parameter sets
  */
 enum BINFHE_PARAMSET {
-    TOY,                // no security
-    MEDIUM,             // 108 bits of security for classical and 100 bits for quantum
-    STD128_LMKCDEY,     // Optimized for LMKCDEY (using Gaussian secrets) -
-                        // more than 128 bits of security for classical computer attacks -
-                        // optimize runtime by finding a non-power-of-two n
-    STD128_AP,          // Optimized for AP (has higher failure probability for GINX) -
-                        // more than 128 bits of security for classical computer attacks -
-                        // optimize runtime by finding a non-power-of-two n
-    STD128,             // more than 128 bits of security for classical computer attacks -
-                        // optimize runtime by finding a non-power-of-two n
-    STD192,             // more than 192 bits of security for classical computer attacks -
-                        // optimize runtime by finding a non-power-of-two n
-    STD256,             // more than 256 bits of security for classical computer attacks -
-                        // optimize runtime by finding a non-power-of-two n
-    STD128Q,            // more than 128 bits of security for quantum attacks -
-                        // optimize runtime by finding a non-power-of-two n
-    STD128Q_LMKCDEY,    // Optimized for LMKCDEY (using Gaussian secrets) -
-                        // more than 128 bits of security for quantum attacks -
-                        // optimize runtime by finding a non-power-of-two n
-    STD192Q,            // more than 192 bits of security for quantum attacks -
-                        // optimize runtime by finding a non-power-of-two n
-    STD256Q,            // more than 256 bits of security for quantum attacks -
-                        // optimize runtime by finding a non-power-of-two n
-    STD128_3,           // more than 128 bits of security for classical computer attacks -
-                        // optimize runtime by finding a non-power-of-two n for 3 binary inputs
-    STD128_3_LMKCDEY,   // Optimized for LMKCDEY (using Gaussian secrets) -
-                        // more than 128 bits of security for classical computer attacks -
-                        // optimize runtime by finding a non-power-of-two n for 3 binary inputs
-    STD128Q_3,          // more than 128 bits of security for quantum computer attacks -
-                        // optimize runtime by finding a non-power-of-two n for 3 binary inputs
-    STD128Q_3_LMKCDEY,  // Optimized for LMKCDEY (using Gaussian secrets) -
-                        // more than 128 bits of security for quantum computer attacks -
-                        // optimize runtime by finding a non-power-of-two n for 3 binary inputs
-    STD192Q_3,          // more than 192 bits of security for quantum computer attacks -
-                        // optimize runtime by finding a non-power-of-two n for 3 binary inputs
-    STD256Q_3,          // more than 256 bits of security for quantum computer attacks -
-                        // optimize runtime by finding a non-power-of-two n for 3 binary inputs
-    STD128_4,           // more than 128 bits of security for classical computer attacks -
-                        // optimize runtime by finding a non-power-of-two n for 4 binary inputs
-    STD128_4_LMKCDEY,   // Optimized for LMKCDEY (using Gaussian secrets) -
-                        // more than 128 bits of security for classical computer attacks -
-                        // optimize runtime by finding a non-power-of-two n for 4 binary inputs
-    STD128Q_4,          // more than 128 bits of security for quantum computer attacks -
-                        // optimize runtime by finding a non-power-of-two n for 4 binary inputs
-    STD128Q_4_LMKCDEY,  // Optimized for LMKCDEY (using Gaussian secrets) -
-                        // more than 128 bits of security for quantum computer attacks -
-                        // optimize runtime by finding a non-power-of-two n for 4 binary inputs
-    STD192Q_4,          // more than 192 bits of security for quantum computer attacks -
-                        // optimize runtime by finding a non-power-of-two n for 4 binary inputs
-    STD256Q_4,          // more than 256 bits of security for quantum computer attacks -
-                        // optimize runtime by finding a non-power-of-two n for 4 binary inputs
-    SIGNED_MOD_TEST     // special parameter set for confirming the signed modular
-                        // reduction in the accumulator updates works correctly
+    TOY,                  // no security
+    MEDIUM,               // 108 bits of security for classical and 100 bits for quantum
+    STD128_AP,            // more than 128 bits of security for classical computer attacks
+    STD128,               // more than 128 bits of security for classical computer attacks
+    STD128_3,             // STD128 for 3 binary inputs
+    STD128_4,             // STD128 for 4 binary inputs
+    STD128Q,              // more than 128 bits of security for quantum attacks
+    STD128Q_3,            // STD128Q for 3 binary inputs
+    STD128Q_4,            // STD128Q for 4 binary inputs
+    STD192,               // more than 192 bits of security for classical computer attacks
+    STD192_3,             // STD192 for 3 binary inputs
+    STD192_4,             // STD192 for 4 binary inputs
+    STD192Q,              // more than 192 bits of security for quantum attacks
+    STD192Q_3,            // STD192Q for 3 binary inputs
+    STD192Q_4,            // STD192Q for 4 binary inputs
+    STD256,               // more than 256 bits of security for classical computer attacks
+    STD256_3,             // STD256 for 3 binary inputs
+    STD256_4,             // STD256 for 4 binary inputs
+    STD256Q,              // more than 256 bits of security for quantum attacks
+    STD256Q_3,            // STD256Q for 3 binary inputs
+    STD256Q_4,            // STD256Q for 4 binary inputs
+    STD128_LMKCDEY,       // STD128 optimized for LMKCDEY (using Gaussian secrets)
+    STD128_3_LMKCDEY,     // STD128_3 optimized for LMKCDEY (using Gaussian secrets)
+    STD128_4_LMKCDEY,     // STD128_4 optimized for LMKCDEY (using Gaussian secrets)
+    STD128Q_LMKCDEY,      // STD128Q optimized for LMKCDEY (using Gaussian secrets)
+    STD128Q_3_LMKCDEY,    // STD128Q_3 optimized for LMKCDEY (using Gaussian secrets)
+    STD128Q_4_LMKCDEY,    // STD128Q_4 optimized for LMKCDEY (using Gaussian secrets)
+    STD192_LMKCDEY,       // STD192 optimized for LMKCDEY (using Gaussian secrets)
+    STD192_3_LMKCDEY,     // STD192_3 optimized for LMKCDEY (using Gaussian secrets)
+    STD192_4_LMKCDEY,     // STD192_4 optimized for LMKCDEY (using Gaussian secrets)
+    STD192Q_LMKCDEY,      // STD192Q optimized for LMKCDEY (using Gaussian secrets)
+    STD192Q_3_LMKCDEY,    // STD192Q_3 optimized for LMKCDEY (using Gaussian secrets)
+    STD192Q_4_LMKCDEY,    // STD192Q_4 optimized for LMKCDEY (using Gaussian secrets)
+    STD256_LMKCDEY,       // STD256 optimized for LMKCDEY (using Gaussian secrets)
+    STD256_3_LMKCDEY,     // STD256_3 optimized for LMKCDEY (using Gaussian secrets)
+    STD256_4_LMKCDEY,     // STD256_4 optimized for LMKCDEY (using Gaussian secrets)
+    STD256Q_LMKCDEY,      // STD256Q optimized for LMKCDEY (using Gaussian secrets)
+    STD256Q_3_LMKCDEY,    // STD256Q_3 optimized for LMKCDEY (using Gaussian secrets)
+    STD256Q_4_LMKCDEY,    // STD256Q_4 optimized for LMKCDEY (using Gaussian secrets)
+    LPF_STD128,           // STD128 configured with lower probability of failures (at least 2**-100)
+    LPF_STD128Q,          // STD128Q configured with lower probability of failures (at least 2**-100)
+    LPF_STD128_LMKCDEY,   // LPF_STD128 optimized for LMKCDEY (using Gaussian secrets)
+    LPF_STD128Q_LMKCDEY,  // LPF_STD128Q optimized for LMKCDEY (using Gaussian secrets)
+    SIGNED_MOD_TEST       // special parameter set for confirming the signed modular
+                          // reduction in the accumulator updates works correctly
 };
 std::ostream& operator<<(std::ostream& s, BINFHE_PARAMSET f);
 

--- a/src/binfhe/include/binfhe-constants.h
+++ b/src/binfhe/include/binfhe-constants.h
@@ -45,53 +45,44 @@ using LWEPlaintextModulus = uint64_t;
 /**
  * @brief Security levels for predefined parameter sets
  */
+// clang-format off
 enum BINFHE_PARAMSET {
-    TOY,                  // no security
-    MEDIUM,               // 108 bits of security for classical and 100 bits for quantum
-    STD128_AP,            // more than 128 bits of security for classical computer attacks
-    STD128,               // more than 128 bits of security for classical computer attacks
-    STD128_3,             // STD128 for 3 binary inputs
-    STD128_4,             // STD128 for 4 binary inputs
-    STD128Q,              // more than 128 bits of security for quantum attacks
-    STD128Q_3,            // STD128Q for 3 binary inputs
-    STD128Q_4,            // STD128Q for 4 binary inputs
-    STD192,               // more than 192 bits of security for classical computer attacks
-    STD192_3,             // STD192 for 3 binary inputs
-    STD192_4,             // STD192 for 4 binary inputs
-    STD192Q,              // more than 192 bits of security for quantum attacks
-    STD192Q_3,            // STD192Q for 3 binary inputs
-    STD192Q_4,            // STD192Q for 4 binary inputs
-    STD256,               // more than 256 bits of security for classical computer attacks
-    STD256_3,             // STD256 for 3 binary inputs
-    STD256_4,             // STD256 for 4 binary inputs
-    STD256Q,              // more than 256 bits of security for quantum attacks
-    STD256Q_3,            // STD256Q for 3 binary inputs
-    STD256Q_4,            // STD256Q for 4 binary inputs
-    STD128_LMKCDEY,       // STD128 optimized for LMKCDEY (using Gaussian secrets)
-    STD128_3_LMKCDEY,     // STD128_3 optimized for LMKCDEY (using Gaussian secrets)
-    STD128_4_LMKCDEY,     // STD128_4 optimized for LMKCDEY (using Gaussian secrets)
-    STD128Q_LMKCDEY,      // STD128Q optimized for LMKCDEY (using Gaussian secrets)
-    STD128Q_3_LMKCDEY,    // STD128Q_3 optimized for LMKCDEY (using Gaussian secrets)
-    STD128Q_4_LMKCDEY,    // STD128Q_4 optimized for LMKCDEY (using Gaussian secrets)
-    STD192_LMKCDEY,       // STD192 optimized for LMKCDEY (using Gaussian secrets)
-    STD192_3_LMKCDEY,     // STD192_3 optimized for LMKCDEY (using Gaussian secrets)
-    STD192_4_LMKCDEY,     // STD192_4 optimized for LMKCDEY (using Gaussian secrets)
-    STD192Q_LMKCDEY,      // STD192Q optimized for LMKCDEY (using Gaussian secrets)
-    STD192Q_3_LMKCDEY,    // STD192Q_3 optimized for LMKCDEY (using Gaussian secrets)
-    STD192Q_4_LMKCDEY,    // STD192Q_4 optimized for LMKCDEY (using Gaussian secrets)
-    STD256_LMKCDEY,       // STD256 optimized for LMKCDEY (using Gaussian secrets)
-    STD256_3_LMKCDEY,     // STD256_3 optimized for LMKCDEY (using Gaussian secrets)
-    STD256_4_LMKCDEY,     // STD256_4 optimized for LMKCDEY (using Gaussian secrets)
-    STD256Q_LMKCDEY,      // STD256Q optimized for LMKCDEY (using Gaussian secrets)
-    STD256Q_3_LMKCDEY,    // STD256Q_3 optimized for LMKCDEY (using Gaussian secrets)
-    STD256Q_4_LMKCDEY,    // STD256Q_4 optimized for LMKCDEY (using Gaussian secrets)
-    LPF_STD128,           // STD128 configured with lower probability of failures (at least 2**-100)
-    LPF_STD128Q,          // STD128Q configured with lower probability of failures (at least 2**-100)
-    LPF_STD128_LMKCDEY,   // LPF_STD128 optimized for LMKCDEY (using Gaussian secrets)
-    LPF_STD128Q_LMKCDEY,  // LPF_STD128Q optimized for LMKCDEY (using Gaussian secrets)
-    SIGNED_MOD_TEST       // special parameter set for confirming the signed modular
+//  NAME,                 // Description                                                     : Approximate Probability of Failure
+    TOY,                  // no security                                                     : 2^(-360)
+    MEDIUM,               // 108 bits of security for classical and 100 bits for quantum     : 2^(-70)
+    STD128_AP,            // more than 128 bits of security for classical computer attacks   : 2^(-50)
+    STD128,               // more than 128 bits of security for classical computer attacks   : 2^(-40)
+    STD128_3,             // STD128 for 3 binary inputs                                      : 2^(-50)
+    STD128_4,             // STD128 for 4 binary inputs                                      : 2^(-50)
+    STD128Q,              // more than 128 bits of security for quantum attacks              : 2^(-40)
+    STD128Q_3,            // STD128Q for 3 binary inputs                                     : 2^(-50)
+    STD128Q_4,            // STD128Q for 4 binary inputs                                     : 2^(-50)
+    STD192,               // more than 192 bits of security for classical computer attacks   : 2^(-40)
+    STD192_3,             // STD192 for 3 binary inputs                                      : 2^(-60)
+    STD192_4,             // STD192 for 4 binary inputs                                      : 2^(-70)
+    STD192Q,              // more than 192 bits of security for quantum attacks              : 2^(-80)
+    STD192Q_3,            // STD192Q for 3 binary inputs                                     : 2^(-80)
+    STD192Q_4,            // STD192Q for 4 binary inputs                                     : 2^(-50)
+    STD256,               // more than 256 bits of security for classical computer attacks   : 2^(-80)
+    STD256_3,             // STD256 for 3 binary inputs                                      : 2^(-70)
+    STD256_4,             // STD256 for 4 binary inputs                                      : 2^(-50)
+    STD256Q,              // more than 256 bits of security for quantum attacks              : 2^(-60)
+    STD256Q_3,            // STD256Q for 3 binary inputs                                     : 2^(-80)
+    STD256Q_4,            // STD256Q for 4 binary inputs                                     : 2^(-50)
+    STD128_LMKCDEY,       // STD128 optimized for LMKCDEY (using Gaussian secrets)           : 2^(-50)
+    STD128Q_LMKCDEY,      // STD128Q optimized for LMKCDEY (using Gaussian secrets)          : 2^(-50)
+    STD192_LMKCDEY,       // STD192 optimized for LMKCDEY (using Gaussian secrets)           : 2^(-60)
+    STD192Q_LMKCDEY,      // STD192Q optimized for LMKCDEY (using Gaussian secrets)          : 2^(-70)
+    STD256_LMKCDEY,       // STD256 optimized for LMKCDEY (using Gaussian secrets)           : 2^(-50)
+    STD256Q_LMKCDEY,      // STD256Q optimized for LMKCDEY (using Gaussian secrets)          : 2^(-60)
+    LPF_STD128,           // STD128 configured with lower probability of failures            : 2^(-120)
+    LPF_STD128Q,          // STD128Q configured with lower probability of failures           : 2^(-75)
+    LPF_STD128_LMKCDEY,   // LPF_STD128 optimized for LMKCDEY (using Gaussian secrets)       : 2^(-100)
+    LPF_STD128Q_LMKCDEY,  // LPF_STD128Q optimized for LMKCDEY (using Gaussian secrets)      : 2^(-90)
+    SIGNED_MOD_TEST       // special parameter set for confirming the signed modular         : 2^(-40)
                           // reduction in the accumulator updates works correctly
 };
+// clang-format on
 std::ostream& operator<<(std::ostream& s, BINFHE_PARAMSET f);
 
 /**

--- a/src/binfhe/include/binfhecontext.h
+++ b/src/binfhe/include/binfhecontext.h
@@ -116,7 +116,7 @@ public:
    * @param timeOptimization whether to use dynamic bootstrapping technique
    * @return creates the cryptocontext
    */
-    void GenerateBinFHEContext(BINFHE_PARAMSET set, bool arbFunc, uint32_t logQ = 11, int64_t N = 0,
+    void GenerateBinFHEContext(BINFHE_PARAMSET set, bool arbFunc, uint32_t logQ = 11, uint32_t N = 0,
                                BINFHE_METHOD method = GINX, bool timeOptimization = false);
 
     /**

--- a/src/binfhe/include/rgsw-cryptoparameters.h
+++ b/src/binfhe/include/rgsw-cryptoparameters.h
@@ -88,7 +88,7 @@ public:
           m_numAutoKeys(numAutoKeys) {
         if (!IsPowerOfTwo(baseG))
             OPENFHE_THROW("Gadget base should be a power of two.");
-        if ((method == LMKCDEY) & (numAutoKeys == 0))
+        if ((method == LMKCDEY) && (numAutoKeys == 0))
             OPENFHE_THROW("numAutoKeys should be greater than 0.");
         auto logQ{log(m_Q.ConvertToDouble())};
         m_digitsG = static_cast<uint32_t>(std::ceil(logQ / log(static_cast<double>(m_baseG))));

--- a/src/binfhe/lib/binfhe-constants-impl.cpp
+++ b/src/binfhe/lib/binfhe-constants-impl.cpp
@@ -118,6 +118,18 @@ std::ostream& operator<<(std::ostream& s, BINFHE_PARAMSET f) {
         case STD256Q_LMKCDEY:
             s << "STD256Q_LMKCDEY";
             break;
+        case LPF_STD128:
+            s << "LPF_STD128";
+            break;
+        case LPF_STD128Q:
+            s << "LPF_STD128Q";
+            break;
+        case LPF_STD128_LMKCDEY:
+            s << "LPF_STD128_LMKCDEY";
+            break;
+        case LPF_STD128Q_LMKCDEY:
+            s << "LPF_STD128Q_LMKCDEY";
+            break;
         case SIGNED_MOD_TEST:
             s << "SIGNED_MOD_TEST";
             break;

--- a/src/binfhe/lib/binfhe-constants-impl.cpp
+++ b/src/binfhe/lib/binfhe-constants-impl.cpp
@@ -103,56 +103,20 @@ std::ostream& operator<<(std::ostream& s, BINFHE_PARAMSET f) {
         case STD128_LMKCDEY:
             s << "STD128_LMKCDEY";
             break;
-        case STD128_3_LMKCDEY:
-            s << "STD128_3_LMKCDEY";
-            break;
-        case STD128_4_LMKCDEY:
-            s << "STD128_4_LMKCDEY";
-            break;
         case STD128Q_LMKCDEY:
             s << "STD128Q_LMKCDEY";
-            break;
-        case STD128Q_3_LMKCDEY:
-            s << "STD128Q_3_LMKCDEY";
-            break;
-        case STD128Q_4_LMKCDEY:
-            s << "STD128Q_4_LMKCDEY";
             break;
         case STD192_LMKCDEY:
             s << "STD192_LMKCDEY";
             break;
-        case STD192_3_LMKCDEY:
-            s << "STD192_3_LMKCDEY";
-            break;
-        case STD192_4_LMKCDEY:
-            s << "STD192_4_LMKCDEY";
-            break;
         case STD192Q_LMKCDEY:
             s << "STD192Q_LMKCDEY";
-            break;
-        case STD192Q_3_LMKCDEY:
-            s << "STD192Q_3_LMKCDEY";
-            break;
-        case STD192Q_4_LMKCDEY:
-            s << "STD192Q_4_LMKCDEY";
             break;
         case STD256_LMKCDEY:
             s << "STD256_LMKCDEY";
             break;
-        case STD256_3_LMKCDEY:
-            s << "STD256_3_LMKCDEY";
-            break;
-        case STD256_4_LMKCDEY:
-            s << "STD256_4_LMKCDEY";
-            break;
         case STD256Q_LMKCDEY:
             s << "STD256Q_LMKCDEY";
-            break;
-        case STD256Q_3_LMKCDEY:
-            s << "STD256Q_3_LMKCDEY";
-            break;
-        case STD256Q_4_LMKCDEY:
-            s << "STD256Q_4_LMKCDEY";
             break;
         case SIGNED_MOD_TEST:
             s << "SIGNED_MOD_TEST";

--- a/src/binfhe/lib/binfhe-constants-impl.cpp
+++ b/src/binfhe/lib/binfhe-constants-impl.cpp
@@ -43,68 +43,116 @@ std::ostream& operator<<(std::ostream& s, BINFHE_PARAMSET f) {
         case MEDIUM:
             s << "MEDIUM";
             break;
-        case STD128_LMKCDEY:
-            s << "STD128_LMKCDEY";
-            break;
         case STD128_AP:
             s << "STD128_AP";
             break;
         case STD128:
             s << "STD128";
             break;
-        case STD192:
-            s << "STD192";
-            break;
-        case STD256:
-            s << "STD256";
-            break;
-        case STD128Q:
-            s << "STD128Q";
-            break;
-        case STD128Q_LMKCDEY:
-            s << "STD128Q_LMKCDEY";
-            break;
-        case STD192Q:
-            s << "STD192Q";
-            break;
-        case STD256Q:
-            s << "STD256Q";
-            break;
         case STD128_3:
             s << "STD128_3";
-            break;
-        case STD128_3_LMKCDEY:
-            s << "STD128_3_LMKCDEY";
-            break;
-        case STD128Q_3:
-            s << "STD128Q_3";
-            break;
-        case STD128Q_3_LMKCDEY:
-            s << "STD128Q_3_LMKCDEY";
-            break;
-        case STD192Q_3:
-            s << "STD192Q_3";
-            break;
-        case STD256Q_3:
-            s << "STD256Q_3";
             break;
         case STD128_4:
             s << "STD128_4";
             break;
-        case STD128_4_LMKCDEY:
-            s << "STD128_4_LMKCDEY";
+        case STD128Q:
+            s << "STD128Q";
+            break;
+        case STD128Q_3:
+            s << "STD128Q_3";
             break;
         case STD128Q_4:
             s << "STD128Q_4";
             break;
-        case STD128Q_4_LMKCDEY:
-            s << "STD128Q_4_LMKCDEY";
+        case STD192:
+            s << "STD192";
+            break;
+        case STD192_3:
+            s << "STD192_3";
+            break;
+        case STD192_4:
+            s << "STD192_4";
+            break;
+        case STD192Q:
+            s << "STD192Q";
+            break;
+        case STD192Q_3:
+            s << "STD192Q_3";
             break;
         case STD192Q_4:
             s << "STD192Q_4";
             break;
+        case STD256:
+            s << "STD256";
+            break;
+        case STD256_3:
+            s << "STD256_3";
+            break;
+        case STD256_4:
+            s << "STD256_4";
+            break;
+        case STD256Q:
+            s << "STD256Q";
+            break;
+        case STD256Q_3:
+            s << "STD256Q_3";
+            break;
         case STD256Q_4:
             s << "STD256Q_4";
+            break;
+        case STD128_LMKCDEY:
+            s << "STD128_LMKCDEY";
+            break;
+        case STD128_3_LMKCDEY:
+            s << "STD128_3_LMKCDEY";
+            break;
+        case STD128_4_LMKCDEY:
+            s << "STD128_4_LMKCDEY";
+            break;
+        case STD128Q_LMKCDEY:
+            s << "STD128Q_LMKCDEY";
+            break;
+        case STD128Q_3_LMKCDEY:
+            s << "STD128Q_3_LMKCDEY";
+            break;
+        case STD128Q_4_LMKCDEY:
+            s << "STD128Q_4_LMKCDEY";
+            break;
+        case STD192_LMKCDEY:
+            s << "STD192_LMKCDEY";
+            break;
+        case STD192_3_LMKCDEY:
+            s << "STD192_3_LMKCDEY";
+            break;
+        case STD192_4_LMKCDEY:
+            s << "STD192_4_LMKCDEY";
+            break;
+        case STD192Q_LMKCDEY:
+            s << "STD192Q_LMKCDEY";
+            break;
+        case STD192Q_3_LMKCDEY:
+            s << "STD192Q_3_LMKCDEY";
+            break;
+        case STD192Q_4_LMKCDEY:
+            s << "STD192Q_4_LMKCDEY";
+            break;
+        case STD256_LMKCDEY:
+            s << "STD256_LMKCDEY";
+            break;
+        case STD256_3_LMKCDEY:
+            s << "STD256_3_LMKCDEY";
+            break;
+        case STD256_4_LMKCDEY:
+            s << "STD256_4_LMKCDEY";
+            break;
+        case STD256Q_LMKCDEY:
+            s << "STD256Q_LMKCDEY";
+            break;
+        case STD256Q_3_LMKCDEY:
+            s << "STD256Q_3_LMKCDEY";
+            break;
+        case STD256Q_4_LMKCDEY:
+            s << "STD256Q_4_LMKCDEY";
             break;
         case SIGNED_MOD_TEST:
             s << "SIGNED_MOD_TEST";

--- a/src/binfhe/lib/binfhecontext.cpp
+++ b/src/binfhe/lib/binfhecontext.cpp
@@ -51,7 +51,7 @@ void BinFHEContext::GenerateBinFHEContext(uint32_t n, uint32_t N, const NativeIn
     m_binfhescheme = std::make_shared<BinFHEScheme>(method);
 }
 
-void BinFHEContext::GenerateBinFHEContext(BINFHE_PARAMSET set, bool arbFunc, uint32_t logQ, int64_t N,
+void BinFHEContext::GenerateBinFHEContext(BINFHE_PARAMSET set, bool arbFunc, uint32_t logQ, uint32_t N,
                                           BINFHE_METHOD method, bool timeOptimization) {
     if (method != GINX)
         OPENFHE_THROW("CGGI is the only supported method");
@@ -81,7 +81,7 @@ void BinFHEContext::GenerateBinFHEContext(BINFHE_PARAMSET set, bool arbFunc, uin
     // choose minimum ringD satisfying sl and Q
     // if specified some larger N, security is also satisfied
     auto minRingDim  = StdLatticeParm::FindRingDim(HEStd_ternary, HEStd_128_classic, logQprime);
-    uint32_t ringDim = N > minRingDim ? N : minRingDim;  // TODO: why is N int64_t?
+    uint32_t ringDim = N > minRingDim ? N : minRingDim;
 
     // find prime Q for NTT
     NativeInteger Q = LastPrime<NativeInteger>(logQprime, 2 * ringDim);
@@ -105,46 +105,39 @@ void BinFHEContext::GenerateBinFHEContext(BINFHE_PARAMSET set, BINFHE_METHOD met
     enum { PRIME = 0 };  // value for modKS if you want to use the intermediate prime for modulus for key switching
     // clang-format off
     static const std::unordered_map<BINFHE_PARAMSET, BinFHEContextParams> paramsMap{
-    //  {BINFHE_PARAMSET       { numBits, cyclOrder, latParam, mod, modKS, stdDev, baseKS, gadgetBase, baseRK, numAutoKeys, keyDist }
-        { TOY,                 { 27, 1024,   64,  512,   PRIME, STD_DEV,  25,       512, 23,  9, UNIFORM_TERNARY } },
-        { MEDIUM,              { 28, 2048,  422, 1024,   16384, STD_DEV, 128,      1024, 32, 10, UNIFORM_TERNARY } },
-        { STD128_AP,           { 27, 2048,  503, 1024,   16384, STD_DEV,  32,       512, 32, 10, UNIFORM_TERNARY } },
-        { STD128,              { 27, 2048,  503, 1024,   16384, STD_DEV,  32,       512, 32, 10, UNIFORM_TERNARY } },
-        { STD128_3,            { 27, 2048,  595, 1024,   65536, STD_DEV,  64,       128, 32, 10, UNIFORM_TERNARY } },
-        { STD128_4,            { 27, 2048,  595, 2048,   65536, STD_DEV,  64,       128, 32, 10, UNIFORM_TERNARY } },
-        { STD128Q,             { 25, 2048,  534, 1024,   16384, STD_DEV,  32,       128, 32, 10, UNIFORM_TERNARY } },
-        { STD128Q_3,           { 50, 4096,  600, 2048,   32768, STD_DEV,  32,  33554432, 32, 10, UNIFORM_TERNARY } },
-        { STD128Q_4,           { 50, 4096,  641, 2048,   65536, STD_DEV,  64,  33554432, 32, 10, UNIFORM_TERNARY } },
-        { STD192,              { 37, 4096,  790, 2048,   16384, STD_DEV,  32,    524288, 32, 10, UNIFORM_TERNARY } },
-        { STD192_3,            { 37, 4096,  875, 4096,   65536, STD_DEV,  64,    524288, 32, 10, UNIFORM_TERNARY } },
-        { STD192_4,            { 37, 4096,  875, 4096,   65536, STD_DEV,  64,      8192, 32, 10, UNIFORM_TERNARY } },
-        { STD192Q,             { 35, 4096,  875, 1024,   32768, STD_DEV,  32,      4096, 32, 10, UNIFORM_TERNARY } },
-        { STD192Q_3,           { 34, 4096,  922, 2048,   65536, STD_DEV,  16,      4096, 32, 10, UNIFORM_TERNARY } },
-        { STD192Q_4,           { 34, 4096,  980, 2048,  131072, STD_DEV,  16,      4096, 32, 10, UNIFORM_TERNARY } },
-        { STD256,              { 29, 4096, 1076, 2048,   32768, STD_DEV,  32,      1024, 32, 10, UNIFORM_TERNARY } },
-        { STD256_3,            { 29, 4096, 1145, 2048,   65536, STD_DEV,  64,       256, 32, 10, UNIFORM_TERNARY } },
-        { STD256_4,            { 29, 4096, 1145, 4096,   65536, STD_DEV,  64,       256, 32, 10, UNIFORM_TERNARY } },
-        { STD256Q,             { 27, 4096, 1225, 1024,   65536, STD_DEV,  16,       128, 32, 10, UNIFORM_TERNARY } },
-        { STD256Q_3,           { 27, 4096, 1400, 4096,   65536, STD_DEV,  21,        64, 32, 10, UNIFORM_TERNARY } },
-        { STD256Q_4,           { 27, 4096, 1625, 4096, 2097152, STD_DEV,  16,        64, 32, 10, UNIFORM_TERNARY } },
-        { STD128_LMKCDEY,      { 28, 2048,  447, 2048,   16384, STD_DEV,  32,      1024, 32, 10,        GAUSSIAN } },
-        { STD128_3_LMKCDEY,    { 56, 4096,  485, 4096,   32768, STD_DEV,  32, 268435456, 32, 10,        GAUSSIAN } },
-        { STD128_4_LMKCDEY,    { 56, 4096,  523, 4096,   65536, STD_DEV,  64,    524288, 32, 10,        GAUSSIAN } },
-        { STD128Q_LMKCDEY,     { 27, 2048,  483, 2048,   16384, STD_DEV,  32,       512, 32, 10,        GAUSSIAN } },
-        { STD128Q_3_LMKCDEY,   { 52, 4096,  524, 4096,   32768, STD_DEV,  32,  67108864, 32, 10,        GAUSSIAN } },
-        { STD128Q_4_LMKCDEY,   { 52, 4096,  565, 4096,   65536, STD_DEV,  64,      8192, 32, 10,        GAUSSIAN } },
-        { STD192_LMKCDEY,      { 39, 4096,  716, 2048,   32768, STD_DEV,  32,   1048576, 32, 10,        GAUSSIAN } },
-        { STD192_3_LMKCDEY,    { 39, 4096,  771, 4096,   65536, STD_DEV,  64,   1048576, 32, 10,        GAUSSIAN } },
-        { STD192_4_LMKCDEY,    { 39, 4096,  771, 4096,   65536, STD_DEV,  64,      8192, 32, 10,        GAUSSIAN } },
-        { STD192Q_LMKCDEY,     { 36, 4096,  776, 4096,   32768, STD_DEV,  32,    262144, 32, 10,        GAUSSIAN } },
-        { STD192Q_3_LMKCDEY,   { 36, 4096,  776, 4096,   32768, STD_DEV,  32,      4096, 32, 10,        GAUSSIAN } },
-        { STD256_LMKCDEY,      { 30, 4096,  939, 2048,   32768, STD_DEV,  32,      1024, 32, 10,        GAUSSIAN } },
-        { STD256Q_LMKCDEY,     { 28, 4096, 1019, 4096,   32768, STD_DEV,  32,      1024, 32, 10,        GAUSSIAN } },
-        { LPF_STD128,          { 27, 2048,  556, 1024,   32768, STD_DEV,  32,       128, 32, 10, UNIFORM_TERNARY } },
-        { LPF_STD128Q,         { 25, 2048,  645, 2048,   65536, STD_DEV,  64,       128, 32, 10, UNIFORM_TERNARY } },
-        { LPF_STD128_LMKCDEY,  { 28, 2048,  593, 2048,  131072, STD_DEV,  64,        64, 32, 10,        GAUSSIAN } },
-        { LPF_STD128Q_LMKCDEY, { 27, 2048,  662, 2048,  262144, STD_DEV,  64,        64, 32, 10,        GAUSSIAN } },
-        { SIGNED_MOD_TEST,     { 28, 2048,  512, 1024,   PRIME, STD_DEV,  25,       128, 23, 10,  UNIFORM_TERNARY} },
+    //  { BINFHE_PARAMSET      { bits, cycOrder, latParam, modq,   modKS,  stdDev, Bks,        Bg, Brk, autoKeys,         keyDist } },
+        { TOY,                 {   27,     1024,       64,  512,   PRIME, STD_DEV,  25,       512,  23,        9, UNIFORM_TERNARY } },
+        { MEDIUM,              {   28,     2048,      422, 1024,   16384, STD_DEV, 128,      1024,  32,       10, UNIFORM_TERNARY } },
+        { STD128_AP,           {   27,     2048,      503, 1024,   16384, STD_DEV,  32,       512,  32,       10, UNIFORM_TERNARY } },
+        { STD128,              {   27,     2048,      503, 1024,   16384, STD_DEV,  32,       512,  32,       10, UNIFORM_TERNARY } },
+        { STD128_3,            {   27,     2048,      595, 1024,   65536, STD_DEV,  64,       128,  32,       10, UNIFORM_TERNARY } },
+        { STD128_4,            {   27,     2048,      595, 2048,   65536, STD_DEV,  64,       128,  32,       10, UNIFORM_TERNARY } },
+        { STD128Q,             {   25,     2048,      534, 1024,   16384, STD_DEV,  32,       128,  32,       10, UNIFORM_TERNARY } },
+        { STD128Q_3,           {   50,     4096,      600, 2048,   32768, STD_DEV,  32,  33554432,  32,       10, UNIFORM_TERNARY } },
+        { STD128Q_4,           {   50,     4096,      641, 2048,   65536, STD_DEV,  64,  33554432,  32,       10, UNIFORM_TERNARY } },
+        { STD192,              {   37,     4096,      790, 2048,   16384, STD_DEV,  32,    524288,  32,       10, UNIFORM_TERNARY } },
+        { STD192_3,            {   37,     4096,      875, 4096,   65536, STD_DEV,  64,    524288,  32,       10, UNIFORM_TERNARY } },
+        { STD192_4,            {   37,     4096,      875, 4096,   65536, STD_DEV,  64,      8192,  32,       10, UNIFORM_TERNARY } },
+        { STD192Q,             {   35,     4096,      875, 1024,   32768, STD_DEV,  32,      4096,  32,       10, UNIFORM_TERNARY } },
+        { STD192Q_3,           {   34,     4096,      922, 2048,   65536, STD_DEV,  16,      4096,  32,       10, UNIFORM_TERNARY } },
+        { STD192Q_4,           {   34,     4096,      980, 2048,  131072, STD_DEV,  16,      4096,  32,       10, UNIFORM_TERNARY } },
+        { STD256,              {   29,     4096,     1076, 2048,   32768, STD_DEV,  32,      1024,  32,       10, UNIFORM_TERNARY } },
+        { STD256_3,            {   29,     4096,     1145, 2048,   65536, STD_DEV,  64,       256,  32,       10, UNIFORM_TERNARY } },
+        { STD256_4,            {   29,     4096,     1145, 4096,   65536, STD_DEV,  64,       256,  32,       10, UNIFORM_TERNARY } },
+        { STD256Q,             {   27,     4096,     1225, 1024,   65536, STD_DEV,  16,       128,  32,       10, UNIFORM_TERNARY } },
+        { STD256Q_3,           {   27,     4096,     1400, 4096,   65536, STD_DEV,  21,        64,  32,       10, UNIFORM_TERNARY } },
+        { STD256Q_4,           {   27,     4096,     1625, 4096, 2097152, STD_DEV,  16,        64,  32,       10, UNIFORM_TERNARY } },
+        { STD128_LMKCDEY,      {   28,     2048,      447, 2048,   16384, STD_DEV,  32,      1024,  32,       10,        GAUSSIAN } },
+        { STD128Q_LMKCDEY,     {   27,     2048,      483, 2048,   16384, STD_DEV,  32,       512,  32,       10,        GAUSSIAN } },
+        { STD192_LMKCDEY,      {   39,     4096,      716, 2048,   32768, STD_DEV,  32,   1048576,  32,       10,        GAUSSIAN } },
+        { STD192Q_LMKCDEY,     {   36,     4096,      776, 4096,   32768, STD_DEV,  32,    262144,  32,       10,        GAUSSIAN } },
+        { STD256_LMKCDEY,      {   30,     4096,      939, 2048,   32768, STD_DEV,  32,      1024,  32,       10,        GAUSSIAN } },
+        { STD256Q_LMKCDEY,     {   28,     4096,     1019, 4096,   32768, STD_DEV,  32,      1024,  32,       10,        GAUSSIAN } },
+        { LPF_STD128,          {   27,     2048,      556, 1024,   32768, STD_DEV,  32,       128,  32,       10, UNIFORM_TERNARY } },
+        { LPF_STD128Q,         {   25,     2048,      645, 2048,   65536, STD_DEV,  64,       128,  32,       10, UNIFORM_TERNARY } },
+        { LPF_STD128_LMKCDEY,  {   28,     2048,      593, 2048,  131072, STD_DEV,  64,        64,  32,       10,        GAUSSIAN } },
+        { LPF_STD128Q_LMKCDEY, {   27,     2048,      662, 2048,  262144, STD_DEV,  64,        64,  32,       10,        GAUSSIAN } },
+        { SIGNED_MOD_TEST,     {   28,     2048,      512, 1024,   PRIME, STD_DEV,  25,       128,  23,       10,  UNIFORM_TERNARY} },
     };
     // clang-format on
 

--- a/src/binfhe/lib/binfhecontext.cpp
+++ b/src/binfhe/lib/binfhecontext.cpp
@@ -141,16 +141,16 @@ void BinFHEContext::GenerateBinFHEContext(BINFHE_PARAMSET set, BINFHE_METHOD met
         { STD256_LMKCDEY,      { 30, 4096,  939, 2048,   32768, STD_DEV,  32,      1024, 32, 10,        GAUSSIAN } },
         { STD256Q_LMKCDEY,     { 28, 4096, 1019, 4096,   32768, STD_DEV,  32,      1024, 32, 10,        GAUSSIAN } },
         { LPF_STD128,          { 27, 2048,  556, 1024,   32768, STD_DEV,  32,       128, 32, 10, UNIFORM_TERNARY } },
-        { LPF_STD128Q,         { 50, 4096,  600, 2048,   32768, STD_DEV,  32,    131072, 32, 10, UNIFORM_TERNARY } },
-        { LPF_STD128_LMKCDEY,  { 56, 4096,  485, 4096,   32768, STD_DEV,  32, 268435456, 32, 10,        GAUSSIAN } },
-        { LPF_STD128Q_LMKCDEY, { 52, 4096,  524, 4096,   32768, STD_DEV,  32,  67108864, 32, 10,        GAUSSIAN } },
+        { LPF_STD128Q,         { 25, 2048,  645, 2048,   65536, STD_DEV,  64,       128, 32, 10, UNIFORM_TERNARY } },
+        { LPF_STD128_LMKCDEY,  { 28, 2048,  593, 2048,  131072, STD_DEV,  64,        64, 32, 10,        GAUSSIAN } },
+        { LPF_STD128Q_LMKCDEY, { 27, 2048,  662, 2048,  262144, STD_DEV,  64,        64, 32, 10,        GAUSSIAN } },
         { SIGNED_MOD_TEST,     { 28, 2048,  512, 1024,   PRIME, STD_DEV,  25,       128, 23, 10,  UNIFORM_TERNARY} },
     };
     // clang-format on
 
     auto search = paramsMap.find(set);
     if (paramsMap.end() == search)
-        OPENFHE_THROW("Unknown parameter set");
+        OPENFHE_THROW("unknown parameter set");
     auto& params = search->second;
 
     auto Q         = LastPrime<NativeInteger>(params.numberBits, params.cyclOrder);
@@ -235,7 +235,7 @@ LWECiphertext BinFHEContext::Encrypt(ConstLWEPublicKey& pk, LWEPlaintext m, BINF
 LWECiphertext BinFHEContext::SwitchCTtoqn(ConstLWESwitchingKey& ksk, ConstLWECiphertext& ct) const {
     auto&& LWEParams = m_params->GetLWEParams();
     if ((ct->GetLength() != LWEParams->GetN()) && (ct->GetModulus() != LWEParams->GetQ()))
-        OPENFHE_THROW("Ciphertext dimension and modulus are not large N and Q");
+        OPENFHE_THROW("ciphertext dimension and modulus are not large N and Q");
     return m_LWEscheme->SwitchCTtoqn(LWEParams, ksk, ct);
 }
 

--- a/src/binfhe/lib/binfhecontext.cpp
+++ b/src/binfhe/lib/binfhecontext.cpp
@@ -316,11 +316,10 @@ std::vector<NativeInteger> BinFHEContext::GenerateLUTviaFunction(NativeInteger (
     NativeInteger x{0};
 
     std::vector<NativeInteger> vec(q.ConvertToInt(), q / p);
-    for (auto&& v : vec) {
-        v *= f(x / q, p);
-        if (v >= q)
+    for (size_t i = 0; i < vec.size(); ++i, x += p) {
+        vec[i] *= f(x / q, p);  // x/q = (i*p)/q = i/(q/p)
+        if (vec[i] >= q)        // (f(x/q, p) >= p) --> (f(x/q, p)*(q/p) >= q)
             OPENFHE_THROW("input function should output in Z_{p_output}");
-        x += p;
     }
     return vec;
 }

--- a/src/binfhe/lib/binfhecontext.cpp
+++ b/src/binfhe/lib/binfhecontext.cpp
@@ -126,7 +126,7 @@ void BinFHEContext::GenerateBinFHEContext(BINFHE_PARAMSET set, BINFHE_METHOD met
         { STD192,            { 37,     4096,         805, 1024, 1 << 15, STD_DEV,     32,    1 << 13,  32,    10,  UNIFORM_TERNARY} },
         { STD256,            { 29,     4096,         990, 2048, 1 << 14, STD_DEV, 1 << 7,    1 <<  8,  46,    10,  UNIFORM_TERNARY} },
         { STD128Q,           { 25,     2048,         534, 1024, 1 << 14, STD_DEV,     32,    1 <<  7,  32,    10,  UNIFORM_TERNARY} },
-        { STD128Q_LMKCDEY,   { 27,     2048,         448, 1024, 1 << 13, STD_DEV,     32,    1 <<  9,  32,    10,  GAUSSIAN       } },
+        { STD128Q_LMKCDEY,   { 27,     2048,         448, 2048, 1 << 13, STD_DEV,     32,    1 <<  9,  32,    10,  GAUSSIAN       } },
         { STD192Q,           { 35,     4096,         875, 1024, 1 << 15, STD_DEV,     32,    1 << 12,  32,    10,  UNIFORM_TERNARY} },
         { STD256Q,           { 27,     4096,        1225, 1024, 1 << 16, STD_DEV,     16,    1 <<  7,  32,    10,  UNIFORM_TERNARY} },
         { STD128_3,          { 27,     2048,         541, 1024, 1 << 15, STD_DEV,     32,    1 <<  7,  32,    10,  UNIFORM_TERNARY} },


### PR DESCRIPTION
- modified default LMKCDEY param sets to lower expected probability of failure (2**-20 --> 2**-40)
- added LPF-qualified BINFHE_PARAMSETs for STD128 and STD128Q with very low probability of failure (e.g., 2**-120 for LPF_STD128)
- added approximate probability of failure to BINFHE_PARAMSET descriptions
- added binfhe-paramsets benchmark
- fixed small bug in rgsw-cryptoparameters.h
- changed data type for N in GenerateBinFHEContext() from innt64_t to uint32_t
- cleaned up binfhecontext.cpp
- modified implementation for BinFHEContext::GenerateLUTviaFunction()