### PR TITLE
clang-specific compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,10 +154,6 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     message (STATUS "BUILTIN_INFO_AVAILABLE is defined")
 endif()
 
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
-    set(IGNORE_WARNINGS "${IGNORE_WARNINGS} -Wno-unused-private-field -Wno-shift-op-parentheses")
-endif()
-
 if( WITH_NATIVEOPT )
     set (NATIVE_OPT "-march=native")
 else()

--- a/src/binfhe/lib/binfhe-base-scheme.cpp
+++ b/src/binfhe/lib/binfhe-base-scheme.cpp
@@ -309,7 +309,7 @@ LWECiphertext BinFHEScheme::EvalFunc(const std::shared_ptr<BinFHECryptoParams>& 
 LWECiphertext BinFHEScheme::EvalFloor(const std::shared_ptr<BinFHECryptoParams>& params, const RingGSWBTKey& EK,
                                       ConstLWECiphertext& ct, const NativeInteger& beta, uint32_t roundbits) const {
     const auto& LWEParams = params->GetLWEParams();
-    NativeInteger q{roundbits == 0 ? LWEParams->Getq() : beta * (1 << roundbits + 1)};
+    NativeInteger q{roundbits == 0 ? LWEParams->Getq() : beta * (1 << (roundbits + 1))};
     NativeInteger mod{ct->GetModulus()};
 
     auto ct1 = std::make_shared<LWECiphertextImpl>(*ct);

--- a/src/core/include/math/hal/intnat/ubintnat.h
+++ b/src/core/include/math/hal/intnat/ubintnat.h
@@ -1143,7 +1143,7 @@ public:
         MultD(av.m_value, bv.m_value, tmp);
         auto rv = GetD(tmp);
         MultD(RShiftD(tmp, n), mu.m_value, tmp);
-        rv -= DNativeInt(mv) * (GetD(tmp) >> n + 7);
+        rv -= DNativeInt(mv) * (GetD(tmp) >> (n + 7));
         NativeIntegerT r(rv);
         if (r.m_value >= mv)
             r.m_value -= mv;
@@ -1211,7 +1211,7 @@ public:
         MultD(av.m_value, bv.m_value, tmp);
         auto rv = GetD(tmp);
         MultD(RShiftD(tmp, n), muv, tmp);
-        rv -= DNativeInt(mv) * (GetD(tmp) >> n + 7);
+        rv -= DNativeInt(mv) * (GetD(tmp) >> (n + 7));
         m_value = static_cast<NativeInt>(rv);
         if (m_value >= mv)
             m_value -= mv;
@@ -1358,7 +1358,7 @@ public:
         MultD(m_value, b.m_value, tmp);
         auto rv = GetD(tmp);
         MultD(RShiftD(tmp, n), mu.m_value, tmp);
-        rv -= DNativeInt(mv) * (GetD(tmp) >> n + 7);
+        rv -= DNativeInt(mv) * (GetD(tmp) >> (n + 7));
         NativeIntegerT r(rv);
         if (r.m_value >= mv)
             r.m_value -= mv;
@@ -1399,7 +1399,7 @@ public:
         int64_t n{modulus.GetMSB() - 2};
         MultD(RShiftD(tmp, n), mu.m_value, tmp);
         auto& mv{modulus.m_value};
-        rv -= DNativeInt(mv) * (GetD(tmp) >> n + 7);
+        rv -= DNativeInt(mv) * (GetD(tmp) >> (n + 7));
         m_value = NativeInt(rv);
         if (m_value >= mv)
             m_value -= mv;
@@ -2051,7 +2051,7 @@ private:
                       typename std::enable_if_t<!std::is_same_v<T, DNativeInt>, bool> = true) {
         prod = {0, a.m_value};
         MultD(RShiftD(prod, n), mu, prod);
-        a.m_value -= static_cast<NativeInt>((GetD(prod) >> n + 7) * mv);
+        a.m_value -= static_cast<NativeInt>((GetD(prod) >> (n + 7)) * mv);
         if (a.m_value >= mv)
             a.m_value -= mv;
     }

--- a/src/pke/unittest/utbgvrns/UnitTestBGVrnsAdvancedSHE.cpp
+++ b/src/pke/unittest/utbgvrns/UnitTestBGVrnsAdvancedSHE.cpp
@@ -119,8 +119,7 @@ static std::vector<TEST_CASE_UTBGVRNS_SHEADVANCED> testCasesUTBGVRNS_SHEADVANCED
 // clang-format on
 //===========================================================================================================
 class UTBGVRNS_SHEADVANCED : public ::testing::TestWithParam<TEST_CASE_UTBGVRNS_SHEADVANCED> {
-    using Element    = DCRTPoly;
-    const double eps = EPSILON;
+    using Element = DCRTPoly;
 
 protected:
     void SetUp() {}


### PR DESCRIPTION
[fix for -Wshift-op-parentheses warning in ubintnat.h](https://github.com/openfheorg/openfhe-development/issues/823)