### PR TITLE
Clear polynomials during CKKS decryption

### DIFF
--- a/src/pke/lib/encoding/ckkspackedencoding.cpp
+++ b/src/pke/lib/encoding/ckkspackedencoding.cpp
@@ -457,6 +457,9 @@ bool CKKSPackedEncoding::Decode(size_t noiseScaleDeg, double scalingFactor, Scal
 
             curValues[i] = cur;
         }
+
+        // clears the values containing information about the noise
+        GetElement<NativePoly>().SetValuesToZero();
     }
     else {
         powP = pow(2, -p);
@@ -486,6 +489,9 @@ bool CKKSPackedEncoding::Decode(size_t noiseScaleDeg, double scalingFactor, Scal
 
             curValues[i] = cur;
         }
+
+        // clears the values containing information about the noise
+        GetElement<Poly>().SetValuesToZero();
     }
 
     // the code below adds a Gaussian noise to the decrypted result


### PR DESCRIPTION
Removes the integer values of polynomials so that the user could only access the floating-point values