### PR TITLE
Binfhe extended

### DIFF
--- a/benchmark/src/binfhe-ap.cpp
+++ b/benchmark/src/binfhe-ap.cpp
@@ -72,7 +72,7 @@ void FHEW_ENCRYPT(benchmark::State& state, ParamSet param_set) {
 
     LWEPrivateKey sk = cc.KeyGen();
     for (auto _ : state) {
-        LWECiphertext ct1 = cc.Encrypt(sk, 1, FRESH);
+        LWECiphertext ct1 = cc.Encrypt(sk, 1, SMALL_DIM);
     }
 }
 
@@ -87,7 +87,7 @@ void FHEW_NOT(benchmark::State& state, ParamSet param_set) {
 
     LWEPrivateKey sk = cc.KeyGen();
 
-    LWECiphertext ct1 = cc.Encrypt(sk, 1, FRESH);
+    LWECiphertext ct1 = cc.Encrypt(sk, 1, SMALL_DIM);
 
     for (auto _ : state) {
         LWECiphertext ct11 = cc.EvalNOT(ct1);
@@ -163,7 +163,7 @@ void FHEW_KEYSWITCH(benchmark::State& state, ParamSet param_set) {
     LWEPrivateKey sk  = cc.KeyGen();
     LWEPrivateKey skN = cc.KeyGenN();
 
-    auto ctQN1         = cc.Encrypt(skN, 1, FRESH);
+    auto ctQN1         = cc.Encrypt(skN, 1, SMALL_DIM);
     auto keySwitchHint = cc.KeySwitchGen(sk, skN);
 
     for (auto _ : state) {

--- a/benchmark/src/binfhe-ginx.cpp
+++ b/benchmark/src/binfhe-ginx.cpp
@@ -73,7 +73,7 @@ void FHEW_ENCRYPT(benchmark::State& state, ParamSet param_set) {
 
     LWEPrivateKey sk = cc.KeyGen();
     for (auto _ : state) {
-        LWECiphertext ct1 = cc.Encrypt(sk, 1, FRESH);
+        LWECiphertext ct1 = cc.Encrypt(sk, 1, SMALL_DIM);
     }
 }
 
@@ -87,7 +87,7 @@ void FHEW_NOT(benchmark::State& state, ParamSet param_set) {
 
     LWEPrivateKey sk = cc.KeyGen();
 
-    LWECiphertext ct1 = cc.Encrypt(sk, 1, FRESH);
+    LWECiphertext ct1 = cc.Encrypt(sk, 1, SMALL_DIM);
 
     for (auto _ : state) {
         LWECiphertext ct11 = cc.EvalNOT(ct1);
@@ -150,7 +150,7 @@ void FHEW_KEYSWITCH(benchmark::State& state, ParamSet param_set) {
     LWEPrivateKey sk  = cc.KeyGen();
     LWEPrivateKey skN = cc.KeyGenN();
 
-    auto ctQN1         = cc.Encrypt(skN, 1, FRESH);
+    auto ctQN1         = cc.Encrypt(skN, 1, SMALL_DIM);
     auto keySwitchHint = cc.KeySwitchGen(sk, skN);
 
     for (auto _ : state) {

--- a/benchmark/src/binfhe-lmkcdey.cpp
+++ b/benchmark/src/binfhe-lmkcdey.cpp
@@ -73,7 +73,7 @@ void FHEW_ENCRYPT(benchmark::State& state, ParamSet param_set) {
 
     LWEPrivateKey sk = cc.KeyGen();
     for (auto _ : state) {
-        LWECiphertext ct1 = cc.Encrypt(sk, 1, FRESH);
+        LWECiphertext ct1 = cc.Encrypt(sk, 1, SMALL_DIM);
     }
 }
 
@@ -87,7 +87,7 @@ void FHEW_NOT(benchmark::State& state, ParamSet param_set) {
 
     LWEPrivateKey sk = cc.KeyGen();
 
-    LWECiphertext ct1 = cc.Encrypt(sk, 1, FRESH);
+    LWECiphertext ct1 = cc.Encrypt(sk, 1, SMALL_DIM);
 
     for (auto _ : state) {
         LWECiphertext ct11 = cc.EvalNOT(ct1);
@@ -150,7 +150,7 @@ void FHEW_KEYSWITCH(benchmark::State& state, ParamSet param_set) {
     LWEPrivateKey sk  = cc.KeyGen();
     LWEPrivateKey skN = cc.KeyGenN();
 
-    auto ctQN1         = cc.Encrypt(skN, 1, FRESH);
+    auto ctQN1         = cc.Encrypt(skN, 1, SMALL_DIM);
     auto keySwitchHint = cc.KeySwitchGen(sk, skN);
 
     for (auto _ : state) {

--- a/benchmark/src/binfhe-paramsets.cpp
+++ b/benchmark/src/binfhe-paramsets.cpp
@@ -68,7 +68,7 @@ using namespace lbcrypto;
     cc.BTKeyGen(sk);
     auto x = std::bind(std::uniform_int_distribution<LWEPlaintext>(0, 1), std::default_random_engine());
     for (auto _ : state)
-        auto ct = cc.EvalBinGate(g, cc.Encrypt(sk, x(), SMALL_DIM, 4), cc.Encrypt(sk, x(), SMALL_DIM, 4));
+        auto ct = cc.EvalBinGate(g, cc.Encrypt(sk, x(), FRESH, 4), cc.Encrypt(sk, x(), FRESH, 4));
 }
 
 [[maybe_unused]] static void FHEW_BINGATE3(benchmark::State& state, BINFHE_PARAMSET s, BINFHE_METHOD m, BINGATE g) {
@@ -79,8 +79,8 @@ using namespace lbcrypto;
     auto x = std::bind(std::uniform_int_distribution<LWEPlaintext>(0, 1), std::default_random_engine());
     for (auto _ : state)
         auto ct = cc.EvalBinGate(
-            g, std::vector<LWECiphertext>{cc.Encrypt(sk, x(), SMALL_DIM, 6), cc.Encrypt(sk, x(), SMALL_DIM, 6),
-                                          cc.Encrypt(sk, x(), SMALL_DIM, 6)});
+            g, std::vector<LWECiphertext>{cc.Encrypt(sk, x(), FRESH, 6), cc.Encrypt(sk, x(), FRESH, 6),
+                                          cc.Encrypt(sk, x(), FRESH, 6)});
 }
 
 [[maybe_unused]] static void FHEW_BINGATE4(benchmark::State& state, BINFHE_PARAMSET s, BINFHE_METHOD m, BINGATE g) {
@@ -91,58 +91,58 @@ using namespace lbcrypto;
     auto x = std::bind(std::uniform_int_distribution<LWEPlaintext>(0, 1), std::default_random_engine());
     for (auto _ : state)
         auto ct = cc.EvalBinGate(
-            g, std::vector<LWECiphertext>{cc.Encrypt(sk, x(), SMALL_DIM, 8), cc.Encrypt(sk, x(), SMALL_DIM, 8),
-                                          cc.Encrypt(sk, x(), SMALL_DIM, 8), cc.Encrypt(sk, x(), SMALL_DIM, 8)});
+            g, std::vector<LWECiphertext>{cc.Encrypt(sk, x(), FRESH, 8), cc.Encrypt(sk, x(), FRESH, 8),
+                                          cc.Encrypt(sk, x(), FRESH, 8), cc.Encrypt(sk, x(), FRESH, 8)});
 }
 
 // clang-format off
-BENCHMARK_CAPTURE(FHEW_BINGATE2, TOY_2_GINX_OR, TOY, GINX, OR)->Unit(benchmark::kMillisecond);
-BENCHMARK_CAPTURE(FHEW_BINGATE2, MEDIUM_2_GINX_OR, MEDIUM, GINX, OR)->Unit(benchmark::kMillisecond);
-BENCHMARK_CAPTURE(FHEW_BINGATE2, STD128_2_AP_OR, STD128_AP, AP, OR)->Unit(benchmark::kMillisecond);
-BENCHMARK_CAPTURE(FHEW_BINGATE2, STD128_2_GINX_OR, STD128, GINX, OR)->Unit(benchmark::kMillisecond);
-BENCHMARK_CAPTURE(FHEW_BINGATE3, STD128_3_GINX_OR, STD128_3, GINX, OR3)->Unit(benchmark::kMillisecond);
-BENCHMARK_CAPTURE(FHEW_BINGATE4, STD128_4_GINX_OR, STD128_4, GINX, OR4)->Unit(benchmark::kMillisecond);
-BENCHMARK_CAPTURE(FHEW_BINGATE2, STD128Q_2_GINX_OR, STD128Q, GINX, OR)->Unit(benchmark::kMillisecond);
+BENCHMARK_CAPTURE(FHEW_BINGATE2, TOY_2_GINX_OR, TOY, GINX, OR)->Unit(benchmark::kMillisecond)->MinTime(5.0);
+BENCHMARK_CAPTURE(FHEW_BINGATE2, MEDIUM_2_GINX_OR, MEDIUM, GINX, OR)->Unit(benchmark::kMillisecond)->MinTime(5.0);
+BENCHMARK_CAPTURE(FHEW_BINGATE2, STD128_2_AP_OR, STD128_AP, AP, OR)->Unit(benchmark::kMillisecond)->MinTime(5.0);
+BENCHMARK_CAPTURE(FHEW_BINGATE2, STD128_2_GINX_OR, STD128, GINX, OR)->Unit(benchmark::kMillisecond)->MinTime(5.0);
+BENCHMARK_CAPTURE(FHEW_BINGATE3, STD128_3_GINX_OR, STD128_3, GINX, OR3)->Unit(benchmark::kMillisecond)->MinTime(5.0);
+BENCHMARK_CAPTURE(FHEW_BINGATE4, STD128_4_GINX_OR, STD128_4, GINX, OR4)->Unit(benchmark::kMillisecond)->MinTime(5.0);
+BENCHMARK_CAPTURE(FHEW_BINGATE2, STD128Q_2_GINX_OR, STD128Q, GINX, OR)->Unit(benchmark::kMillisecond)->MinTime(5.0);
 #if NATIVEINT >= 64
-BENCHMARK_CAPTURE(FHEW_BINGATE3, STD128Q_3_GINX_OR, STD128Q_3, GINX, OR3)->Unit(benchmark::kMillisecond);
-BENCHMARK_CAPTURE(FHEW_BINGATE4, STD128Q_4_GINX_OR, STD128Q_4, GINX, OR4)->Unit(benchmark::kMillisecond);
-BENCHMARK_CAPTURE(FHEW_BINGATE2, STD192_2_GINX_OR, STD192, GINX, OR)->Unit(benchmark::kMillisecond);
-BENCHMARK_CAPTURE(FHEW_BINGATE3, STD192_3_GINX_OR, STD192_3, GINX, OR3)->Unit(benchmark::kMillisecond);
-BENCHMARK_CAPTURE(FHEW_BINGATE4, STD192_4_GINX_OR, STD192_4, GINX, OR4)->Unit(benchmark::kMillisecond);
-BENCHMARK_CAPTURE(FHEW_BINGATE2, STD192Q_2_GINX_OR, STD192Q, GINX, OR)->Unit(benchmark::kMillisecond);
-BENCHMARK_CAPTURE(FHEW_BINGATE3, STD192Q_3_GINX_OR, STD192Q_3, GINX, OR3)->Unit(benchmark::kMillisecond);
-BENCHMARK_CAPTURE(FHEW_BINGATE4, STD192Q_4_GINX_OR, STD192Q_4, GINX, OR4)->Unit(benchmark::kMillisecond);
-BENCHMARK_CAPTURE(FHEW_BINGATE2, STD256_2_GINX_OR, STD256, GINX, OR)->Unit(benchmark::kMillisecond);
-BENCHMARK_CAPTURE(FHEW_BINGATE3, STD256_3_GINX_OR, STD256_3, GINX, OR3)->Unit(benchmark::kMillisecond);
-BENCHMARK_CAPTURE(FHEW_BINGATE4, STD256_4_GINX_OR, STD256_4, GINX, OR4)->Unit(benchmark::kMillisecond);
+BENCHMARK_CAPTURE(FHEW_BINGATE3, STD128Q_3_GINX_OR, STD128Q_3, GINX, OR3)->Unit(benchmark::kMillisecond)->MinTime(5.0);
+BENCHMARK_CAPTURE(FHEW_BINGATE4, STD128Q_4_GINX_OR, STD128Q_4, GINX, OR4)->Unit(benchmark::kMillisecond)->MinTime(5.0);
+BENCHMARK_CAPTURE(FHEW_BINGATE2, STD192_2_GINX_OR, STD192, GINX, OR)->Unit(benchmark::kMillisecond)->MinTime(5.0);
+BENCHMARK_CAPTURE(FHEW_BINGATE3, STD192_3_GINX_OR, STD192_3, GINX, OR3)->Unit(benchmark::kMillisecond)->MinTime(5.0);
+BENCHMARK_CAPTURE(FHEW_BINGATE4, STD192_4_GINX_OR, STD192_4, GINX, OR4)->Unit(benchmark::kMillisecond)->MinTime(5.0);
+BENCHMARK_CAPTURE(FHEW_BINGATE2, STD192Q_2_GINX_OR, STD192Q, GINX, OR)->Unit(benchmark::kMillisecond)->MinTime(5.0);
+BENCHMARK_CAPTURE(FHEW_BINGATE3, STD192Q_3_GINX_OR, STD192Q_3, GINX, OR3)->Unit(benchmark::kMillisecond)->MinTime(5.0);
+BENCHMARK_CAPTURE(FHEW_BINGATE4, STD192Q_4_GINX_OR, STD192Q_4, GINX, OR4)->Unit(benchmark::kMillisecond)->MinTime(5.0);
+BENCHMARK_CAPTURE(FHEW_BINGATE2, STD256_2_GINX_OR, STD256, GINX, OR)->Unit(benchmark::kMillisecond)->MinTime(5.0);
+BENCHMARK_CAPTURE(FHEW_BINGATE3, STD256_3_GINX_OR, STD256_3, GINX, OR3)->Unit(benchmark::kMillisecond)->MinTime(5.0);
+BENCHMARK_CAPTURE(FHEW_BINGATE4, STD256_4_GINX_OR, STD256_4, GINX, OR4)->Unit(benchmark::kMillisecond)->MinTime(5.0);
 #endif
-BENCHMARK_CAPTURE(FHEW_BINGATE2, STD256Q_2_GINX_OR, STD256Q, GINX, OR)->Unit(benchmark::kMillisecond);
-BENCHMARK_CAPTURE(FHEW_BINGATE3, STD256Q_3_GINX_OR, STD256Q_3, GINX, OR3)->Unit(benchmark::kMillisecond);
-BENCHMARK_CAPTURE(FHEW_BINGATE4, STD256Q_4_GINX_OR, STD256Q_4, GINX, OR4)->Unit(benchmark::kMillisecond);
-BENCHMARK_CAPTURE(FHEW_BINGATE2, STD128_2_LMKCDEY_OR, STD128_LMKCDEY, LMKCDEY, OR)->Unit(benchmark::kMillisecond);
-BENCHMARK_CAPTURE(FHEW_BINGATE3, STD128_3_LMKCDEY_OR, STD128_3_LMKCDEY, LMKCDEY, OR3)->Unit(benchmark::kMillisecond);
-BENCHMARK_CAPTURE(FHEW_BINGATE4, STD128_4_LMKCDEY_OR, STD128_4_LMKCDEY, LMKCDEY, OR4)->Unit(benchmark::kMillisecond);
-BENCHMARK_CAPTURE(FHEW_BINGATE2, STD128Q_2_LMKCDEY_OR, STD128Q_LMKCDEY, LMKCDEY, OR)->Unit(benchmark::kMillisecond);
-BENCHMARK_CAPTURE(FHEW_BINGATE3, STD128Q_3_LMKCDEY_OR, STD128Q_3_LMKCDEY, LMKCDEY, OR3)->Unit(benchmark::kMillisecond);
+BENCHMARK_CAPTURE(FHEW_BINGATE2, STD256Q_2_GINX_OR, STD256Q, GINX, OR)->Unit(benchmark::kMillisecond)->MinTime(5.0);
+BENCHMARK_CAPTURE(FHEW_BINGATE3, STD256Q_3_GINX_OR, STD256Q_3, GINX, OR3)->Unit(benchmark::kMillisecond)->MinTime(5.0);
+BENCHMARK_CAPTURE(FHEW_BINGATE4, STD256Q_4_GINX_OR, STD256Q_4, GINX, OR4)->Unit(benchmark::kMillisecond)->MinTime(5.0);
+BENCHMARK_CAPTURE(FHEW_BINGATE2, STD128_2_LMKCDEY_OR, STD128_LMKCDEY, LMKCDEY, OR)->Unit(benchmark::kMillisecond)->MinTime(5.0);
+BENCHMARK_CAPTURE(FHEW_BINGATE3, STD128_3_LMKCDEY_OR, STD128_3_LMKCDEY, LMKCDEY, OR3)->Unit(benchmark::kMillisecond)->MinTime(5.0);
+BENCHMARK_CAPTURE(FHEW_BINGATE4, STD128_4_LMKCDEY_OR, STD128_4_LMKCDEY, LMKCDEY, OR4)->Unit(benchmark::kMillisecond)->MinTime(5.0);
+BENCHMARK_CAPTURE(FHEW_BINGATE2, STD128Q_2_LMKCDEY_OR, STD128Q_LMKCDEY, LMKCDEY, OR)->Unit(benchmark::kMillisecond)->MinTime(5.0);
+BENCHMARK_CAPTURE(FHEW_BINGATE3, STD128Q_3_LMKCDEY_OR, STD128Q_3_LMKCDEY, LMKCDEY, OR3)->Unit(benchmark::kMillisecond)->MinTime(5.0);
 #if NATIVEINT >= 64
-BENCHMARK_CAPTURE(FHEW_BINGATE4, STD128Q_4_LMKCDEY_OR, STD128Q_4_LMKCDEY, LMKCDEY, OR4)->Unit(benchmark::kMillisecond);
-BENCHMARK_CAPTURE(FHEW_BINGATE2, STD192_2_LMKCDEY_OR, STD192_LMKCDEY, LMKCDEY, OR)->Unit(benchmark::kMillisecond);
-BENCHMARK_CAPTURE(FHEW_BINGATE3, STD192_3_LMKCDEY_OR, STD192_3_LMKCDEY, LMKCDEY, OR3)->Unit(benchmark::kMillisecond);
-BENCHMARK_CAPTURE(FHEW_BINGATE4, STD192_4_LMKCDEY_OR, STD192_4_LMKCDEY, LMKCDEY, OR4)->Unit(benchmark::kMillisecond);
-BENCHMARK_CAPTURE(FHEW_BINGATE2, STD192Q_2_LMKCDEY_OR, STD192Q_LMKCDEY, LMKCDEY, OR)->Unit(benchmark::kMillisecond);
-BENCHMARK_CAPTURE(FHEW_BINGATE3, STD192Q_3_LMKCDEY_OR, STD192Q_3_LMKCDEY, LMKCDEY, OR3)->Unit(benchmark::kMillisecond);
-BENCHMARK_CAPTURE(FHEW_BINGATE4, STD192Q_4_LMKCDEY_OR, STD192Q_4_LMKCDEY, LMKCDEY, OR4)->Unit(benchmark::kMillisecond);
-BENCHMARK_CAPTURE(FHEW_BINGATE2, STD256_2_LMKCDEY_OR, STD256_LMKCDEY, LMKCDEY, OR)->Unit(benchmark::kMillisecond);
-BENCHMARK_CAPTURE(FHEW_BINGATE3, STD256_3_LMKCDEY_OR, STD256_3_LMKCDEY, LMKCDEY, OR3)->Unit(benchmark::kMillisecond);
-BENCHMARK_CAPTURE(FHEW_BINGATE4, STD256_4_LMKCDEY_OR, STD256_4_LMKCDEY, LMKCDEY, OR4)->Unit(benchmark::kMillisecond);
-BENCHMARK_CAPTURE(FHEW_BINGATE2, STD256Q_2_LMKCDEY_OR, STD256Q_LMKCDEY, LMKCDEY, OR)->Unit(benchmark::kMillisecond);
-BENCHMARK_CAPTURE(FHEW_BINGATE3, STD256Q_3_LMKCDEY_OR, STD256Q_3_LMKCDEY, LMKCDEY, OR3)->Unit(benchmark::kMillisecond);
-BENCHMARK_CAPTURE(FHEW_BINGATE4, STD256Q_4_LMKCDEY_OR, STD256Q_4_LMKCDEY, LMKCDEY, OR4)->Unit(benchmark::kMillisecond);
+BENCHMARK_CAPTURE(FHEW_BINGATE4, STD128Q_4_LMKCDEY_OR, STD128Q_4_LMKCDEY, LMKCDEY, OR4)->Unit(benchmark::kMillisecond)->MinTime(5.0);
+BENCHMARK_CAPTURE(FHEW_BINGATE2, STD192_2_LMKCDEY_OR, STD192_LMKCDEY, LMKCDEY, OR)->Unit(benchmark::kMillisecond)->MinTime(5.0);
+BENCHMARK_CAPTURE(FHEW_BINGATE3, STD192_3_LMKCDEY_OR, STD192_3_LMKCDEY, LMKCDEY, OR3)->Unit(benchmark::kMillisecond)->MinTime(5.0);
+BENCHMARK_CAPTURE(FHEW_BINGATE4, STD192_4_LMKCDEY_OR, STD192_4_LMKCDEY, LMKCDEY, OR4)->Unit(benchmark::kMillisecond)->MinTime(5.0);
+BENCHMARK_CAPTURE(FHEW_BINGATE2, STD192Q_2_LMKCDEY_OR, STD192Q_LMKCDEY, LMKCDEY, OR)->Unit(benchmark::kMillisecond)->MinTime(5.0);
+BENCHMARK_CAPTURE(FHEW_BINGATE3, STD192Q_3_LMKCDEY_OR, STD192Q_3_LMKCDEY, LMKCDEY, OR3)->Unit(benchmark::kMillisecond)->MinTime(5.0);
+BENCHMARK_CAPTURE(FHEW_BINGATE4, STD192Q_4_LMKCDEY_OR, STD192Q_4_LMKCDEY, LMKCDEY, OR4)->Unit(benchmark::kMillisecond)->MinTime(5.0);
+BENCHMARK_CAPTURE(FHEW_BINGATE2, STD256_2_LMKCDEY_OR, STD256_LMKCDEY, LMKCDEY, OR)->Unit(benchmark::kMillisecond)->MinTime(5.0);
+BENCHMARK_CAPTURE(FHEW_BINGATE3, STD256_3_LMKCDEY_OR, STD256_3_LMKCDEY, LMKCDEY, OR3)->Unit(benchmark::kMillisecond)->MinTime(5.0);
+BENCHMARK_CAPTURE(FHEW_BINGATE4, STD256_4_LMKCDEY_OR, STD256_4_LMKCDEY, LMKCDEY, OR4)->Unit(benchmark::kMillisecond)->MinTime(5.0);
+BENCHMARK_CAPTURE(FHEW_BINGATE2, STD256Q_2_LMKCDEY_OR, STD256Q_LMKCDEY, LMKCDEY, OR)->Unit(benchmark::kMillisecond)->MinTime(5.0);
+BENCHMARK_CAPTURE(FHEW_BINGATE3, STD256Q_3_LMKCDEY_OR, STD256Q_3_LMKCDEY, LMKCDEY, OR3)->Unit(benchmark::kMillisecond)->MinTime(5.0);
+BENCHMARK_CAPTURE(FHEW_BINGATE4, STD256Q_4_LMKCDEY_OR, STD256Q_4_LMKCDEY, LMKCDEY, OR4)->Unit(benchmark::kMillisecond)->MinTime(5.0);
 #endif
-BENCHMARK_CAPTURE(FHEW_BINGATE2, LPF_STD128_2_GINX_OR, LPF_STD128, GINX, OR)->Unit(benchmark::kMillisecond);
-BENCHMARK_CAPTURE(FHEW_BINGATE2, LPF_STD128Q_2_GINX_OR, LPF_STD128Q, GINX, OR)->Unit(benchmark::kMillisecond);
-BENCHMARK_CAPTURE(FHEW_BINGATE2, LPF_STD128_2_LMKCDEY_OR, LPF_STD128_LMKCDEY, LMKCDEY, OR)->Unit(benchmark::kMillisecond);
-BENCHMARK_CAPTURE(FHEW_BINGATE2, LPF_STD128Q_2_LMKCDEY_OR, LPF_STD128Q_LMKCDEY, LMKCDEY, OR)->Unit(benchmark::kMillisecond);
+BENCHMARK_CAPTURE(FHEW_BINGATE2, LPF_STD128_2_GINX_OR, LPF_STD128, GINX, OR)->Unit(benchmark::kMillisecond)->MinTime(5.0);
+BENCHMARK_CAPTURE(FHEW_BINGATE2, LPF_STD128Q_2_GINX_OR, LPF_STD128Q, GINX, OR)->Unit(benchmark::kMillisecond)->MinTime(5.0);
+BENCHMARK_CAPTURE(FHEW_BINGATE2, LPF_STD128_2_LMKCDEY_OR, LPF_STD128_LMKCDEY, LMKCDEY, OR)->Unit(benchmark::kMillisecond)->MinTime(5.0);
+BENCHMARK_CAPTURE(FHEW_BINGATE2, LPF_STD128Q_2_LMKCDEY_OR, LPF_STD128Q_LMKCDEY, LMKCDEY, OR)->Unit(benchmark::kMillisecond)->MinTime(5.0);
 // clang-format on
 
 BENCHMARK_MAIN();

--- a/benchmark/src/binfhe-paramsets.cpp
+++ b/benchmark/src/binfhe-paramsets.cpp
@@ -68,7 +68,7 @@ using namespace lbcrypto;
     cc.BTKeyGen(sk);
     auto x = std::bind(std::uniform_int_distribution<LWEPlaintext>(0, 1), std::default_random_engine());
     for (auto _ : state)
-        auto ct = cc.EvalBinGate(g, cc.Encrypt(sk, x(), FRESH, 4), cc.Encrypt(sk, x(), FRESH, 4));
+        auto ct = cc.EvalBinGate(g, cc.Encrypt(sk, x(), SMALL_DIM, 4), cc.Encrypt(sk, x(), SMALL_DIM, 4));
 }
 
 [[maybe_unused]] static void FHEW_BINGATE3(benchmark::State& state, BINFHE_PARAMSET s, BINFHE_METHOD m, BINGATE g) {
@@ -79,8 +79,8 @@ using namespace lbcrypto;
     auto x = std::bind(std::uniform_int_distribution<LWEPlaintext>(0, 1), std::default_random_engine());
     for (auto _ : state)
         auto ct = cc.EvalBinGate(
-            g, std::vector<LWECiphertext>{cc.Encrypt(sk, x(), FRESH, 6), cc.Encrypt(sk, x(), FRESH, 6),
-                                          cc.Encrypt(sk, x(), FRESH, 6)});
+            g, std::vector<LWECiphertext>{cc.Encrypt(sk, x(), SMALL_DIM, 6), cc.Encrypt(sk, x(), SMALL_DIM, 6),
+                                          cc.Encrypt(sk, x(), SMALL_DIM, 6)});
 }
 
 [[maybe_unused]] static void FHEW_BINGATE4(benchmark::State& state, BINFHE_PARAMSET s, BINFHE_METHOD m, BINGATE g) {
@@ -91,8 +91,8 @@ using namespace lbcrypto;
     auto x = std::bind(std::uniform_int_distribution<LWEPlaintext>(0, 1), std::default_random_engine());
     for (auto _ : state)
         auto ct = cc.EvalBinGate(
-            g, std::vector<LWECiphertext>{cc.Encrypt(sk, x(), FRESH, 8), cc.Encrypt(sk, x(), FRESH, 8),
-                                          cc.Encrypt(sk, x(), FRESH, 8), cc.Encrypt(sk, x(), FRESH, 8)});
+            g, std::vector<LWECiphertext>{cc.Encrypt(sk, x(), SMALL_DIM, 8), cc.Encrypt(sk, x(), SMALL_DIM, 8),
+                                          cc.Encrypt(sk, x(), SMALL_DIM, 8), cc.Encrypt(sk, x(), SMALL_DIM, 8)});
 }
 
 // clang-format off

--- a/src/binfhe/examples/boolean-ap.cpp
+++ b/src/binfhe/examples/boolean-ap.cpp
@@ -68,7 +68,7 @@ int main() {
     // Encrypt two ciphertexts representing Boolean True (1)
     // By default, freshly encrypted ciphertexts are bootstrapped.
     // If you wish to get a fresh encryption without bootstrapping, write
-    // auto   ct1 = cc.Encrypt(sk, 1, FRESH);
+    // auto   ct1 = cc.Encrypt(sk, 1, LARGE_DIM);
     auto ct1 = cc.Encrypt(sk, 1);
     auto ct2 = cc.Encrypt(sk, 1);
 

--- a/src/binfhe/examples/boolean-lmkcdey.cpp
+++ b/src/binfhe/examples/boolean-lmkcdey.cpp
@@ -62,7 +62,7 @@ int main() {
     // Encrypt two ciphertexts representing Boolean True (1)
     // By default, freshly encrypted ciphertexts are bootstrapped.
     // If you wish to get a fresh encryption without bootstrapping, write
-    // auto   ct1 = cc.Encrypt(sk, 1, FRESH);
+    // auto   ct1 = cc.Encrypt(sk, 1, LARGE_DIM);
     auto ct1 = cc.Encrypt(sk, 1);
     auto ct2 = cc.Encrypt(sk, 1);
 

--- a/src/binfhe/examples/boolean-serial-binary-dynamic-large-precision.cpp
+++ b/src/binfhe/examples/boolean-serial-binary-dynamic-large-precision.cpp
@@ -198,7 +198,7 @@ int main() {
 
     for (int i = 0; i < 8; i++) {
         // We first encrypt with large Q
-        auto ct1 = cc.Encrypt(sk, p / 2 + i - 3, FRESH, p, Q);
+        auto ct1 = cc.Encrypt(sk, p / 2 + i - 3, LARGE_DIM, p, Q);
 
         // Get the MSB
         ct1 = cc.EvalSign(ct1);

--- a/src/binfhe/examples/boolean-serial-json-dynamic-large-precision.cpp
+++ b/src/binfhe/examples/boolean-serial-json-dynamic-large-precision.cpp
@@ -198,7 +198,7 @@ int main() {
 
     for (int i = 0; i < 8; i++) {
         // We first encrypt with large Q
-        auto ct1 = cc.Encrypt(sk, p / 2 + i - 3, FRESH, p, Q);
+        auto ct1 = cc.Encrypt(sk, p / 2 + i - 3, LARGE_DIM, p, Q);
 
         // Get the MSB
         ct1 = cc.EvalSign(ct1);

--- a/src/binfhe/examples/boolean.cpp
+++ b/src/binfhe/examples/boolean.cpp
@@ -65,7 +65,7 @@ int main() {
     // Encrypt two ciphertexts representing Boolean True (1).
     // By default, freshly encrypted ciphertexts are bootstrapped.
     // If you wish to get a fresh encryption without bootstrapping, write
-    // auto   ct1 = cc.Encrypt(sk, 1, FRESH);
+    // auto   ct1 = cc.Encrypt(sk, 1, LARGE_DIM);
     auto ct1 = cc.Encrypt(sk, 1);
     auto ct2 = cc.Encrypt(sk, 1);
 

--- a/src/binfhe/examples/eval-decomp.cpp
+++ b/src/binfhe/examples/eval-decomp.cpp
@@ -70,7 +70,7 @@ int main() {
     std::cout << "Completed the key generation." << std::endl;
 
     // Sample Program: Step 3: Encryption
-    auto ct1 = cc.Encrypt(sk, P / 2 + 1, FRESH, P, Q);
+    auto ct1 = cc.Encrypt(sk, P / 2 + 1, LARGE_DIM, P, Q);
     std::cout << "Encrypted value: " << P / 2 + 1 << std::endl;
 
     // Sample Program: Step 4: Evaluation

--- a/src/binfhe/examples/eval-flooring.cpp
+++ b/src/binfhe/examples/eval-flooring.cpp
@@ -66,7 +66,7 @@ int main() {
     uint32_t input = 6;
     std::cout << "Homomorphically round down the input by " << bits << " bits." << std::endl;
 
-    auto ct1 = cc.Encrypt(sk, input % p, FRESH, p);
+    auto ct1 = cc.Encrypt(sk, input % p, LARGE_DIM, p);
 
     // Sample Program: Step 4: Evaluation
     auto ctRounded = cc.EvalFloor(ct1, bits);

--- a/src/binfhe/examples/eval-function.cpp
+++ b/src/binfhe/examples/eval-function.cpp
@@ -72,7 +72,7 @@ int main() {
     // Sample Program: Step 4: evalute f(x) homomorphically and decrypt
     // Note that we check for all the possible plaintexts.
     for (int i = 0; i < p; i++) {
-        auto ct1 = cc.Encrypt(sk, i % p, FRESH, p);
+        auto ct1 = cc.Encrypt(sk, i % p, LARGE_DIM, p);
 
         auto ct_cube = cc.EvalFunc(ct1, lut);
 

--- a/src/binfhe/examples/eval-sign.cpp
+++ b/src/binfhe/examples/eval-sign.cpp
@@ -73,7 +73,7 @@ int main() {
     // Note that we check for 8 different numbers
     for (int i = 0; i < 8; i++) {
         // We first encrypt with large Q
-        auto ct1 = cc.Encrypt(sk, p / 2 + i - 3, FRESH, p, Q);
+        auto ct1 = cc.Encrypt(sk, p / 2 + i - 3, LARGE_DIM, p, Q);
 
         // Get the MSB
         ct1 = cc.EvalSign(ct1);

--- a/src/binfhe/examples/pke/boolean-pke.cpp
+++ b/src/binfhe/examples/pke/boolean-pke.cpp
@@ -79,7 +79,7 @@ int main() {
     // Encrypt two ciphertexts representing Boolean True (1).
     // By default, freshly encrypted ciphertexts are bootstrapped.
     // If you wish to get a fresh encryption without bootstrapping, write
-    // auto   ct1 = cc.Encrypt(sk, 1, FRESH);
+    // auto   ct1 = cc.Encrypt(sk, 1, LARGE_DIM);
     auto ct1 = cc.Encrypt(cc.GetPublicKey(), 1);
     auto ct2 = cc.Encrypt(cc.GetPublicKey(), 1);
 

--- a/src/binfhe/include/binfhe-base-scheme.h
+++ b/src/binfhe/include/binfhe-base-scheme.h
@@ -99,7 +99,7 @@ public:
    * @return a shared pointer to the resulting ciphertext
    */
     LWECiphertext EvalBinGate(const std::shared_ptr<BinFHECryptoParams>& params, BINGATE gate, const RingGSWBTKey& EK,
-                              ConstLWECiphertext& ct1, ConstLWECiphertext& ct2) const;
+                              ConstLWECiphertext& ct1, ConstLWECiphertext& ct2, bool extended = false) const;
 
     /**
    * Evaluates a binary gate on a vector of ciphertexts (calls bootstrapping as a subroutine).
@@ -132,7 +132,7 @@ public:
    * @return a shared pointer to the resulting ciphertext
    */
     LWECiphertext Bootstrap(const std::shared_ptr<BinFHECryptoParams>& params, const RingGSWBTKey& EK,
-                            ConstLWECiphertext& ct) const;
+                            ConstLWECiphertext& ct, bool extended = false) const;
 
     /**
    * Evaluate an arbitrary function

--- a/src/binfhe/include/binfhe-base-scheme.h
+++ b/src/binfhe/include/binfhe-base-scheme.h
@@ -112,7 +112,7 @@ public:
    * @return a shared pointer to the resulting ciphertext
    */
     LWECiphertext EvalBinGate(const std::shared_ptr<BinFHECryptoParams>& params, BINGATE gate, const RingGSWBTKey& EK,
-                              const std::vector<LWECiphertext>& ctvector) const;
+                              const std::vector<LWECiphertext>& ctvector, bool extended = false) const;
 
     /**
    * Evaluates NOT gate

--- a/src/binfhe/include/binfhe-constants.h
+++ b/src/binfhe/include/binfhe-constants.h
@@ -102,8 +102,8 @@ std::ostream& operator<<(std::ostream& s, BINFHE_PARAMSET f);
  */
 enum BINFHE_OUTPUT {
     INVALID_OUTPUT = 0,
-    FRESH,         // a fresh encryption
-    BOOTSTRAPPED,  // a freshly encrypted ciphertext is bootstrapped
+    FRESH,         // a fresh encryption (deprecated)
+    BOOTSTRAPPED,  // a freshly encrypted ciphertext is bootstrapped (deprecated)
     LARGE_DIM,     // a fresh encryption with dimension N
     SMALL_DIM,     // a freshly encrypted ciphertext of dimension N and modulus Q switched to n and q
 };

--- a/src/binfhe/include/binfhecontext.h
+++ b/src/binfhe/include/binfhecontext.h
@@ -311,7 +311,7 @@ public:
    * @param ctvector vector of ciphertexts
    * @return a shared pointer to the resulting ciphertext
    */
-    LWECiphertext EvalBinGate(BINGATE gate, const std::vector<LWECiphertext>& ctvector) const;
+    LWECiphertext EvalBinGate(BINGATE gate, const std::vector<LWECiphertext>& ctvector, bool extended = false) const;
 
     /**
    * Bootstraps a ciphertext (without peforming any operation)

--- a/src/binfhe/include/binfhecontext.h
+++ b/src/binfhe/include/binfhecontext.h
@@ -302,7 +302,7 @@ public:
    * @param ct2 second ciphertext
    * @return a shared pointer to the resulting ciphertext
    */
-    LWECiphertext EvalBinGate(BINGATE gate, ConstLWECiphertext& ct1, ConstLWECiphertext& ct2) const;
+    LWECiphertext EvalBinGate(BINGATE gate, ConstLWECiphertext& ct1, ConstLWECiphertext& ct2, bool extended = false) const;
 
     /**
    * Evaluates a binary gate on vector of ciphertexts (calls bootstrapping as a subroutine)
@@ -319,7 +319,7 @@ public:
    * @param ct ciphertext to be bootstrapped
    * @return a shared pointer to the resulting ciphertext
    */
-    LWECiphertext Bootstrap(ConstLWECiphertext& ct) const;
+    LWECiphertext Bootstrap(ConstLWECiphertext& ct, bool extended = false) const;
 
     /**
    * Evaluate an arbitrary function

--- a/src/binfhe/include/binfhecontext.h
+++ b/src/binfhe/include/binfhecontext.h
@@ -206,13 +206,13 @@ public:
    *
    * @param sk the secret key
    * @param m the plaintext
-   * @param output SMALL_DIM to generate fresh ciphertext, LARGE_DIM to
-   * generate a refreshed ciphertext (default)
+   * @param output SMALL_DIM to generate fresh ciphertext (default), LARGE_DIM to
+   * generate a refreshed ciphertext
    * @param p plaintext modulus
    * @param mod the ciphertext modulus to encrypt with; by default m_q in params
    * @return a shared pointer to the ciphertext
    */
-    LWECiphertext Encrypt(ConstLWEPrivateKey& sk, LWEPlaintext m, BINFHE_OUTPUT output = LARGE_DIM,
+    LWECiphertext Encrypt(ConstLWEPrivateKey& sk, LWEPlaintext m, BINFHE_OUTPUT output = SMALL_DIM,
                           LWEPlaintextModulus p = 4, const NativeInteger& mod = 0) const;
 
     /**

--- a/src/binfhe/include/binfhecontext.h
+++ b/src/binfhe/include/binfhecontext.h
@@ -206,13 +206,13 @@ public:
    *
    * @param sk the secret key
    * @param m the plaintext
-   * @param output FRESH to generate fresh ciphertext, BOOTSTRAPPED to
+   * @param output SMALL_DIM to generate fresh ciphertext, LARGE_DIM to
    * generate a refreshed ciphertext (default)
    * @param p plaintext modulus
    * @param mod the ciphertext modulus to encrypt with; by default m_q in params
    * @return a shared pointer to the ciphertext
    */
-    LWECiphertext Encrypt(ConstLWEPrivateKey& sk, LWEPlaintext m, BINFHE_OUTPUT output = BOOTSTRAPPED,
+    LWECiphertext Encrypt(ConstLWEPrivateKey& sk, LWEPlaintext m, BINFHE_OUTPUT output = LARGE_DIM,
                           LWEPlaintextModulus p = 4, const NativeInteger& mod = 0) const;
 
     /**

--- a/src/binfhe/include/lwe-keypair.h
+++ b/src/binfhe/include/lwe-keypair.h
@@ -54,7 +54,8 @@ public:
     LWEPublicKey publicKey{nullptr};
     LWEPrivateKey secretKey{nullptr};
 
-    LWEKeyPairImpl(LWEPublicKey Av, LWEPrivateKey s) noexcept : publicKey(std::move(Av)), secretKey(std::move(s)) {}
+    LWEKeyPairImpl(const LWEPublicKey& Av, const LWEPrivateKey& s) : publicKey(Av), secretKey(s) {}
+    LWEKeyPairImpl(LWEPublicKey&& Av, LWEPrivateKey&& s) noexcept : publicKey(std::move(Av)), secretKey(std::move(s)) {}
 
     bool good() {
         return publicKey && secretKey;

--- a/src/binfhe/include/lwe-keyswitchkey.h
+++ b/src/binfhe/include/lwe-keyswitchkey.h
@@ -50,9 +50,13 @@ class LWESwitchingKeyImpl : public Serializable {
 public:
     LWESwitchingKeyImpl() = default;
 
-    explicit LWESwitchingKeyImpl(const std::vector<std::vector<std::vector<NativeVector>>>& keyA,
-                                 const std::vector<std::vector<std::vector<NativeInteger>>>& keyB)
+    LWESwitchingKeyImpl(const std::vector<std::vector<std::vector<NativeVector>>>& keyA,
+                        const std::vector<std::vector<std::vector<NativeInteger>>>& keyB)
         : m_keyA(keyA), m_keyB(keyB) {}
+
+    LWESwitchingKeyImpl(std::vector<std::vector<std::vector<NativeVector>>>&& keyA,
+                        std::vector<std::vector<std::vector<NativeInteger>>>&& keyB)
+        : m_keyA(std::move(keyA)), m_keyB(std::move(keyB)) {}
 
     LWESwitchingKeyImpl(const LWESwitchingKeyImpl& rhs) : m_keyA(rhs.m_keyA), m_keyB(rhs.m_keyB) {}
 

--- a/src/binfhe/include/lwe-publickey.h
+++ b/src/binfhe/include/lwe-publickey.h
@@ -49,7 +49,9 @@ class LWEPublicKeyImpl : public Serializable {
 public:
     LWEPublicKeyImpl() = default;
 
-    explicit LWEPublicKeyImpl(const std::vector<NativeVector>& A, const NativeVector& v) : m_A(A), m_v(v) {}
+    LWEPublicKeyImpl(const std::vector<NativeVector>& A, const NativeVector& v) : m_A(A), m_v(v) {}
+
+    LWEPublicKeyImpl(std::vector<NativeVector>&& A, NativeVector&& v) noexcept : m_A(std::move(A)), m_v(std::move(v)) {}
 
     LWEPublicKeyImpl(LWEPublicKeyImpl&& rhs) noexcept : m_A(std::move(rhs.m_A)), m_v(std::move(rhs.m_v)) {}
 

--- a/src/binfhe/include/rlwe-ciphertext.h
+++ b/src/binfhe/include/rlwe-ciphertext.h
@@ -65,6 +65,8 @@ public:
 
     explicit RLWECiphertextImpl(const std::vector<NativePoly>& elements) : m_elements(elements) {}
 
+    explicit RLWECiphertextImpl(std::vector<NativePoly>&& elements) : m_elements(std::move(elements)) {}
+
     RLWECiphertextImpl(const RLWECiphertextImpl& rhs) : m_elements(rhs.m_elements) {}
 
     RLWECiphertextImpl(RLWECiphertextImpl&& rhs) noexcept : m_elements(std::move(rhs.m_elements)) {}

--- a/src/binfhe/include/rlwe-ciphertext.h
+++ b/src/binfhe/include/rlwe-ciphertext.h
@@ -65,7 +65,7 @@ public:
 
     explicit RLWECiphertextImpl(const std::vector<NativePoly>& elements) : m_elements(elements) {}
 
-    explicit RLWECiphertextImpl(std::vector<NativePoly>&& elements) : m_elements(std::move(elements)) {}
+    explicit RLWECiphertextImpl(std::vector<NativePoly>&& elements) noexcept : m_elements(std::move(elements)) {}
 
     RLWECiphertextImpl(const RLWECiphertextImpl& rhs) : m_elements(rhs.m_elements) {}
 

--- a/src/binfhe/lib/binfhe-base-scheme.cpp
+++ b/src/binfhe/lib/binfhe-base-scheme.cpp
@@ -59,7 +59,7 @@ RingGSWBTKey BinFHEScheme::KeyGen(const std::shared_ptr<BinFHECryptoParams>& par
     const auto& RGSWParams = params->GetRingGSWParams();
     const auto& polyParams = RGSWParams->GetPolyParams();
     NativePoly skNPoly(polyParams);
-    skNPoly.SetValues(skN->GetElement(), Format::COEFFICIENT);
+    skNPoly.SetValues(std::move(skN->GetElement()), Format::COEFFICIENT);
     skNPoly.SetFormat(Format::EVALUATION);
 
     ek.BSkey = ACCscheme->KeyGenAcc(RGSWParams, skNPoly, LWEsk);
@@ -70,47 +70,47 @@ RingGSWBTKey BinFHEScheme::KeyGen(const std::shared_ptr<BinFHECryptoParams>& par
 // Full evaluation as described in https://eprint.iacr.org/2020/086
 LWECiphertext BinFHEScheme::EvalBinGate(const std::shared_ptr<BinFHECryptoParams>& params, BINGATE gate,
                                         const RingGSWBTKey& EK, ConstLWECiphertext& ct1,
-                                        ConstLWECiphertext& ct2) const {
+                                        ConstLWECiphertext& ct2, bool extended) const {
     if (ct1 == ct2)
         OPENFHE_THROW("Input ciphertexts should be independant");
 
-    LWECiphertext ctprep = std::make_shared<LWECiphertextImpl>(*ct1);
+    const auto& LWEParams = params->GetLWEParams();
+    NativeInteger Q{LWEParams->GetQ()};
+
+    // input cts expected with SMALL_DIM
+    auto cct1       = (Q == ct1->GetModulus()) ? LWEscheme->SwitchCTtoqn(LWEParams, EK.KSkey, ct1) : std::make_shared<LWECiphertextImpl>(*ct1);
+    const auto cct2 = (Q == ct2->GetModulus()) ? LWEscheme->SwitchCTtoqn(LWEParams, EK.KSkey, ct2) : ct2;
+
     // the additive homomorphic operation for XOR/NXOR is different from the other gates we compute
     // 2*(ct1 + ct2) mod 4 for XOR, 0 -> 0, 2 -> 1
     // XOR_FAST and XNOR_FAST are included for backwards compatibility; they map to XOR and XNOR
     if ((gate == XOR) || (gate == XNOR) || (gate == XOR_FAST) || (gate == XNOR_FAST)) {
-        LWEscheme->EvalAddEq(ctprep, ct2);
-        LWEscheme->EvalAddEq(ctprep, ctprep);
+        LWEscheme->EvalAddEq(cct1, cct2);
+        LWEscheme->EvalAddEq(cct1, cct1);
     }
     else {
         // for all other gates, we simply compute (ct1 + ct2) mod 4
         // for AND: 0,1 -> 0 and 2,3 -> 1
         // for OR: 1,2 -> 1 and 3,0 -> 0
-        LWEscheme->EvalAddEq(ctprep, ct2);
+        LWEscheme->EvalAddEq(cct1, cct2);
     }
-
-    auto acc{BootstrapGateCore(params, gate, EK.BSkey, ctprep)};
 
     // the accumulator result is encrypted w.r.t. the transposed secret key
     // we can transpose "a" to get an encryption under the original secret key
-    std::vector<NativePoly>& accVec{acc->GetElements()};
+    auto accVec{BootstrapGateCore(params, gate, EK.BSkey, cct1)->GetElements()};
     accVec[0] = accVec[0].Transpose();
     accVec[0].SetFormat(Format::COEFFICIENT);
     accVec[1].SetFormat(Format::COEFFICIENT);
 
     // we add Q/8 to "b" to to map back to Q/4 (i.e., mod 2) arithmetic.
-    const auto& LWEParams = params->GetLWEParams();
-    NativeInteger Q{LWEParams->GetQ()};
     NativeInteger b{(Q >> 3) + 1};
     b.ModAddFastEq(accVec[1][0], Q);
 
-    auto ctExt = std::make_shared<LWECiphertextImpl>(std::move(accVec[0].GetValues()), std::move(b));
-    // Modulus switching to a middle step Q'
-    auto ctMS = LWEscheme->ModSwitch(LWEParams->GetqKS(), ctExt);
-    // Key switching
-    auto ctKS = LWEscheme->KeySwitch(LWEParams, EK.KSkey, ctMS);
-    // Modulus switching
-    return LWEscheme->ModSwitch(ct1->GetModulus(), ctKS);
+    auto ctExt = std::make_shared<LWECiphertextImpl>(std::move(accVec[0].GetValues()), b);
+
+    if (extended)
+        return ctExt;
+    return LWEscheme->SwitchCTtoqn(LWEParams, EK.KSkey, ctExt);
 }
 
 // Full evaluation as described in https://eprint.iacr.org/2020/086
@@ -134,11 +134,10 @@ LWECiphertext BinFHEScheme::EvalBinGate(const std::shared_ptr<BinFHECryptoParams
         for (size_t i = 1; i < ctvector.size(); i++) {
             LWEscheme->EvalAddEq(ctprep, ctvector[i]);
         }
-        auto acc = BootstrapGateCore(params, gate, EK.BSkey, ctprep);
 
-        std::vector<NativePoly>& accVec = acc->GetElements();
         // the accumulator result is encrypted w.r.t. the transposed secret key
         // we can transpose "a" to get an encryption under the original secret key
+        auto accVec{BootstrapGateCore(params, gate, EK.BSkey, ctprep)->GetElements()};
         accVec[0] = accVec[0].Transpose();
         accVec[0].SetFormat(Format::COEFFICIENT);
         accVec[1].SetFormat(Format::COEFFICIENT);
@@ -149,7 +148,9 @@ LWECiphertext BinFHEScheme::EvalBinGate(const std::shared_ptr<BinFHECryptoParams
         NativeInteger b = Q / NativeInteger(2 * p) + 1;
         b.ModAddFastEq(accVec[1][0], Q);
 
-        auto ctExt = std::make_shared<LWECiphertextImpl>(std::move(accVec[0].GetValues()), std::move(b));
+        auto ctExt = std::make_shared<LWECiphertextImpl>(std::move(accVec[0].GetValues()), b);
+        // ctExt->SetptModulus(p);
+
         // Modulus switching to a middle step Q'
         auto ctMS = LWEscheme->ModSwitch(LWEParams->GetqKS(), ctExt);
         // Key switching
@@ -173,17 +174,14 @@ LWECiphertext BinFHEScheme::EvalBinGate(const std::shared_ptr<BinFHECryptoParams
 }
 // Full evaluation as described in https://eprint.iacr.org/2020/086
 LWECiphertext BinFHEScheme::Bootstrap(const std::shared_ptr<BinFHECryptoParams>& params, const RingGSWBTKey& EK,
-                                      ConstLWECiphertext& ct) const {
-    NativeInteger p = ct->GetptModulus();
+                                      ConstLWECiphertext& ct, bool extended) const {
     LWECiphertext ctprep{std::make_shared<LWECiphertextImpl>(*ct)};
     // ctprep = ct + q/4
     LWEscheme->EvalAddConstEq(ctprep, (ct->GetModulus() >> 2));
 
-    auto acc{BootstrapGateCore(params, AND, EK.BSkey, ctprep)};
-
     // the accumulator result is encrypted w.r.t. the transposed secret key
     // we can transpose "a" to get an encryption under the original secret key
-    std::vector<NativePoly>& accVec{acc->GetElements()};
+    auto accVec{BootstrapGateCore(params, AND, EK.BSkey, ctprep)->GetElements()};
     accVec[0] = accVec[0].Transpose();
     accVec[0].SetFormat(Format::COEFFICIENT);
     accVec[1].SetFormat(Format::COEFFICIENT);
@@ -191,16 +189,15 @@ LWECiphertext BinFHEScheme::Bootstrap(const std::shared_ptr<BinFHECryptoParams>&
     // we add Q/8 to "b" to to map back to Q/4 (i.e., mod 2) arithmetic.
     const auto& LWEParams = params->GetLWEParams();
     NativeInteger Q{LWEParams->GetQ()};
-    NativeInteger b = Q / NativeInteger(2 * p) + 1;
+    NativeInteger b{Q / NativeInteger(2 * ct->GetptModulus()) + 1};
     b.ModAddFastEq(accVec[1][0], Q);
 
-    auto ctExt = std::make_shared<LWECiphertextImpl>(std::move(accVec[0].GetValues()), std::move(b));
-    // Modulus switching to a middle step Q'
-    auto ctMS = LWEscheme->ModSwitch(LWEParams->GetqKS(), ctExt);
-    // Key switching
-    auto ctKS = LWEscheme->KeySwitch(LWEParams, EK.KSkey, ctMS);
-    // Modulus switching
-    return LWEscheme->ModSwitch(ct->GetModulus(), ctKS);
+    auto ctExt = std::make_shared<LWECiphertextImpl>(std::move(accVec[0].GetValues()), b);
+    // ctExt->SetptModulus(ct->GetptModulus());
+
+    if (extended)
+        return ctExt;
+    return LWEscheme->SwitchCTtoqn(LWEParams, EK.KSkey, ctExt);
 }
 
 // Evaluation of the NOT operation; no key material is needed
@@ -418,8 +415,6 @@ LWECiphertext BinFHEScheme::EvalSign(const std::shared_ptr<BinFHECryptoParams>& 
     return cttmp;
 }
 
-//////
-
 // Evaluate Ciphertext Decomposition
 std::vector<LWECiphertext> BinFHEScheme::EvalDecomp(const std::shared_ptr<BinFHECryptoParams>& params,
                                                     const std::map<uint32_t, RingGSWBTKey>& EKs, ConstLWECiphertext& ct,
@@ -492,38 +487,43 @@ RLWECiphertext BinFHEScheme::BootstrapGateCore(const std::shared_ptr<BinFHECrypt
         OPENFHE_THROW(errMsg);
     }
 
-    auto& LWEParams  = params->GetLWEParams();
-    auto& RGSWParams = params->GetRingGSWParams();
-    auto polyParams  = RGSWParams->GetPolyParams();
-
-    // Specifies the range [q1,q2) that will be used for mapping
-    NativeInteger p  = ct->GetptModulus();
+    // Specifies the range [lb, ub) that will be used for mapping
     NativeInteger q  = ct->GetModulus();
-    uint32_t qHalf   = q.ConvertToInt() >> 1;
+    auto qHalf       = q.ConvertToInt<uint32_t>() >> 1;
+    auto& RGSWParams = params->GetRingGSWParams();
     NativeInteger q1 = RGSWParams->GetGateConst()[static_cast<size_t>(gate)];
     NativeInteger q2 = q1.ModAddFast(NativeInteger(qHalf), q);
 
+    bool swap = q1 >= q2;
+    auto lb = swap? q2 : q1;
+    auto ub = swap? q1 : q2;
+
     // depending on whether the value is the range, it will be set
     // to either Q/8 or -Q/8 to match binary arithmetic
+    auto& LWEParams      = params->GetLWEParams();
     NativeInteger Q      = LWEParams->GetQ();
-    NativeInteger Q2p    = Q / NativeInteger(2 * p) + 1;
+    NativeInteger Q2p    = Q / (ct->GetptModulus() * 2) + 1;
     NativeInteger Q2pNeg = Q - Q2p;
 
-    uint32_t N = LWEParams->GetN();
+    auto lv = swap? Q2p : Q2pNeg;
+    auto uv = swap? Q2pNeg : Q2p;
+
+    const uint32_t N = LWEParams->GetN();
     NativeVector m(N, Q);
     // Since q | (2*N), we deal with a sparse embedding of Z_Q[x]/(X^{q/2}+1) to
     // Z_Q[x]/(X^N+1)
-    uint32_t factor = (2 * N / q.ConvertToInt());
 
-    const NativeInteger& b = ct->GetB();
-    for (size_t j = 0; j < qHalf; ++j) {
-        NativeInteger temp = b.ModSub(j, q);
-        if (q1 < q2)
-            m[j * factor] = ((temp >= q1) && (temp < q2)) ? Q2pNeg : Q2p;
-        else
-            m[j * factor] = ((temp >= q2) && (temp < q1)) ? Q2p : Q2pNeg;
+    const uint32_t factor = (N / qHalf);
+
+    NativeInteger b = ct->GetB();
+
+    for (uint32_t i = 0; i < N; i += factor) {
+        m[i] = ((b >= lb) && (b < ub)) ? lv : uv;
+        b.ModSubEq(1, q);
     }
+
     std::vector<NativePoly> res(2);
+    auto& polyParams = RGSWParams->GetPolyParams();
     // no need to do NTT as all coefficients of this poly are zero
     res[0] = NativePoly(polyParams, Format::EVALUATION, true);
     res[1] = NativePoly(polyParams, Format::COEFFICIENT, false);
@@ -585,23 +585,15 @@ RLWECiphertext BinFHEScheme::BootstrapFuncCore(const std::shared_ptr<BinFHECrypt
 template <typename Func>
 LWECiphertext BinFHEScheme::BootstrapFunc(const std::shared_ptr<BinFHECryptoParams>& params, const RingGSWBTKey& EK,
                                           ConstLWECiphertext& ct, const Func f, const NativeInteger& fmod) const {
-    auto acc = BootstrapFuncCore(params, EK.BSkey, ct, f, fmod);
-
-    std::vector<NativePoly>& accVec = acc->GetElements();
     // the accumulator result is encrypted w.r.t. the transposed secret key
     // we can transpose "a" to get an encryption under the original secret key
+    auto accVec{BootstrapFuncCore(params, EK.BSkey, ct, f, fmod)->GetElements()};
     accVec[0] = accVec[0].Transpose();
     accVec[0].SetFormat(Format::COEFFICIENT);
     accVec[1].SetFormat(Format::COEFFICIENT);
 
-    auto ctExt      = std::make_shared<LWECiphertextImpl>(std::move(accVec[0].GetValues()), std::move(accVec[1][0]));
-    auto& LWEParams = params->GetLWEParams();
-    // Modulus switching to a middle step Q'
-    auto ctMS = LWEscheme->ModSwitch(LWEParams->GetqKS(), ctExt);
-    // Key switching
-    auto ctKS = LWEscheme->KeySwitch(LWEParams, EK.KSkey, ctMS);
-    // Modulus switching
-    return LWEscheme->ModSwitch(fmod, ctKS);
+    auto ctExt = std::make_shared<LWECiphertextImpl>(std::move(accVec[0].GetValues()), accVec[1][0]);
+    return LWEscheme->SwitchCTtoqn(params->GetLWEParams(), EK.KSkey, ctExt);
 }
 
 };  // namespace lbcrypto

--- a/src/binfhe/lib/binfhe-constants-impl.cpp
+++ b/src/binfhe/lib/binfhe-constants-impl.cpp
@@ -184,6 +184,12 @@ std::ostream& operator<<(std::ostream& s, BINFHE_OUTPUT f) {
         case BOOTSTRAPPED:
             s << "BOOTSTRAPPED";
             break;
+        case LARGE_DIM:
+            s << "LARGE_DIM";
+            break;
+        case SMALL_DIM:
+            s << "SMALL_DIM";
+            break;
         default:
             s << "UNKNOWN";
             break;

--- a/src/binfhe/lib/binfhecontext.cpp
+++ b/src/binfhe/lib/binfhecontext.cpp
@@ -232,8 +232,10 @@ LWECiphertext BinFHEContext::Encrypt(ConstLWEPublicKey& pk, LWEPlaintext m, BINF
     // Switch from ct of modulus Q and dimension N to smaller q and n
     // This is done by default while calling Encrypt but the output could
     // be set to LARGE_DIM to skip this switching
-    if (output == SMALL_DIM)
-        return SwitchCTtoqn(m_BTKey.KSkey, ct);
+    if (output == SMALL_DIM) {
+        ct = SwitchCTtoqn(m_BTKey.KSkey, ct);
+        ct->SetptModulus(p);
+    }
     return ct;
 }
 
@@ -279,8 +281,8 @@ LWECiphertext BinFHEContext::EvalBinGate(const BINGATE gate, ConstLWECiphertext&
     return m_binfhescheme->EvalBinGate(m_params, gate, m_BTKey, ct1, ct2, extended);
 }
 
-LWECiphertext BinFHEContext::EvalBinGate(const BINGATE gate, const std::vector<LWECiphertext>& ctvector) const {
-    return m_binfhescheme->EvalBinGate(m_params, gate, m_BTKey, ctvector);
+LWECiphertext BinFHEContext::EvalBinGate(const BINGATE gate, const std::vector<LWECiphertext>& ctvector, bool extended) const {
+    return m_binfhescheme->EvalBinGate(m_params, gate, m_BTKey, ctvector, extended);
 }
 
 LWECiphertext BinFHEContext::Bootstrap(ConstLWECiphertext& ct, bool extended) const {

--- a/src/binfhe/lib/binfhecontext.cpp
+++ b/src/binfhe/lib/binfhecontext.cpp
@@ -275,16 +275,16 @@ void BinFHEContext::BTKeyGen(ConstLWEPrivateKey& sk, KEYGEN_MODE keygenMode) {
     }
 }
 
-LWECiphertext BinFHEContext::EvalBinGate(const BINGATE gate, ConstLWECiphertext& ct1, ConstLWECiphertext& ct2) const {
-    return m_binfhescheme->EvalBinGate(m_params, gate, m_BTKey, ct1, ct2);
+LWECiphertext BinFHEContext::EvalBinGate(const BINGATE gate, ConstLWECiphertext& ct1, ConstLWECiphertext& ct2, bool extended) const {
+    return m_binfhescheme->EvalBinGate(m_params, gate, m_BTKey, ct1, ct2, extended);
 }
 
 LWECiphertext BinFHEContext::EvalBinGate(const BINGATE gate, const std::vector<LWECiphertext>& ctvector) const {
     return m_binfhescheme->EvalBinGate(m_params, gate, m_BTKey, ctvector);
 }
 
-LWECiphertext BinFHEContext::Bootstrap(ConstLWECiphertext& ct) const {
-    return m_binfhescheme->Bootstrap(m_params, m_BTKey, ct);
+LWECiphertext BinFHEContext::Bootstrap(ConstLWECiphertext& ct, bool extended) const {
+    return m_binfhescheme->Bootstrap(m_params, m_BTKey, ct, extended);
 }
 
 LWECiphertext BinFHEContext::EvalNOT(ConstLWECiphertext& ct) const {

--- a/src/binfhe/lib/lwe-pke.cpp
+++ b/src/binfhe/lib/lwe-pke.cpp
@@ -107,8 +107,8 @@ LWECiphertext LWEEncryptionScheme::Encrypt(const std::shared_ptr<LWECryptoParams
         OPENFHE_THROW(errMsg);
     }
 
-    NativeVector s = sk->GetElement();
-    uint32_t n     = s.GetLength();
+    NativeVector s   = sk->GetElement();
+    const uint32_t n = s.GetLength();
     s.SwitchModulus(mod);
 
     NativeInteger b = (m % p) * (mod / p) + params->GetDgg().GenerateInteger(mod);
@@ -118,7 +118,7 @@ LWECiphertext LWEEncryptionScheme::Encrypt(const std::shared_ptr<LWECryptoParams
 
     NativeInteger mu = mod.ComputeMu();
 
-    for (size_t i = 0; i < n; ++i) {
+    for (uint32_t i = 0; i < n; ++i) {
         b += a[i].ModMulFast(s[i], mod, mu);
     }
 
@@ -161,7 +161,7 @@ LWECiphertext LWEEncryptionScheme::EncryptN(const std::shared_ptr<LWECryptoParam
     for (size_t i = 0; i < N; ++i)
         b.ModAddFastEq(bp[i].ModMulFast(sp[i], mod, mu), mod);
 
-    auto ct = std::make_shared<LWECiphertextImpl>(std::move(a), std::move(b));
+    auto ct = std::make_shared<LWECiphertextImpl>(std::move(a), b);
     ct->SetptModulus(p);
     return ct;
 }
@@ -255,7 +255,7 @@ LWECiphertext LWEEncryptionScheme::ModSwitch(NativeInteger q, ConstLWECiphertext
     auto n = ctQ->GetLength();
     auto Q = ctQ->GetModulus();
     NativeVector a(n, q);
-    for (size_t i = 0; i < n; ++i)
+    for (uint32_t i = 0; i < n; ++i)
         a[i] = RoundqQ(ctQ->GetA()[i], q, Q);
     return std::make_shared<LWECiphertextImpl>(std::move(a), RoundqQ(ctQ->GetB(), q, Q));
 }
@@ -368,7 +368,7 @@ LWECiphertext LWEEncryptionScheme::KeySwitch(const std::shared_ptr<LWECryptoPara
                 a[k].ModSubFastEq(refAj[k], Q);
         }
     }
-    return std::make_shared<LWECiphertextImpl>(std::move(a), std::move(b));
+    return std::make_shared<LWECiphertextImpl>(std::move(a), b);
 }
 
 // noiseless LWE embedding
@@ -377,9 +377,7 @@ LWECiphertext LWEEncryptionScheme::KeySwitch(const std::shared_ptr<LWECryptoPara
 LWECiphertext LWEEncryptionScheme::NoiselessEmbedding(const std::shared_ptr<LWECryptoParams>& params,
                                                       LWEPlaintext m) const {
     NativeInteger q(params->Getq());
-    NativeInteger b(m * (q >> 2));
-    NativeVector a(params->Getn(), q);
-    return std::make_shared<LWECiphertextImpl>(std::move(a), std::move(b));
+    return std::make_shared<LWECiphertextImpl>(NativeVector(params->Getn(), q), (q >> 2)*m);
 }
 
 };  // namespace lbcrypto

--- a/src/binfhe/unittest/UnitTestFHEW.cpp
+++ b/src/binfhe/unittest/UnitTestFHEW.cpp
@@ -243,8 +243,8 @@ protected:
             auto sk  = cc.KeyGen();
             auto skN = cc.KeyGenN();
 
-            auto ctQN1 = cc.Encrypt(skN, 1, FRESH, 4, Q);
-            auto ctQN0 = cc.Encrypt(skN, 0, FRESH, 4, Q);
+            auto ctQN1 = cc.Encrypt(skN, 1, SMALL_DIM, 4, Q);
+            auto ctQN0 = cc.Encrypt(skN, 0, SMALL_DIM, 4, Q);
 
             NativeVector newSK = sk->GetElement();
             newSK.SwitchModulus(Q);
@@ -297,8 +297,8 @@ protected:
             newSK.SwitchModulus(Q);
             auto skQ = std::make_shared<LWEPrivateKeyImpl>(newSK);
 
-            auto ctQ1 = cc.Encrypt(skQ, 1, FRESH, 4, Q);
-            auto ctQ0 = cc.Encrypt(skQ, 0, FRESH, 4, Q);
+            auto ctQ1 = cc.Encrypt(skQ, 1, SMALL_DIM, 4, Q);
+            auto ctQ0 = cc.Encrypt(skQ, 0, SMALL_DIM, 4, Q);
 
             // switches the modulus from Q to q
             auto ct1 = cc.GetLWEScheme()->ModSwitch(cc.GetParams()->GetLWEParams()->Getq(), ctQ1);
@@ -339,8 +339,8 @@ protected:
 
             auto sk = cc.KeyGen();
 
-            auto ct1 = cc.Encrypt(sk, 1, FRESH);
-            auto ct0 = cc.Encrypt(sk, 0, FRESH);
+            auto ct1 = cc.Encrypt(sk, 1);
+            auto ct0 = cc.Encrypt(sk, 0);
 
             auto ct1Not = cc.EvalNOT(ct1);
             auto ct0Not = cc.EvalNOT(ct0);

--- a/src/binfhe/unittest/UnitTestFHEWExtended.cpp
+++ b/src/binfhe/unittest/UnitTestFHEWExtended.cpp
@@ -1,0 +1,153 @@
+//==================================================================================
+// BSD 2-Clause License
+//
+// Copyright (c) 2014-2024, NJIT, Duality Technologies Inc. and other contributors
+//
+// All rights reserved.
+//
+// Author TPOC: contact@openfhe.org
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//==================================================================================
+
+#include "binfhecontext.h"
+#include "gtest/gtest.h"
+
+using namespace lbcrypto;
+
+TEST(UNITTestFHEWExtended, EvalBinGate2) {
+    auto cc = BinFHEContext();
+    cc.GenerateBinFHEContext(TOY, GINX);
+
+    auto sk = cc.KeyGen();
+    cc.BTKeyGen(sk, PUB_ENCRYPT);
+
+    auto pk = cc.GetPublicKey();
+    auto Q  = cc.GetParams()->GetLWEParams()->GetQ();
+
+    auto ct_small = cc.Encrypt(pk, 1, SMALL_DIM, 4);
+    EXPECT_NE(Q, ct_small->GetModulus());
+
+    auto ct_large = cc.Encrypt(pk, 1, LARGE_DIM, 4);
+    EXPECT_EQ(Q, ct_large->GetModulus());
+
+    auto ct11 = cc.EvalBinGate(OR, ct_small, ct_large, true);
+    EXPECT_EQ(Q, ct11->GetModulus());
+
+    auto ct12 = cc.EvalBinGate(AND, ct_large, ct_small, true);
+    EXPECT_EQ(Q, ct12->GetModulus());
+
+    auto ct2  = cc.EvalBinGate(NAND, ct11, ct12, false);
+    EXPECT_NE(Q, ct2->GetModulus());
+    EXPECT_EQ(4, ct2->GetptModulus());
+
+    LWEPlaintext result;
+    cc.Decrypt(sk, ct2, &result);
+    EXPECT_EQ(0, result);
+}
+
+TEST(UNITTestFHEWExtended, EvalBinGate3) {
+    auto cc = BinFHEContext();
+    cc.GenerateBinFHEContext(TOY, GINX);
+
+    auto sk = cc.KeyGen();
+    cc.BTKeyGen(sk, PUB_ENCRYPT);
+
+    auto pk = cc.GetPublicKey();
+    auto Q  = cc.GetParams()->GetLWEParams()->GetQ();
+
+    auto ct_small = cc.Encrypt(pk, 1, SMALL_DIM, 6);
+    EXPECT_NE(Q, ct_small->GetModulus());
+
+    auto ct_large = cc.Encrypt(pk, 1, LARGE_DIM, 6);
+    EXPECT_EQ(Q, ct_large->GetModulus());
+
+    std::vector<LWECiphertext> v{ct_small, ct_large, cc.Encrypt(pk, 0, FRESH, 6)};
+
+    auto ct11 = cc.EvalBinGate(OR3, v, true);
+    EXPECT_EQ(Q, ct11->GetModulus());
+    EXPECT_EQ(6, ct11->GetptModulus());
+
+    auto ct12 = cc.EvalBinGate(AND3, v, true);
+    EXPECT_EQ(Q, ct12->GetModulus());
+    EXPECT_EQ(6, ct12->GetptModulus());
+
+    auto ct2  = cc.EvalBinGate(NAND, ct11, ct12, false);
+    EXPECT_NE(Q, ct2->GetModulus());
+    EXPECT_EQ(4, ct2->GetptModulus());
+
+    LWEPlaintext result;
+    cc.Decrypt(sk, ct2, &result);
+    EXPECT_EQ(1, result);
+}
+
+TEST(UNITTestFHEWExtended, EvalBinGate4) {
+    auto cc = BinFHEContext();
+    cc.GenerateBinFHEContext(TOY, GINX);
+
+    auto sk = cc.KeyGen();
+    cc.BTKeyGen(sk, PUB_ENCRYPT);
+
+    auto pk = cc.GetPublicKey();
+    auto Q  = cc.GetParams()->GetLWEParams()->GetQ();
+
+    auto ct_small = cc.Encrypt(pk, 1, SMALL_DIM, 8);
+    EXPECT_NE(Q, ct_small->GetModulus());
+
+    auto ct_large = cc.Encrypt(pk, 1, LARGE_DIM, 8);
+    EXPECT_EQ(Q, ct_large->GetModulus());
+
+    std::vector<LWECiphertext> v{ct_small, ct_large, cc.Encrypt(pk, 0, FRESH, 8), cc.Encrypt(pk, 1, FRESH, 8)};
+
+    auto ct11 = cc.EvalBinGate(OR4, v, true);
+    EXPECT_EQ(Q, ct11->GetModulus());
+    EXPECT_EQ(8, ct11->GetptModulus());
+
+    auto ct12 = cc.EvalBinGate(AND4, v, true);
+    EXPECT_EQ(Q, ct12->GetModulus());
+    EXPECT_EQ(8, ct12->GetptModulus());
+
+    auto ct2  = cc.EvalBinGate(NAND, ct11, ct12, false);
+    EXPECT_NE(Q, ct2->GetModulus());
+    EXPECT_EQ(4, ct2->GetptModulus());
+
+    LWEPlaintext result;
+    cc.Decrypt(sk, ct2, &result);
+    EXPECT_EQ(1, result);
+}
+
+TEST(UNITTestFHEWExtended, BootStrap) {
+    auto cc = BinFHEContext();
+    cc.GenerateBinFHEContext(TOY, GINX);
+
+    auto sk = cc.KeyGen();
+    cc.BTKeyGen(sk, PUB_ENCRYPT);
+
+    auto pk = cc.GetPublicKey();
+    auto Q  = cc.GetParams()->GetLWEParams()->GetQ();
+
+    auto ct1 = cc.Bootstrap(cc.Encrypt(pk, 1, SMALL_DIM, 4), true);
+    EXPECT_EQ(Q, ct1->GetModulus());
+
+    auto ct0 = cc.Bootstrap(cc.Encrypt(pk, 0, LARGE_DIM, 4), true);
+    EXPECT_EQ(Q, ct0->GetModulus());
+}

--- a/src/binfhe/unittest/UnitTestFHEWExtended.cpp
+++ b/src/binfhe/unittest/UnitTestFHEWExtended.cpp
@@ -81,7 +81,7 @@ TEST(UNITTestFHEWExtended, EvalBinGate3) {
     auto ct_large = cc.Encrypt(pk, 1, LARGE_DIM, 6);
     EXPECT_EQ(Q, ct_large->GetModulus());
 
-    std::vector<LWECiphertext> v{ct_small, ct_large, cc.Encrypt(pk, 0, FRESH, 6)};
+    std::vector<LWECiphertext> v{ct_small, ct_large, cc.Encrypt(pk, 0, SMALL_DIM, 6)};
 
     auto ct11 = cc.EvalBinGate(OR3, v, true);
     EXPECT_EQ(Q, ct11->GetModulus());
@@ -116,7 +116,7 @@ TEST(UNITTestFHEWExtended, EvalBinGate4) {
     auto ct_large = cc.Encrypt(pk, 1, LARGE_DIM, 8);
     EXPECT_EQ(Q, ct_large->GetModulus());
 
-    std::vector<LWECiphertext> v{ct_small, ct_large, cc.Encrypt(pk, 0, FRESH, 8), cc.Encrypt(pk, 1, FRESH, 8)};
+    std::vector<LWECiphertext> v{ct_small, ct_large, cc.Encrypt(pk, 0, SMALL_DIM, 8), cc.Encrypt(pk, 1, LARGE_DIM, 8)};
 
     auto ct11 = cc.EvalBinGate(OR4, v, true);
     EXPECT_EQ(Q, ct11->GetModulus());

--- a/src/binfhe/unittest/UnitTestFHEWPKESerial.cpp
+++ b/src/binfhe/unittest/UnitTestFHEWPKESerial.cpp
@@ -127,7 +127,7 @@ void UnitTestFHEWPKESerial(const ST& sertype, BINFHE_PARAMSET secLevel, BINFHE_M
 // They are left in this file for debugging purposes only.
 // TEST(UnitTestFHEWSerialAP, JSON) {
 //     std::string msg = "UnitTestFHEWSerialAP.JSON serialization test failed: ";
-//     UnitTestFHEWSerial(SerType::JSON, TOY, AP, FRESH, msg);
+//     UnitTestFHEWSerial(SerType::JSON, TOY, AP, SMALL_DIM, msg);
 // }
 
 TEST(UnitTestFHEWPKESerialAP, BINARY) {
@@ -137,7 +137,7 @@ TEST(UnitTestFHEWPKESerialAP, BINARY) {
 
 // TEST(UnitTestFHEWSerialGINX, JSON) {
 //     std::string msg = "UnitTestFHEWSerialGINX.JSON serialization test failed: ";
-//     UnitTestFHEWSerial(SerType::JSON, TOY, GINX, FRESH, msg);
+//     UnitTestFHEWSerial(SerType::JSON, TOY, GINX, SMALL_DIM, msg);
 // }
 
 TEST(UnitTestFHEWPKESerialGINX, BINARY) {

--- a/src/binfhe/unittest/UnitTestFHEWSerial.cpp
+++ b/src/binfhe/unittest/UnitTestFHEWSerial.cpp
@@ -119,25 +119,25 @@ void UnitTestFHEWSerial(const ST& sertype, BINFHE_PARAMSET secLevel, BINFHE_METH
 // They are left in this file for debugging purposes only.
 // TEST(UnitTestFHEWSerialAP, JSON) {
 //     std::string msg = "UnitTestFHEWSerialAP.JSON serialization test failed: ";
-//     UnitTestFHEWSerial(SerType::JSON, TOY, AP, FRESH, msg);
+//     UnitTestFHEWSerial(SerType::JSON, TOY, AP, SMALL_DIM, msg);
 // }
 
 TEST(UnitTestFHEWSerialAP, BINARY) {
     std::string msg = "UnitTestFHEWSerialAP.BINARY serialization test failed: ";
-    UnitTestFHEWSerial(SerType::BINARY, TOY, AP, FRESH, msg);
+    UnitTestFHEWSerial(SerType::BINARY, TOY, AP, SMALL_DIM, msg);
 }
 
 // TEST(UnitTestFHEWSerialGINX, JSON) {
 //     std::string msg = "UnitTestFHEWSerialGINX.JSON serialization test failed: ";
-//     UnitTestFHEWSerial(SerType::JSON, TOY, GINX, FRESH, msg);
+//     UnitTestFHEWSerial(SerType::JSON, TOY, GINX, SMALL_DIM, msg);
 // }
 
 TEST(UnitTestFHEWSerialGINX, BINARY) {
     std::string msg = "UnitTestFHEWSerialGINX.BINARY serialization test failed: ";
-    UnitTestFHEWSerial(SerType::BINARY, TOY, GINX, FRESH, msg);
+    UnitTestFHEWSerial(SerType::BINARY, TOY, GINX, SMALL_DIM, msg);
 }
 
 TEST(UnitTestFHEWSerialLMKCDEY, BINARY) {
     std::string msg = "UnitTestFHEWSerialGINX.BINARY serialization test failed: ";
-    UnitTestFHEWSerial(SerType::BINARY, TOY, LMKCDEY, FRESH, msg);
+    UnitTestFHEWSerial(SerType::BINARY, TOY, LMKCDEY, SMALL_DIM, msg);
 }

--- a/src/binfhe/unittest/UnitTestFunc.cpp
+++ b/src/binfhe/unittest/UnitTestFunc.cpp
@@ -57,7 +57,7 @@ TEST(UnitTestFHEWGINX, EvalArbFunc) {
     auto lut = cc.GenerateLUTviaFunction(fp, p);
 
     for (int i = 0; i < p; i++) {
-        auto ct1 = cc.Encrypt(sk, i % p, FRESH, p);
+        auto ct1 = cc.Encrypt(sk, i % p, LARGE_DIM, p);
 
         auto ct_cube = cc.EvalFunc(ct1, lut);
 
@@ -82,7 +82,7 @@ TEST(UnitTestFHEWGINX, EvalFloorFunc) {
     int p = cc.GetMaxPlaintextSpace().ConvertToInt();  // Obtain the maximum plaintext space
 
     for (int i = p / 2 - 3; i < p / 2 + 5; i++) {
-        auto ct1 = cc.Encrypt(sk, i % p, FRESH, p);
+        auto ct1 = cc.Encrypt(sk, i % p, LARGE_DIM, p);
 
         // round by one bit.
         auto ctRounded = cc.EvalFloor(ct1, 1);
@@ -111,7 +111,7 @@ TEST(UnitTestFHEWGINX, EvalSignFuncTime) {
     std::string failed = "Large Precision Sign Evalution failed";
 
     for (int i = 0; i < 8; i++) {
-        auto ct1 = cc.Encrypt(sk, p * factor / 2 + i - 3, FRESH, p * factor, Q);
+        auto ct1 = cc.Encrypt(sk, p * factor / 2 + i - 3, LARGE_DIM, p * factor, Q);
         ct1      = cc.EvalSign(ct1);
         LWEPlaintext result;
         cc.Decrypt(sk, ct1, &result, 2);
@@ -135,7 +135,7 @@ TEST(UnitTestFHEWGINX, EvalSignFuncSpace) {
     std::string failed = "Large Precision Sign Evalution failed";
 
     for (int i = 0; i < 8; i++) {
-        auto ct1 = cc.Encrypt(sk, p * factor / 2 + i - 3, FRESH, p * factor, Q);
+        auto ct1 = cc.Encrypt(sk, p * factor / 2 + i - 3, LARGE_DIM, p * factor, Q);
         ct1      = cc.EvalSign(ct1);
         LWEPlaintext result;
         cc.Decrypt(sk, ct1, &result, 2);
@@ -161,7 +161,7 @@ TEST(UnitTestFHEWGINX, EvalDigitDecompTime) {
 
     // digit decomposes values starting with st upto st + 7 and checks every digit of each decomposition
     for (uint64_t i = st; i < st + 8; i++) {
-        auto ct1 = cc.Encrypt(sk, i, FRESH, p_basic * factor, Q);
+        auto ct1 = cc.Encrypt(sk, i, LARGE_DIM, p_basic * factor, Q);
 
         auto decomp = cc.EvalDecomp(ct1);
         EXPECT_EQ(usint(ceil(log(factor) / log(p_basic)) + 1), decomp.size()) << failed;
@@ -221,7 +221,7 @@ TEST(UnitTestFHEWGINX, EvalDigitDecompSpace) {
     std::string failed = "Large Precision Ciphertext Decomposition failed";
 
     for (uint64_t i = st; i < st + 8; i++) {
-        auto ct1 = cc.Encrypt(sk, i, FRESH, p_basic * factor, Q);
+        auto ct1 = cc.Encrypt(sk, i, LARGE_DIM, p_basic * factor, Q);
 
         auto decomp = cc.EvalDecomp(ct1);
         EXPECT_EQ(usint(ceil(log(factor) / log(p_basic)) + 1), decomp.size()) << failed;

--- a/src/pke/examples/scheme-switching.cpp
+++ b/src/pke/examples/scheme-switching.cpp
@@ -311,29 +311,26 @@ void SwitchFHEWtoCKKS() {
     // Encrypt
     std::vector<LWECiphertext> ctxtsLWE1(slots);
     for (uint32_t i = 0; i < slots; i++) {
-        ctxtsLWE1[i] =
-            ccLWE->Encrypt(lwesk, x1[i]);  // encrypted under small plantext modulus p = 4 and ciphertext modulus
+        // encrypted under small plantext modulus p = 4 and ciphertext modulus
+        ctxtsLWE1[i] = ccLWE->Encrypt(lwesk, x1[i]);
     }
 
     std::vector<LWECiphertext> ctxtsLWE2(slots);
     for (uint32_t i = 0; i < slots; i++) {
-        ctxtsLWE2[i] =
-            ccLWE->Encrypt(lwesk, x1[i], FRESH,
-                           pLWE1);  // encrypted under larger plaintext modulus p = 16 but small ciphertext modulus
+        // encrypted under larger plaintext modulus p = 16 but small ciphertext modulus
+        ctxtsLWE2[i] = ccLWE->Encrypt(lwesk, x1[i], LARGE_DIM, pLWE1);
     }
 
     std::vector<LWECiphertext> ctxtsLWE3(slots);
     for (uint32_t i = 0; i < slots; i++) {
-        ctxtsLWE3[i] =
-            ccLWE->Encrypt(lwesk, x2[i], FRESH, pLWE2,
-                           modulus_LWE);  // encrypted under larger plaintext modulus and large ciphertext modulus
+        // encrypted under larger plaintext modulus and large ciphertext modulus
+        ctxtsLWE3[i] = ccLWE->Encrypt(lwesk, x2[i], LARGE_DIM, pLWE2, modulus_LWE);
     }
 
     std::vector<LWECiphertext> ctxtsLWE4(slots);
     for (uint32_t i = 0; i < slots; i++) {
-        ctxtsLWE4[i] =
-            ccLWE->Encrypt(lwesk, x2[i], FRESH, pLWE3,
-                           modulus_LWE);  // encrypted under large plaintext modulus and large ciphertext modulus
+        // encrypted under large plaintext modulus and large ciphertext modulus
+        ctxtsLWE4[i] = ccLWE->Encrypt(lwesk, x2[i], LARGE_DIM, pLWE3, modulus_LWE);
     }
 
     // Step 5. Perform the scheme switching
@@ -1485,15 +1482,14 @@ void PolyViaSchemeSwitching() {
     // Encrypt
     std::vector<LWECiphertext> ctxtsLWE1(slots);
     for (uint32_t i = 0; i < slots; i++) {
-        ctxtsLWE1[i] = ccLWE->Encrypt(privateKeyFHEW,
-                                      x1[i]);  // encrypted under small plantext modulus p = 4 and ciphertext modulus
+        // encrypted under small plantext modulus p = 4 and ciphertext modulus
+        ctxtsLWE1[i] = ccLWE->Encrypt(privateKeyFHEW, x1[i]);
     }
 
     std::vector<LWECiphertext> ctxtsLWE2(slots);
     for (uint32_t i = 0; i < slots; i++) {
-        ctxtsLWE2[i] =
-            ccLWE->Encrypt(privateKeyFHEW, x2[i], FRESH, pLWE2,
-                           modulus_LWE);  // encrypted under large plaintext modulus and large ciphertext modulus
+        // encrypted under large plaintext modulus and large ciphertext modulus
+        ctxtsLWE2[i] = ccLWE->Encrypt(privateKeyFHEW, x2[i], LARGE_DIM, pLWE2, modulus_LWE);
     }
 
     // Step 5. Perform the scheme switching

--- a/src/pke/extras/scheme-switching-timing.cpp
+++ b/src/pke/extras/scheme-switching-timing.cpp
@@ -290,9 +290,8 @@ void SwitchFHEWtoCKKS(uint32_t depth, uint32_t slots, uint32_t numValues) {
     // Encrypt
     std::vector<LWECiphertext> ctxtsLWE(slots);
     for (uint32_t i = 0; i < slots; i++) {
-        ctxtsLWE[i] =
-            ccLWE->Encrypt(lwesk, x[i], FRESH, pLWE,
-                           modulus_LWE);  // encrypted under large plaintext modulus and large ciphertext modulus
+        // encrypted under large plaintext modulus and large ciphertext modulus
+        ctxtsLWE[i] = ccLWE->Encrypt(lwesk, x[i], LARGE_DIM, pLWE, modulus_LWE);
     }
 
     // Step 5. Perform the scheme switching

--- a/src/pke/unittest/utckksrns/UnitTestSchemeSwitch.cpp
+++ b/src/pke/unittest/utckksrns/UnitTestSchemeSwitch.cpp
@@ -379,12 +379,12 @@ protected:
             // TODO: Andreea: number of slots is 32 here
             for (uint32_t i = 0; i < testData.slots; i++) {
                 // encrypted under small plantext modulus p = 4 and ciphertext modulus
-                ctxtsLWE1[i] = ccLWE->Encrypt(lwesk, x1[i], FRESH, 4, modulus_LWE);
+                ctxtsLWE1[i] = ccLWE->Encrypt(lwesk, x1[i], LARGE_DIM, 4, modulus_LWE);
             }
             std::vector<LWECiphertext> ctxtsLWE2(testData.slots);
             for (uint32_t i = 0; i < testData.slots; i++) {
                 // encrypted under larger plaintext modulus and large ciphertext modulus
-                ctxtsLWE2[i] = ccLWE->Encrypt(lwesk, x2[i], FRESH, pLWE, modulus_LWE);
+                ctxtsLWE2[i] = ccLWE->Encrypt(lwesk, x2[i], LARGE_DIM, pLWE, modulus_LWE);
             }
 
             cc->EvalFHEWtoCKKSSetup(ccLWE, testData.slots, testData.logQ);


### PR DESCRIPTION
- Added extended functionality to EvalBinGate() and Bootstrapping()
- Added unit tests for extended functionality
- Added move constructors for many classes in binfhe
- Bug fix for binfhe pk encryption
- Updates to binfhe-paramsets benchmark
- Update to operator<<(std::ostream& s, BINFHE_OUTPUT f)
- Changed default BINFHE_OUTPUT for secret key encryption to SMALL_DIM
- Limit use of FRESH and BOOTSTRAPPED BINFHE_OUTPUT