### PR TITLE
PKE class clean-up

### DIFF
--- a/src/pke/include/key/evalkey.h
+++ b/src/pke/include/key/evalkey.h
@@ -167,7 +167,7 @@ public:
    * @param &a is the Element to be copied.
    */
 
-    virtual void SetAinDCRT(const DCRTPoly& a) {
+    virtual void SetAinDCRT(const Element& a) {
         OPENFHE_THROW("SetAinDCRT copy operation not supported");
     }
 
@@ -177,7 +177,7 @@ public:
    *
    * @param &&a is the Element to be moved.
    */
-    virtual void SetAinDCRT(DCRTPoly&& a) {
+    virtual void SetAinDCRT(Element&& a) {
         OPENFHE_THROW("SetAinDCRT move operation not supported");
     }
 
@@ -188,7 +188,7 @@ public:
    * @return  Element.
    */
 
-    virtual const DCRTPoly& GetAinDCRT() const {
+    virtual const Element& GetAinDCRT() const {
         OPENFHE_THROW("GetAinDCRT operation not supported");
     }
 
@@ -199,7 +199,7 @@ public:
    * @param &b is the Element to be copied.
    */
 
-    virtual void SetBinDCRT(const DCRTPoly& b) {
+    virtual void SetBinDCRT(const Element& b) {
         OPENFHE_THROW("SetAinDCRT copy operation not supported");
     }
 
@@ -209,7 +209,7 @@ public:
    *
    * @param &&b is the Element to be moved.
    */
-    virtual void SetBinDCRT(DCRTPoly&& b) {
+    virtual void SetBinDCRT(Element&& b) {
         OPENFHE_THROW("SetAinDCRT move operation not supported");
     }
 
@@ -220,7 +220,7 @@ public:
    * @return  Element.
    */
 
-    virtual const DCRTPoly& GetBinDCRT() const {
+    virtual const Element& GetBinDCRT() const {
         OPENFHE_THROW("GetAinDCRT operation not supported");
     }
 

--- a/src/pke/include/key/evalkeyrelin.h
+++ b/src/pke/include/key/evalkeyrelin.h
@@ -175,7 +175,7 @@ public:
    * @param &a is the Element to be copied.
    */
 
-    virtual void SetAinDCRT(const DCRTPoly& a) {
+    virtual void SetAinDCRT(const Element& a) {
         m_dcrtKeys.insert(m_dcrtKeys.begin() + 0, a);
     }
 
@@ -185,7 +185,7 @@ public:
    *
    * @param &&a is the Element to be moved.
    */
-    virtual void SetAinDCRT(DCRTPoly&& a) {
+    virtual void SetAinDCRT(Element&& a) {
         m_dcrtKeys.insert(m_dcrtKeys.begin() + 0, std::move(a));
     }
 
@@ -196,7 +196,7 @@ public:
    * @return  Element.
    */
 
-    virtual const DCRTPoly& GetAinDCRT() const {
+    virtual const Element& GetAinDCRT() const {
         return m_dcrtKeys.at(0);
     }
 
@@ -207,7 +207,7 @@ public:
    * @param &b is the Element to be copied.
    */
 
-    virtual void SetBinDCRT(const DCRTPoly& b) {
+    virtual void SetBinDCRT(const Element& b) {
         m_dcrtKeys.insert(m_dcrtKeys.begin() + 1, b);
     }
 
@@ -217,7 +217,7 @@ public:
    *
    * @param &&b is the Element to be moved.
    */
-    virtual void SetBinDCRT(DCRTPoly&& b) {
+    virtual void SetBinDCRT(Element&& b) {
         m_dcrtKeys.insert(m_dcrtKeys.begin() + 1, std::move(b));
     }
 
@@ -228,7 +228,7 @@ public:
    * @return  Element.
    */
 
-    virtual const DCRTPoly& GetBinDCRT() const {
+    virtual const Element& GetBinDCRT() const {
         return m_dcrtKeys.at(1);
     }
 

--- a/src/pke/include/scheme/bfvrns/bfvrns-parametergeneration.h
+++ b/src/pke/include/scheme/bfvrns/bfvrns-parametergeneration.h
@@ -47,9 +47,9 @@ class ParameterGenerationBFVRNS : public ParameterGenerationRNS {
 public:
     virtual ~ParameterGenerationBFVRNS() {}
 
-    bool ParamsGenBFVRNS(std::shared_ptr<CryptoParametersBase<DCRTPoly>> cryptoParams, uint32_t evalAddCount,
-                         uint32_t multiplicativeDepth, uint32_t keySwitchCount, size_t dcrBits, uint32_t n,
-                         uint32_t numPartQ) const override;
+    bool ParamsGenBFVRNSInternal(std::shared_ptr<CryptoParametersBase<DCRTPoly>> cryptoParams, uint32_t evalAddCount,
+                                 uint32_t multiplicativeDepth, uint32_t keySwitchCount, size_t dcrBits, uint32_t n,
+                                 uint32_t numPartQ) const override;
 
     /////////////////////////////////////
     // SERIALIZATION

--- a/src/pke/include/scheme/bgvrns/bgvrns-parametergeneration.h
+++ b/src/pke/include/scheme/bgvrns/bgvrns-parametergeneration.h
@@ -94,9 +94,9 @@ public:
    * @param numHops numbers of hops for HRA-secure PRE
    * @return A boolean.
    */
-    bool ParamsGenBGVRNS(std::shared_ptr<CryptoParametersBase<DCRTPoly>> cryptoParams, uint32_t evalAddCount,
-                         uint32_t keySwitchCount, uint32_t cyclOrder, uint32_t numPrimes, uint32_t firstModSize,
-                         uint32_t dcrtBits, uint32_t numPartQ, uint32_t numHops) const override;
+    bool ParamsGenBGVRNSInternal(std::shared_ptr<CryptoParametersBase<DCRTPoly>> cryptoParams, uint32_t evalAddCount,
+                                 uint32_t keySwitchCount, uint32_t cyclOrder, uint32_t numPrimes, uint32_t firstModSize,
+                                 uint32_t dcrtBits, uint32_t numPartQ, uint32_t numHops) const override;
 
     /////////////////////////////////////
     // SERIALIZATION

--- a/src/pke/include/scheme/ckksrns/ckksrns-parametergeneration.h
+++ b/src/pke/include/scheme/ckksrns/ckksrns-parametergeneration.h
@@ -47,9 +47,9 @@ class ParameterGenerationCKKSRNS : public ParameterGenerationRNS {
 public:
     virtual ~ParameterGenerationCKKSRNS() {}
 
-    bool ParamsGenCKKSRNS(std::shared_ptr<CryptoParametersBase<DCRTPoly>> cryptoParams, usint cyclOrder,
-                          usint numPrimes, usint scalingModSize, usint firstModSize, uint32_t mulPartQ,
-                          COMPRESSION_LEVEL mPIntBootCiphertextCompressionLevel) const override;
+    bool ParamsGenCKKSRNSInternal(std::shared_ptr<CryptoParametersBase<DCRTPoly>> cryptoParams, usint cyclOrder,
+                                  usint numPrimes, usint scalingModSize, usint firstModSize, uint32_t mulPartQ,
+                                  COMPRESSION_LEVEL mPIntBootCiphertextCompressionLevel) const override;
 
     /////////////////////////////////////
     // SERIALIZATION

--- a/src/pke/include/schemebase/base-leveledshe.h
+++ b/src/pke/include/schemebase/base-leveledshe.h
@@ -435,11 +435,11 @@ public:
         OPENFHE_THROW("double scalar multiplication is not implemented for this scheme");
     }
 
-    virtual Ciphertext<DCRTPoly> MultByInteger(ConstCiphertext<DCRTPoly> ciphertext, uint64_t integer) const {
+    virtual Ciphertext<Element> MultByInteger(ConstCiphertext<Element> ciphertext, uint64_t integer) const {
         OPENFHE_THROW("MultByInteger is not implemented for this scheme");
     }
 
-    virtual void MultByIntegerInPlace(Ciphertext<DCRTPoly>& ciphertext, uint64_t integer) const {
+    virtual void MultByIntegerInPlace(Ciphertext<Element>& ciphertext, uint64_t integer) const {
         OPENFHE_THROW("MultByIntegerInPlace is not implemented for this scheme");
     }
 

--- a/src/pke/include/schemebase/base-parametergeneration.h
+++ b/src/pke/include/schemebase/base-parametergeneration.h
@@ -77,9 +77,9 @@ public:
    * dimension
    * @param numPartQ number of partitions of Q for HYBRID key switching
    */
-    virtual bool ParamsGenBFVRNS(std::shared_ptr<CryptoParametersBase<Element>> cryptoParams, uint32_t evalAddCount,
-                                 uint32_t multiplicativeDepth, uint32_t keySwitchCount, size_t dcrtBits, uint32_t n,
-                                 uint32_t numPartQ) const {
+    virtual bool ParamsGenBFVRNSInternal(std::shared_ptr<CryptoParametersBase<Element>> cryptoParams,
+                                         uint32_t evalAddCount, uint32_t multiplicativeDepth, uint32_t keySwitchCount,
+                                         size_t dcrtBits, uint32_t n, uint32_t numPartQ) const {
         OPENFHE_THROW("This signature for ParamsGen is not supported for this scheme.");
     }
 
@@ -95,9 +95,10 @@ public:
    * @param firstModSize the bit-size of the first modulus
    * @param numPartQ number of partitions of Q for HYBRID key switching
    */
-    virtual bool ParamsGenCKKSRNS(std::shared_ptr<CryptoParametersBase<Element>> cryptoParams, uint32_t cyclOrder,
-                                  uint32_t numPrimes, uint32_t scalingModSize, uint32_t firstModSize, uint32_t numPartQ,
-                                  COMPRESSION_LEVEL mPIntBootCiphertextCompressionLevel) const {
+    virtual bool ParamsGenCKKSRNSInternal(std::shared_ptr<CryptoParametersBase<Element>> cryptoParams,
+                                          uint32_t cyclOrder, uint32_t numPrimes, uint32_t scalingModSize,
+                                          uint32_t firstModSize, uint32_t numPartQ,
+                                          COMPRESSION_LEVEL mPIntBootCiphertextCompressionLevel) const {
         OPENFHE_THROW("This signature for ParamsGen is not supported for this scheme.");
     }
 
@@ -115,9 +116,10 @@ public:
    * @param numPartQ number of partitions of Q for HYBRID key switching
    * @param PRENumHops bound for the HRA-secure mode of PRE
    */
-    virtual bool ParamsGenBGVRNS(std::shared_ptr<CryptoParametersBase<DCRTPoly>> cryptoParams, uint32_t evalAddCount,
-                                 uint32_t keySwitchCount, uint32_t cyclOrder, uint32_t numPrimes, uint32_t firstModSize,
-                                 uint32_t dcrtBits, uint32_t numPartQ, uint32_t PRENumHops) const {
+    virtual bool ParamsGenBGVRNSInternal(std::shared_ptr<CryptoParametersBase<DCRTPoly>> cryptoParams,
+                                         uint32_t evalAddCount, uint32_t keySwitchCount, uint32_t cyclOrder,
+                                         uint32_t numPrimes, uint32_t firstModSize, uint32_t dcrtBits,
+                                         uint32_t numPartQ, uint32_t PRENumHops) const {
         OPENFHE_THROW("This signature for ParamsGen is not supported for this scheme.");
     }
 

--- a/src/pke/include/schemebase/base-scheme.h
+++ b/src/pke/include/schemebase/base-scheme.h
@@ -194,31 +194,31 @@ public:
     // PARAMETER GENERATION WRAPPER
     //------------------------------------------------------------------------------
 
-    virtual bool ParamsGenBFVRNS(std::shared_ptr<CryptoParametersBase<Element>> cryptoParams, uint32_t evalAddCount,
-                                 uint32_t multiplicativeDepth, uint32_t keySwitchCount, size_t dcrtBits, uint32_t n,
-                                 uint32_t numPartQ) const {
+    bool ParamsGenBFVRNS(std::shared_ptr<CryptoParametersBase<Element>> cryptoParams, uint32_t evalAddCount,
+                         uint32_t multiplicativeDepth, uint32_t keySwitchCount, size_t dcrtBits, uint32_t n,
+                         uint32_t numPartQ) const {
         if (!m_ParamsGen)
             OPENFHE_THROW("m_ParamsGen is nullptr");
-        return m_ParamsGen->ParamsGenBFVRNS(cryptoParams, evalAddCount, multiplicativeDepth, keySwitchCount, dcrtBits,
-                                            n, numPartQ);
+        return m_ParamsGen->ParamsGenBFVRNSInternal(cryptoParams, evalAddCount, multiplicativeDepth, keySwitchCount,
+                                                    dcrtBits, n, numPartQ);
     }
 
-    virtual bool ParamsGenCKKSRNS(std::shared_ptr<CryptoParametersBase<Element>> cryptoParams, uint32_t cyclOrder,
-                                  uint32_t numPrimes, uint32_t scalingModSize, uint32_t firstModSize, uint32_t numPartQ,
-                                  COMPRESSION_LEVEL mPIntBootCiphertextCompressionLevel) const {
+    bool ParamsGenCKKSRNS(std::shared_ptr<CryptoParametersBase<Element>> cryptoParams, uint32_t cyclOrder,
+                          uint32_t numPrimes, uint32_t scalingModSize, uint32_t firstModSize, uint32_t numPartQ,
+                          COMPRESSION_LEVEL mPIntBootCiphertextCompressionLevel) const {
         if (!m_ParamsGen)
             OPENFHE_THROW("m_ParamsGen is nullptr");
-        return m_ParamsGen->ParamsGenCKKSRNS(cryptoParams, cyclOrder, numPrimes, scalingModSize, firstModSize, numPartQ,
-                                             mPIntBootCiphertextCompressionLevel);
+        return m_ParamsGen->ParamsGenCKKSRNSInternal(cryptoParams, cyclOrder, numPrimes, scalingModSize, firstModSize,
+                                                     numPartQ, mPIntBootCiphertextCompressionLevel);
     }
 
-    virtual bool ParamsGenBGVRNS(std::shared_ptr<CryptoParametersBase<DCRTPoly>> cryptoParams, uint32_t evalAddCount,
-                                 uint32_t keySwitchCount, uint32_t cyclOrder, uint32_t numPrimes, uint32_t firstModSize,
-                                 uint32_t dcrtBits, uint32_t numPartQ, uint32_t PRENumHops) const {
+    bool ParamsGenBGVRNS(std::shared_ptr<CryptoParametersBase<Element>> cryptoParams, uint32_t evalAddCount,
+                         uint32_t keySwitchCount, uint32_t cyclOrder, uint32_t numPrimes, uint32_t firstModSize,
+                         uint32_t dcrtBits, uint32_t numPartQ, uint32_t PRENumHops) const {
         if (!m_ParamsGen)
             OPENFHE_THROW("m_ParamsGen is nullptr");
-        return m_ParamsGen->ParamsGenBGVRNS(cryptoParams, evalAddCount, keySwitchCount, cyclOrder, numPrimes,
-                                            firstModSize, dcrtBits, numPartQ, PRENumHops);
+        return m_ParamsGen->ParamsGenBGVRNSInternal(cryptoParams, evalAddCount, keySwitchCount, cyclOrder, numPrimes,
+                                                    firstModSize, dcrtBits, numPartQ, PRENumHops);
     }
 
     /////////////////////////////////////////
@@ -852,14 +852,14 @@ public:
         return;
     }
 
-    virtual Ciphertext<DCRTPoly> MultByInteger(ConstCiphertext<DCRTPoly> ciphertext, uint64_t integer) const {
+    virtual Ciphertext<Element> MultByInteger(ConstCiphertext<Element> ciphertext, uint64_t integer) const {
         VerifyLeveledSHEEnabled(__func__);
         if (!ciphertext)
             OPENFHE_THROW("Input ciphertext is nullptr");
         return m_LeveledSHE->MultByInteger(ciphertext, integer);
     }
 
-    virtual void MultByIntegerInPlace(Ciphertext<DCRTPoly>& ciphertext, uint64_t integer) const {
+    virtual void MultByIntegerInPlace(Ciphertext<Element>& ciphertext, uint64_t integer) const {
         VerifyLeveledSHEEnabled(__func__);
         if (!ciphertext)
             OPENFHE_THROW("Input ciphertext is nullptr");
@@ -1046,7 +1046,7 @@ public:
         return m_LeveledSHE->Compress(ciphertext, towersLeft);
     }
 
-    virtual void AdjustLevelsInPlace(Ciphertext<DCRTPoly>& ciphertext1, Ciphertext<DCRTPoly>& ciphertext2) const {
+    virtual void AdjustLevelsInPlace(Ciphertext<Element>& ciphertext1, Ciphertext<Element>& ciphertext2) const {
         VerifyLeveledSHEEnabled(__func__);
         if (!ciphertext1)
             OPENFHE_THROW("Input ciphertext1 is nullptr");
@@ -1056,8 +1056,7 @@ public:
         return;
     }
 
-    virtual void AdjustLevelsAndDepthInPlace(Ciphertext<DCRTPoly>& ciphertext1,
-                                             Ciphertext<DCRTPoly>& ciphertext2) const {
+    virtual void AdjustLevelsAndDepthInPlace(Ciphertext<Element>& ciphertext1, Ciphertext<Element>& ciphertext2) const {
         VerifyLeveledSHEEnabled(__func__);
         if (!ciphertext1)
             OPENFHE_THROW("Input ciphertext1 is nullptr");
@@ -1067,8 +1066,8 @@ public:
         return;
     }
 
-    virtual void AdjustLevelsAndDepthToOneInPlace(Ciphertext<DCRTPoly>& ciphertext1,
-                                                  Ciphertext<DCRTPoly>& ciphertext2) const {
+    virtual void AdjustLevelsAndDepthToOneInPlace(Ciphertext<Element>& ciphertext1,
+                                                  Ciphertext<Element>& ciphertext2) const {
         VerifyLeveledSHEEnabled(__func__);
         if (!ciphertext1)
             OPENFHE_THROW("Input ciphertext1 is nullptr");
@@ -1432,7 +1431,7 @@ public:
         return m_SchemeSwitch->EvalCKKStoFHEW(ciphertext, numCtxts);
     }
 
-    void EvalFHEWtoCKKSSetup(const CryptoContextImpl<DCRTPoly>& ccCKKS, const std::shared_ptr<BinFHEContext>& ccLWE,
+    void EvalFHEWtoCKKSSetup(const CryptoContextImpl<Element>& ccCKKS, const std::shared_ptr<BinFHEContext>& ccLWE,
                              uint32_t numSlotsCKKS = 0, uint32_t logQ = 25) {
         VerifySchemeSwitchEnabled(__func__);
         m_SchemeSwitch->EvalFHEWtoCKKSSetup(ccCKKS, ccLWE, numSlotsCKKS, logQ);

--- a/src/pke/include/schemerns/rns-parametergeneration.h
+++ b/src/pke/include/schemerns/rns-parametergeneration.h
@@ -53,67 +53,6 @@ class ParameterGenerationRNS : public ParameterGenerationBase<DCRTPoly> {
 public:
     virtual ~ParameterGenerationRNS() {}
 
-    /**
-   * Method for computing all derived parameters based on chosen primitive
-   * parameters
-   *
-   * @param *cryptoParams the crypto parameters object to be populated with
-   * parameters.
-   * @param evalAddCount number of EvalAdds assuming no EvalMult and KeySwitch
-   * operations are performed.
-   * @param multiplicativeDepth number of EvalMults assuming no EvalAdd and
-   * KeySwitch operations are performed.
-   * @param keySwitchCount number of KeySwitch operations assuming no EvalAdd
-   * and EvalMult operations are performed.
-   * @param dcrtBits number of bits in each CRT modulus*
-   * @param n ring dimension in case the user wants to use a custom ring
-   * dimension
-   */
-    bool ParamsGenBFVRNS(std::shared_ptr<CryptoParametersBase<DCRTPoly>> cryptoParams, uint32_t evalAddCount,
-                         uint32_t multiplicativeDepth, uint32_t keySwitchCount, size_t dcrtBits, uint32_t numPartQ,
-                         uint32_t n) const override {
-        OPENFHE_THROW("This signature for ParamsGen is not supported for this scheme.");
-    }
-
-    /**
-   * Method for computing all derived parameters based on chosen primitive
-   * parameters.
-   *
-   * @param cryptoParams the crypto parameters object to be populated with parameters.
-   * @param cyclOrder the cyclotomic order.
-   * @param numPrimes number of modulus towers to support.
-   * @param scalingModSize the bit-width for plaintexts and DCRTPoly's.
-   * @param firstModSize the bit-size of the first modulus
-   * @param numPartQ number of partitions of Q for HYBRID key switching
-   *
-   */
-    bool ParamsGenCKKSRNS(std::shared_ptr<CryptoParametersBase<DCRTPoly>> cryptoParams, uint32_t cyclOrder,
-                          uint32_t numPrimes, uint32_t scalingModSize, uint32_t firstModSize, uint32_t mulPartQ,
-                          COMPRESSION_LEVEL mPIntBootCiphertextCompressionLevel) const override {
-        OPENFHE_THROW("This signature for ParamsGen is not supported for this scheme.");
-    }
-
-    /**
-   * Method for computing all derived parameters based on chosen primitive
-   * parameters. This is intended for BGVrns
-   * @param *cryptoParams the crypto parameters object to be populated with
-   * parameters.
-   * @param evalAddCount number of EvalAdds per level.
-   * @param keySwitchCount number of KeySwitch operations per level.
-   * @param cyclOrder the cyclotomic order.
-   * @param numPrimes number of modulus towers to support.
-   * @param digitSize the digit size
-   * @param secretKeyDist
-   * @param ksTech the key switching technique used (e.g., BV or GHS)
-   * @param firstModSize the bit-size of the first modulus
-   * @param dcrtBits the bit-width of moduli.
-   */
-    bool ParamsGenBGVRNS(std::shared_ptr<CryptoParametersBase<DCRTPoly>> cryptoParams, uint32_t evalAddCount,
-                         uint32_t keySwitchCount, uint32_t cyclOrder, uint32_t numPrimes, uint32_t firstModSize,
-                         uint32_t dcrtBits, uint32_t numPartQ, uint32_t PRENumHops) const override {
-        OPENFHE_THROW("This signature for ParamsGen is not supported for this scheme.");
-    }
-
     /////////////////////////////////////
     // SERIALIZATION
     /////////////////////////////////////

--- a/src/pke/lib/scheme/bfvrns/bfvrns-parametergeneration.cpp
+++ b/src/pke/lib/scheme/bfvrns/bfvrns-parametergeneration.cpp
@@ -42,10 +42,10 @@ BFV implementation. See https://eprint.iacr.org/2021/204 for details.
 
 namespace lbcrypto {
 
-bool ParameterGenerationBFVRNS::ParamsGenBFVRNS(std::shared_ptr<CryptoParametersBase<DCRTPoly>> cryptoParams,
-                                                uint32_t evalAddCount, uint32_t multiplicativeDepth,
-                                                uint32_t keySwitchCount, size_t dcrtBits, uint32_t nCustom,
-                                                uint32_t numDigits) const {
+bool ParameterGenerationBFVRNS::ParamsGenBFVRNSInternal(std::shared_ptr<CryptoParametersBase<DCRTPoly>> cryptoParams,
+                                                        uint32_t evalAddCount, uint32_t multiplicativeDepth,
+                                                        uint32_t keySwitchCount, size_t dcrtBits, uint32_t nCustom,
+                                                        uint32_t numDigits) const {
     if (!cryptoParams)
         OPENFHE_THROW("No crypto parameters are supplied to BFVrns ParamsGen");
 

--- a/src/pke/lib/scheme/bgvrns/bgvrns-parametergeneration.cpp
+++ b/src/pke/lib/scheme/bgvrns/bgvrns-parametergeneration.cpp
@@ -347,10 +347,10 @@ void ParameterGenerationBGVRNS::InitializeFloodingDgg(
     cryptoParamsRNS->SetFloodingDistributionParameter(noise_param);
 }
 
-bool ParameterGenerationBGVRNS::ParamsGenBGVRNS(std::shared_ptr<CryptoParametersBase<DCRTPoly>> cryptoParams,
-                                                uint32_t evalAddCount, uint32_t keySwitchCount, uint32_t cyclOrder,
-                                                uint32_t numPrimes, uint32_t firstModSize, uint32_t dcrtBits,
-                                                uint32_t numPartQ, uint32_t numHops) const {
+bool ParameterGenerationBGVRNS::ParamsGenBGVRNSInternal(std::shared_ptr<CryptoParametersBase<DCRTPoly>> cryptoParams,
+                                                        uint32_t evalAddCount, uint32_t keySwitchCount,
+                                                        uint32_t cyclOrder, uint32_t numPrimes, uint32_t firstModSize,
+                                                        uint32_t dcrtBits, uint32_t numPartQ, uint32_t numHops) const {
     const auto cryptoParamsBGVRNS = std::dynamic_pointer_cast<CryptoParametersBGVRNS>(cryptoParams);
 
     uint32_t ptm                     = cryptoParamsBGVRNS->GetPlaintextModulus();

--- a/src/pke/lib/scheme/ckksrns/ckksrns-parametergeneration.cpp
+++ b/src/pke/lib/scheme/ckksrns/ckksrns-parametergeneration.cpp
@@ -47,10 +47,10 @@ const size_t AUXMODSIZE = 119;
 const size_t AUXMODSIZE = 60;
 #endif
 
-bool ParameterGenerationCKKSRNS::ParamsGenCKKSRNS(std::shared_ptr<CryptoParametersBase<DCRTPoly>> cryptoParams,
-                                                  usint cyclOrder, usint numPrimes, usint scalingModSize,
-                                                  usint firstModSize, uint32_t numPartQ,
-                                                  COMPRESSION_LEVEL mPIntBootCiphertextCompressionLevel) const {
+bool ParameterGenerationCKKSRNS::ParamsGenCKKSRNSInternal(std::shared_ptr<CryptoParametersBase<DCRTPoly>> cryptoParams,
+                                                          usint cyclOrder, usint numPrimes, usint scalingModSize,
+                                                          usint firstModSize, uint32_t numPartQ,
+                                                          COMPRESSION_LEVEL mPIntBootCiphertextCompressionLevel) const {
     // the "const" modifier for cryptoParamsCKKSRNS and encodingParams below doesn't mean that the objects those 2 pointers
     // point to are const (not changeable). it means that the pointers themselves are const only.
     const auto cryptoParamsCKKSRNS      = std::dynamic_pointer_cast<CryptoParametersCKKSRNS>(cryptoParams);

--- a/src/pke/lib/schemebase/base-leveledshe.cpp
+++ b/src/pke/lib/schemebase/base-leveledshe.cpp
@@ -471,8 +471,8 @@ Ciphertext<Element> LeveledSHEBase<Element>::EvalAutomorphism(ConstCiphertext<El
 template <class Element>
 std::shared_ptr<std::vector<Element>> LeveledSHEBase<Element>::EvalFastRotationPrecompute(
     ConstCiphertext<Element> ciphertext) const {
-    const std::vector<DCRTPoly>& cv = ciphertext->GetElements();
-    auto algo                       = ciphertext->GetCryptoContext()->GetScheme();
+    const std::vector<Element>& cv = ciphertext->GetElements();
+    auto algo                      = ciphertext->GetCryptoContext()->GetScheme();
 
     return algo->EvalKeySwitchPrecomputeCore(cv[1], ciphertext->GetCryptoParameters());
 }
@@ -498,8 +498,8 @@ Ciphertext<Element> LeveledSHEBase<Element>::EvalFastRotation(
     }
     auto evalKey = evalKeyIterator->second;
 
-    auto algo                       = cc->GetScheme();
-    const std::vector<DCRTPoly>& cv = ciphertext->GetElements();
+    auto algo                      = cc->GetScheme();
+    const std::vector<Element>& cv = ciphertext->GetElements();
 
     std::shared_ptr<std::vector<Element>> ba = algo->EvalFastKeySwitchCore(digits, evalKey, cv[0].GetParams());
 


### PR DESCRIPTION
* Replaced the DCRTPoly type with Element in template functions
* Made ParamsGenBGVRNS(), ParamsGenCKKSRNS() and ParamsGenBFVRNS() non-virtual in base-scheme.h