### PR TITLE
Added a validation for the cryptocontext params: digitSize should be less than 32 if keySwitchTechnique == BV (BGV/BFV)

### DIFF
--- a/src/pke/lib/scheme/gen-cryptocontext-params-validation.cpp
+++ b/src/pke/lib/scheme/gen-cryptocontext-params-validation.cpp
@@ -61,13 +61,6 @@ void validateParametersForCryptocontext(const Params& parameters) {
         }
     }
     else if (isBFVRNS(scheme)) {
-        if(BV == parameters.GetKeySwitchTechnique()) {
-            const uint32_t maxDigitSize = uint32_t(std::ceil(MAX_MODULUS_SIZE/2));
-            if(maxDigitSize < parameters.GetDigitSize()) {
-                OPENFHE_THROW("digitSize should not be greater than " + std::to_string(maxDigitSize) +
-                              " for keySwitchTechnique == BV");
-            }
-        }
         if (0 == parameters.GetPlaintextModulus()) {
             OPENFHE_THROW("PlaintextModulus is not set. It should be set to a non-zero value");
         }
@@ -76,13 +69,6 @@ void validateParametersForCryptocontext(const Params& parameters) {
         }
     }
     else if (isBGVRNS(scheme)) {
-        if(BV == parameters.GetKeySwitchTechnique()) {
-            const uint32_t maxDigitSize = uint32_t(std::ceil(MAX_MODULUS_SIZE/2));
-            if(maxDigitSize < parameters.GetDigitSize()) {
-                OPENFHE_THROW("digitSize should not be greater than " + std::to_string(maxDigitSize) +
-                              " for keySwitchTechnique == BV");
-            }
-        }
         if (0 == parameters.GetPlaintextModulus()) {
             OPENFHE_THROW("PlaintextModulus is not set. It should be set to a non-zero value");
         }
@@ -146,6 +132,13 @@ void validateParametersForCryptocontext(const Params& parameters) {
         std::string errorMsg(std::string("Invalid ringDim [") + std::to_string(parameters.GetRingDim()) +
                              "]. Ring dimension must be a power of 2.");
         OPENFHE_THROW(errorMsg);
+    }
+    if (BV == parameters.GetKeySwitchTechnique()) {
+        const uint32_t maxDigitSize = uint32_t(std::ceil(MAX_MODULUS_SIZE / 2));
+        if (maxDigitSize < parameters.GetDigitSize()) {
+            OPENFHE_THROW("digitSize should not be greater than " + std::to_string(maxDigitSize) +
+                          " for keySwitchTechnique == BV");
+        }
     }
     //====================================================================================================================
     constexpr usint maxMultiplicativeDepthValue = 1000;

--- a/src/pke/lib/scheme/gen-cryptocontext-params-validation.cpp
+++ b/src/pke/lib/scheme/gen-cryptocontext-params-validation.cpp
@@ -61,6 +61,11 @@ void validateParametersForCryptocontext(const Params& parameters) {
         }
     }
     else if (isBFVRNS(scheme)) {
+        if(BV == parameters.GetKeySwitchTechnique()) {
+            if(32 <= parameters.GetDigitSize()) {
+                OPENFHE_THROW("digitSize should be less than 32 for keySwitchTechnique == BV");
+            }
+        }
         if (0 == parameters.GetPlaintextModulus()) {
             OPENFHE_THROW("PlaintextModulus is not set. It should be set to a non-zero value");
         }
@@ -69,6 +74,11 @@ void validateParametersForCryptocontext(const Params& parameters) {
         }
     }
     else if (isBGVRNS(scheme)) {
+        if(BV == parameters.GetKeySwitchTechnique()) {
+            if(32 <= parameters.GetDigitSize()) {
+                OPENFHE_THROW("digitSize should be less than 32 for keySwitchTechnique == BV");
+            }
+        }
         if (0 == parameters.GetPlaintextModulus()) {
             OPENFHE_THROW("PlaintextModulus is not set. It should be set to a non-zero value");
         }

--- a/src/pke/lib/scheme/gen-cryptocontext-params-validation.cpp
+++ b/src/pke/lib/scheme/gen-cryptocontext-params-validation.cpp
@@ -62,8 +62,10 @@ void validateParametersForCryptocontext(const Params& parameters) {
     }
     else if (isBFVRNS(scheme)) {
         if(BV == parameters.GetKeySwitchTechnique()) {
-            if(32 <= parameters.GetDigitSize()) {
-                OPENFHE_THROW("digitSize should be less than 32 for keySwitchTechnique == BV");
+            const uint32_t maxDigitSize = uint32_t(std::ceil(MAX_MODULUS_SIZE/2));
+            if(maxDigitSize < parameters.GetDigitSize()) {
+                OPENFHE_THROW("digitSize should not be greater than " + std::to_string(maxDigitSize) +
+                              " for keySwitchTechnique == BV");
             }
         }
         if (0 == parameters.GetPlaintextModulus()) {
@@ -75,8 +77,10 @@ void validateParametersForCryptocontext(const Params& parameters) {
     }
     else if (isBGVRNS(scheme)) {
         if(BV == parameters.GetKeySwitchTechnique()) {
-            if(32 <= parameters.GetDigitSize()) {
-                OPENFHE_THROW("digitSize should be less than 32 for keySwitchTechnique == BV");
+            const uint32_t maxDigitSize = uint32_t(std::ceil(MAX_MODULUS_SIZE/2));
+            if(maxDigitSize < parameters.GetDigitSize()) {
+                OPENFHE_THROW("digitSize should not be greater than " + std::to_string(maxDigitSize) +
+                              " for keySwitchTechnique == BV");
             }
         }
         if (0 == parameters.GetPlaintextModulus()) {


### PR DESCRIPTION
Validate digitSize for BFV/BGV:
it should not be greater than (MAX_MODULUS_SIZE/2) if keySwitchTechnique is set to "BV"