### PR TITLE
Corrected operator== for the family of cryptoparameters classes

### DIFF
--- a/src/core/include/lattice/hal/default/ildcrtparams.h
+++ b/src/core/include/lattice/hal/default/ildcrtparams.h
@@ -345,7 +345,7 @@ public:
         return 1;
     }
 
-private:
+protected:
     std::ostream& doprint(std::ostream& out) const override {
         out << "ILDCRTParams ";
         ElemParams<IntType>::doprint(out);
@@ -355,6 +355,7 @@ private:
         return out << std::endl;
     }
 
+private:
     // array of smaller ILParams
     std::vector<std::shared_ptr<ILNativeParams>> m_params;
 };

--- a/src/core/include/lattice/hal/default/ilparams.h
+++ b/src/core/include/lattice/hal/default/ilparams.h
@@ -152,7 +152,7 @@ public:
         return 1;
     }
 
-private:
+protected:
     std::ostream& doprint(std::ostream& out) const override {
         out << "ILParams ";
         ElemParams<IntType>::doprint(out);

--- a/src/pke/include/encoding/coefpackedencoding.h
+++ b/src/pke/include/encoding/coefpackedencoding.h
@@ -48,13 +48,54 @@ namespace lbcrypto {
 class CoefPackedEncoding : public PlaintextImpl {
     std::vector<int64_t> value;
 
+protected:
+    /**
+    * @brief PrintValue() is called by operator<<
+    * @param out stream to print to
+    */
+    void PrintValue(std::ostream& out) const override {
+        out << "(";
+
+        // for sanity's sake: get rid of all trailing zeroes and print "..." instead
+        size_t i       = value.size();
+        bool allZeroes = true;
+        while (i > 0) {
+            --i;
+            if (value[i] != 0) {
+                allZeroes = false;
+                break;
+            }
+        }
+
+        if (allZeroes == false) {
+            for (size_t j = 0; j <= i; ++j)
+                out << value[j] << ", ";
+        }
+        out << "... )";
+    }
+
+    /**
+    * Method to compare two plaintext to test for equivalence
+    * Testing that the plaintexts are of the same type done in operator==
+    *
+    * @param rhs - the other plaintext to compare to.
+    * @return whether the two plaintext are equivalent.
+    */
+    bool CompareTo(const PlaintextImpl& rhs) const override {
+        const auto* el = dynamic_cast<const CoefPackedEncoding*>(&rhs);
+        if (el == nullptr)
+            return false;
+
+        return this->value == el->value;
+    }
+
 public:
     template <typename T, typename std::enable_if<std::is_same<T, Poly::Params>::value ||
                                                       std::is_same<T, NativePoly::Params>::value ||
                                                       std::is_same<T, DCRTPoly::Params>::value,
                                                   bool>::type = true>
     CoefPackedEncoding(std::shared_ptr<T> vp, EncodingParams ep, SCHEME schemeId = SCHEME::INVALID_SCHEME)
-        : PlaintextImpl(vp, ep, schemeId) {}
+        : PlaintextImpl(vp, ep, COEF_PACKED_ENCODING, schemeId) {}
 
     template <typename T, typename std::enable_if<std::is_same<T, Poly::Params>::value ||
                                                       std::is_same<T, NativePoly::Params>::value ||
@@ -62,15 +103,15 @@ public:
                                                   bool>::type = true>
     CoefPackedEncoding(std::shared_ptr<T> vp, EncodingParams ep, const std::vector<int64_t>& coeffs,
                        SCHEME schemeId = SCHEME::INVALID_SCHEME)
-        : PlaintextImpl(vp, ep, schemeId), value(coeffs) {}
+        : PlaintextImpl(vp, ep, COEF_PACKED_ENCODING, schemeId), value(coeffs) {}
 
-    virtual ~CoefPackedEncoding() = default;
+    ~CoefPackedEncoding() override = default;
 
     /**
    * GetCoeffsValue
    * @return the un-encoded scalar
    */
-    const std::vector<int64_t>& GetCoefPackedValue() const {
+    const std::vector<int64_t>& GetCoefPackedValue() const override {
         return value;
     }
 
@@ -78,7 +119,7 @@ public:
    * SetIntVectorValue
    * @param val integer vector to initialize the plaintext
    */
-    void SetIntVectorValue(const std::vector<int64_t>& val) {
+    void SetIntVectorValue(const std::vector<int64_t>& val) override {
         value = val;
     }
 
@@ -86,28 +127,20 @@ public:
    * Encode the plaintext into the Poly
    * @return true on success
    */
-    bool Encode();
+    bool Encode() override;
 
     /**
    * Decode the Poly into the string
    * @return true on success
-   */
-    bool Decode();
-
-    /**
-   * GetEncodingType
-   * @return this is a COEF_PACKED_ENCODING encoding
-   */
-    PlaintextEncodings GetEncodingType() const {
-        return COEF_PACKED_ENCODING;
-    }
+   */ 
+    bool Decode() override;
 
     /**
    * Get length of the plaintext
    *
    * @return number of elements in this plaintext
    */
-    size_t GetLength() const {
+    size_t GetLength() const override {
         return value.size();
     }
 
@@ -115,38 +148,8 @@ public:
    * SetLength of the plaintext to the given size
    * @param siz
    */
-    void SetLength(size_t siz) {
+    void SetLength(size_t siz) override {
         value.resize(siz);
-    }
-
-    /**
-   * Method to compare two plaintext to test for equivalence
-   * Testing that the plaintexts are of the same type done in operator==
-   *
-   * @param other - the other plaintext to compare to.
-   * @return whether the two plaintext are equivalent.
-   */
-    bool CompareTo(const PlaintextImpl& other) const {
-        const auto& oth = static_cast<const CoefPackedEncoding&>(other);
-        return oth.value == this->value;
-    }
-
-    /**
-   * PrintValue - used by operator<< for this object
-   * @param out
-   */
-    void PrintValue(std::ostream& out) const {
-        // for sanity's sake, trailing zeros get elided into "..."
-        out << "(";
-        size_t i = value.size();
-        while (--i > 0)
-            if (value[i] != 0)
-                break;
-
-        for (size_t j = 0; j <= i; j++)
-            out << ' ' << value[j];
-
-        out << " ... )";
     }
 };
 

--- a/src/pke/include/encoding/encodingparams.h
+++ b/src/pke/include/encoding/encodingparams.h
@@ -124,7 +124,7 @@ public:
     /**
    * Destructor.
    */
-    virtual ~EncodingParamsImpl() {}
+    virtual ~EncodingParamsImpl() = default;
 
     // ACCESSORS
 
@@ -253,29 +253,6 @@ public:
         return !(*this == other);
     }
 
-private:
-    std::ostream& doprint(std::ostream& out) const {
-        out << "[p=" << m_plaintextModulus << " rootP =" << m_plaintextRootOfUnity << " bigP =" << m_plaintextBigModulus
-            << " rootBigP =" << m_plaintextBigRootOfUnity << " g=" << m_plaintextGenerator << " L=" << m_batchSize
-            << "]";
-        return out;
-    }
-
-    // plaintext modulus that is used by all schemes
-    PlaintextModulus m_plaintextModulus;
-    // root of unity for plaintext modulus
-    NativeInteger m_plaintextRootOfUnity;
-    // big plaintext modulus that is used for arbitrary cyclotomics
-    NativeInteger m_plaintextBigModulus;
-    // root of unity for big plaintext modulus
-    NativeInteger m_plaintextBigRootOfUnity;
-    // plaintext generator is used for packed encoding (to find the correct
-    // automorphism index)
-    uint32_t m_plaintextGenerator;
-    // maximum batch size used by EvalSumKeyGen for packed encoding
-    uint32_t m_batchSize;
-
-public:
     template <class Archive>
     void save(Archive& ar, std::uint32_t const version) const {
         ar(::cereal::make_nvp("m", m_plaintextModulus));
@@ -306,6 +283,29 @@ public:
     static uint32_t SerializedVersion() {
         return 1;
     }
+
+protected:
+    std::ostream& doprint(std::ostream& out) const {
+        out << "[p=" << m_plaintextModulus << " rootP =" << m_plaintextRootOfUnity << " bigP =" << m_plaintextBigModulus
+            << " rootBigP =" << m_plaintextBigRootOfUnity << " g=" << m_plaintextGenerator << " L=" << m_batchSize
+            << "]";
+        return out;
+    }
+
+private:
+    // plaintext modulus that is used by all schemes
+    PlaintextModulus m_plaintextModulus;
+    // root of unity for plaintext modulus
+    NativeInteger m_plaintextRootOfUnity;
+    // big plaintext modulus that is used for arbitrary cyclotomics
+    NativeInteger m_plaintextBigModulus;
+    // root of unity for big plaintext modulus
+    NativeInteger m_plaintextBigRootOfUnity;
+    // plaintext generator is used for packed encoding (to find the correct
+    // automorphism index)
+    uint32_t m_plaintextGenerator;
+    // maximum batch size used by EvalSumKeyGen for packed encoding
+    uint32_t m_batchSize;
 };
 
 inline std::ostream& operator<<(std::ostream& out, const std::shared_ptr<EncodingParamsImpl>& o) {

--- a/src/pke/include/encoding/stringencoding.h
+++ b/src/pke/include/encoding/stringencoding.h
@@ -53,25 +53,25 @@ public:
                                                       std::is_same<T, NativePoly::Params>::value ||
                                                       std::is_same<T, DCRTPoly::Params>::value,
                                                   bool>::type = true>
-    StringEncoding(std::shared_ptr<T> vp, EncodingParams ep) : PlaintextImpl(vp, ep) {}
+    StringEncoding(std::shared_ptr<T> vp, EncodingParams ep) : PlaintextImpl(vp, ep, STRING_ENCODING) {}
 
     template <typename T, typename std::enable_if<std::is_same<T, Poly::Params>::value ||
                                                       std::is_same<T, NativePoly::Params>::value ||
                                                       std::is_same<T, DCRTPoly::Params>::value,
                                                   bool>::type = true>
     StringEncoding(std::shared_ptr<T> vp, EncodingParams ep, const std::string& str)
-        : PlaintextImpl(vp, ep), ptx(str) {}
+        : PlaintextImpl(vp, ep, STRING_ENCODING), ptx(str) {}
 
     // TODO provide wide-character version (for unicode); right now this class
     // only supports strings of 7-bit ASCII characters
 
-    virtual ~StringEncoding() {}
+    ~StringEncoding() override = default;
 
     /**
    * GetStringValue
    * @return the un-encoded string
    */
-    const std::string& GetStringValue() const {
+    const std::string& GetStringValue() const override {
         return ptx;
     }
 
@@ -79,7 +79,7 @@ public:
    * SetStringValue
    * @param val to initialize the Plaintext
    */
-    void SetStringValue(const std::string& value) {
+    void SetStringValue(const std::string& value) override {
         ptx = value;
     }
 
@@ -87,48 +87,44 @@ public:
    * Encode the plaintext into the Poly
    * @return true on success
    */
-    bool Encode();
+    bool Encode() override;
 
     /**
    * Decode the Poly into the string
    * @return true on success
    */
-    bool Decode();
-
-    /**
-   * GetEncodingType
-   * @return STRING_ENCODING
-   */
-    PlaintextEncodings GetEncodingType() const {
-        return STRING_ENCODING;
-    }
+    bool Decode() override;
 
     /**
    * Get length of the plaintext
    *
    * @return number of elements in this plaintext
    */
-    size_t GetLength() const {
+    size_t GetLength() const override {
         return ptx.size();
     }
 
+protected:
     /**
-   * Method to compare two plaintext to test for equivalence
-   * Testing that the plaintexts are of the same type done in operator==
-   *
-   * @param other - the other plaintext to compare to.
-   * @return whether the two plaintext are equivalent.
-   */
-    bool CompareTo(const PlaintextImpl& other) const {
-        const auto& oth = static_cast<const StringEncoding&>(other);
-        return oth.ptx == this->ptx;
+    * Method to compare two plaintext to test for equivalence
+    * Testing that the plaintexts are of the same type done in operator==
+    *
+    * @param rhs - the other plaintext to compare to.
+    * @return whether the two plaintext are equivalent.
+    */
+    bool CompareTo(const PlaintextImpl& rhs) const override {
+        const auto* el = dynamic_cast<const StringEncoding*>(&rhs);
+        if (el == nullptr)
+            return false;
+
+        return this->ptx == el->ptx;
     }
 
     /**
-   * PrintValue - used by operator<< for this object
-   * @param out
-   */
-    void PrintValue(std::ostream& out) const {
+    * PrintValue - used by operator<< for this object
+    * @param out
+    */
+    void PrintValue(std::ostream& out) const override {
         out << ptx;
     }
 };

--- a/src/pke/include/metadata.h
+++ b/src/pke/include/metadata.h
@@ -92,20 +92,11 @@ public:
     }
 
     /**
-   * A method that prints the contents of metadata objects.
-   * Please override in subclasses to print all members.
-   */
-    virtual std::ostream& print(std::ostream& out) const {
-        out << "[ ]" << std::endl;
-        return out;
-    }
-
-    /**
-   * << operator implements by calling member method print.
+   * << operator implements by calling member method PrintMetadata.
    * This is a friend method and cannot be overriden by subclasses.
    */
     friend std::ostream& operator<<(std::ostream& out, const Metadata& m) {
-        m.print(out);
+        m.PrintMetadata(out);
         return out;
     }
 
@@ -138,6 +129,15 @@ public:
    */
     static uint32_t SerializedVersion() {
         return 1;
+    }
+
+protected:
+    /**
+    * A method that prints the contents of metadata objects.
+    * Please override in subclasses to print all members.
+    */
+    virtual std::ostream& PrintMetadata(std::ostream& out) const {
+        OPENFHE_THROW("Not implemented");
     }
 };
 

--- a/src/pke/include/schemebase/base-cryptoparameters.h
+++ b/src/pke/include/schemebase/base-cryptoparameters.h
@@ -68,7 +68,7 @@ public:
    *
    * @return the plaintext modulus.
    */
-    virtual const PlaintextModulus& GetPlaintextModulus() const {
+    PlaintextModulus GetPlaintextModulus() const {
         return m_encodingParams->GetPlaintextModulus();
     }
 
@@ -77,7 +77,7 @@ public:
    *
    * @return the ring element parameters.
    */
-    virtual const std::shared_ptr<typename Element::Params> GetElementParams() const {
+    const std::shared_ptr<typename Element::Params> GetElementParams() const {
         return m_params;
     }
 
@@ -88,14 +88,14 @@ public:
    *
    * @return the encoding parameters.
    */
-    virtual const EncodingParams GetEncodingParams() const {
+    const EncodingParams GetEncodingParams() const {
         return m_encodingParams;
     }
 
     /**
    * Sets the value of plaintext modulus p
    */
-    virtual void SetPlaintextModulus(const PlaintextModulus& plaintextModulus) {
+    void SetPlaintextModulus(PlaintextModulus plaintextModulus) {
         m_encodingParams->SetPlaintextModulus(plaintextModulus);
     }
 
@@ -119,7 +119,7 @@ public:
         return out;
     }
 
-    virtual usint GetDigitSize() const {
+    virtual uint32_t GetDigitSize() const {
         return 0;
     }
 
@@ -167,7 +167,7 @@ public:
         ar(::cereal::make_nvp("enp", m_encodingParams));
     }
 
-    std::string SerializedObjectName() const {
+    std::string SerializedObjectName() const override {
         return "CryptoParametersBase";
     }
     static uint32_t SerializedVersion() {
@@ -209,7 +209,6 @@ protected:
         out << "Encoding Parameters: " << *m_encodingParams << std::endl;
     }
 
-protected:
     // element-specific parameters
     std::shared_ptr<typename Element::Params> m_params;
 

--- a/src/pke/include/schemebase/base-cryptoparameters.h
+++ b/src/pke/include/schemebase/base-cryptoparameters.h
@@ -59,9 +59,9 @@ class CryptoParametersBase : public Serializable {
     using TugType  = typename Element::TugType;
 
 public:
-    CryptoParametersBase() {}
+    CryptoParametersBase() = default;
 
-    virtual ~CryptoParametersBase() {}
+    virtual ~CryptoParametersBase() = default;
 
     /**
    * Returns the value of plaintext modulus p
@@ -99,11 +99,11 @@ public:
         m_encodingParams->SetPlaintextModulus(plaintextModulus);
     }
 
-    virtual bool operator==(const CryptoParametersBase<Element>& cmp) const {
-        return *m_encodingParams == *(cmp.GetEncodingParams()) && *m_params == *(cmp.GetElementParams());
+    bool operator==(const CryptoParametersBase<Element>& rhs) const {
+        return CompareTo(rhs);
     }
-    virtual bool operator!=(const CryptoParametersBase<Element>& cmp) const {
-        return !(*this == cmp);
+    bool operator!=(const CryptoParametersBase<Element>& rhs) const {
+        return !(*this == rhs);
     }
 
     /**
@@ -192,6 +192,16 @@ protected:
     CryptoParametersBase(CryptoParametersBase<Element>* from, std::shared_ptr<typename Element::Params> newElemParms) {
         *this    = *from;
         m_params = newElemParms;
+    }
+
+    /**
+    * @brief CompareTo() is a method to compare two CryptoParametersBase objects. It is called by operator==()
+    *
+    * @param rhs - the other CryptoParametersBase object to compare to.
+    * @return whether the two CryptoParametersBase objects are equivalent.
+    */
+    virtual bool CompareTo(const CryptoParametersBase<Element>& rhs) const {
+        return (*m_encodingParams == *(rhs.GetEncodingParams()) && *m_params == *(rhs.GetElementParams()));
     }
 
     virtual void PrintParameters(std::ostream& out) const {

--- a/src/pke/include/schemebase/rlwe-cryptoparameters.h
+++ b/src/pke/include/schemebase/rlwe-cryptoparameters.h
@@ -127,9 +127,9 @@ public:
     }
 
     /**
-   * Destructor
+   * Virtual Destructor
    */
-    virtual ~CryptoParametersRLWE() {}
+    ~CryptoParametersRLWE() = default;
 
     /**
    * Returns the value of standard deviation r for discrete Gaussian
@@ -414,33 +414,6 @@ public:
         m_thresholdNumOfParties = thresholdNumOfParties;
     }
 
-    /**
-   * == operator to compare to this instance of CryptoParametersRLWE object.
-   *
-   * @param &rhs CryptoParameters to check equality against.
-   */
-    bool operator==(const CryptoParametersBase<Element>& rhs) const {
-        const auto* el = dynamic_cast<const CryptoParametersRLWE<Element>*>(&rhs);
-
-        if (el == nullptr)
-            return false;
-
-        return CryptoParametersBase<Element>::operator==(*el) &&
-               this->GetPlaintextModulus() == el->GetPlaintextModulus() &&
-               *this->GetElementParams() == *el->GetElementParams() &&
-               *this->GetEncodingParams() == *el->GetEncodingParams() &&
-               m_distributionParameter == el->GetDistributionParameter() &&
-               m_assuranceMeasure == el->GetAssuranceMeasure() && m_noiseScale == el->GetNoiseScale() &&
-               m_digitSize == el->GetDigitSize() && m_secretKeyDist == el->GetSecretKeyDist() &&
-               m_stdLevel == el->GetStdLevel() && m_maxRelinSkDeg == el->GetMaxRelinSkDeg() &&
-               m_PREMode == el->GetPREMode() && m_multipartyMode == el->GetMultipartyMode() &&
-               m_executionMode == el->GetExecutionMode() &&
-               m_floodingDistributionParameter == el->GetFloodingDistributionParameter() &&
-               m_statisticalSecurity == el->GetStatisticalSecurity() &&
-               m_numAdversarialQueries == el->GetNumAdversarialQueries() &&
-               m_thresholdNumOfParties == el->GetThresholdNumOfParties();
-    }
-
     void PrintParameters(std::ostream& os) const {
         CryptoParametersBase<Element>::PrintParameters(os);
 
@@ -541,6 +514,33 @@ protected:
     double m_numAdversarialQueries = 1;
 
     usint m_thresholdNumOfParties = 1;
+
+    /**
+    * @brief CompareTo() is a method to compare two CryptoParametersRLWE objects.
+    *        It is called by CryptoParametersBase::operator==()
+    * @param rhs - the other CryptoParametersRLWE object to compare to.
+    * @return whether the two CryptoParametersRLWE objects are equivalent.
+    */
+    bool CompareTo(const CryptoParametersBase<Element>& rhs) const override {
+        const auto* el = dynamic_cast<const CryptoParametersRLWE<Element>*>(&rhs);
+        if (el == nullptr)
+            return false;
+
+        return CryptoParametersBase<Element>::CompareTo(*el) &&
+               this->GetPlaintextModulus() == el->GetPlaintextModulus() &&
+               *this->GetElementParams() == *el->GetElementParams() &&
+               *this->GetEncodingParams() == *el->GetEncodingParams() &&
+               m_distributionParameter == el->GetDistributionParameter() &&
+               m_assuranceMeasure == el->GetAssuranceMeasure() && m_noiseScale == el->GetNoiseScale() &&
+               m_digitSize == el->GetDigitSize() && m_secretKeyDist == el->GetSecretKeyDist() &&
+               m_stdLevel == el->GetStdLevel() && m_maxRelinSkDeg == el->GetMaxRelinSkDeg() &&
+               m_PREMode == el->GetPREMode() && m_multipartyMode == el->GetMultipartyMode() &&
+               m_executionMode == el->GetExecutionMode() &&
+               m_floodingDistributionParameter == el->GetFloodingDistributionParameter() &&
+               m_statisticalSecurity == el->GetStatisticalSecurity() &&
+               m_numAdversarialQueries == el->GetNumAdversarialQueries() &&
+               m_thresholdNumOfParties == el->GetThresholdNumOfParties();
+    }
 };
 
 }  // namespace lbcrypto

--- a/src/pke/include/schemebase/rlwe-cryptoparameters.h
+++ b/src/pke/include/schemebase/rlwe-cryptoparameters.h
@@ -129,7 +129,7 @@ public:
     /**
    * Virtual Destructor
    */
-    ~CryptoParametersRLWE() = default;
+    ~CryptoParametersRLWE() override = default;
 
     /**
    * Returns the value of standard deviation r for discrete Gaussian
@@ -174,7 +174,7 @@ public:
    *
    * @return the digit size.
    */
-    usint GetDigitSize() const {
+    uint32_t GetDigitSize() const override {
         return m_digitSize;
     }
 
@@ -184,7 +184,7 @@ public:
    *
    * @return maximum power of secret key
    */
-    uint32_t GetMaxRelinSkDeg() const {
+    uint32_t GetMaxRelinSkDeg() const override {
         return m_maxRelinSkDeg;
     }
 
@@ -414,14 +414,6 @@ public:
         m_thresholdNumOfParties = thresholdNumOfParties;
     }
 
-    void PrintParameters(std::ostream& os) const {
-        CryptoParametersBase<Element>::PrintParameters(os);
-
-        os << "Distrib parm " << GetDistributionParameter() << ", Assurance measure " << GetAssuranceMeasure()
-           << ", Noise scale " << GetNoiseScale() << ", Digit Size " << GetDigitSize() << ", SecretKeyDist "
-           << GetSecretKeyDist() << ", Standard security level " << GetStdLevel() << std::endl;
-    }
-
     template <class Archive>
     void save(Archive& ar, std::uint32_t const version) const {
         ar(::cereal::base_class<CryptoParametersBase<Element>>(this));
@@ -465,7 +457,7 @@ public:
         m_dggFlooding.SetStd(m_floodingDistributionParameter);
     }
 
-    std::string SerializedObjectName() const {
+    std::string SerializedObjectName() const override {
         return "CryptoParametersRLWE";
     }
 
@@ -479,7 +471,7 @@ protected:
     // noise scale
     PlaintextModulus m_noiseScale = 1;
     // digit size
-    usint m_digitSize = 1;
+    uint32_t m_digitSize = 1;
     // the highest power of secret key for which relinearization key is generated
     uint32_t m_maxRelinSkDeg = 2;
     // specifies whether the secret polynomials are generated from discrete
@@ -540,6 +532,14 @@ protected:
                m_statisticalSecurity == el->GetStatisticalSecurity() &&
                m_numAdversarialQueries == el->GetNumAdversarialQueries() &&
                m_thresholdNumOfParties == el->GetThresholdNumOfParties();
+    }
+
+    void PrintParameters(std::ostream& os) const override {
+        CryptoParametersBase<Element>::PrintParameters(os);
+
+        os << "Distrib parm " << GetDistributionParameter() << ", Assurance measure " << GetAssuranceMeasure()
+           << ", Noise scale " << GetNoiseScale() << ", Digit Size " << GetDigitSize() << ", SecretKeyDist "
+           << GetSecretKeyDist() << ", Standard security level " << GetStdLevel() << std::endl;
     }
 };
 

--- a/src/pke/include/schemerns/rns-cryptoparameters.h
+++ b/src/pke/include/schemerns/rns-cryptoparameters.h
@@ -140,7 +140,25 @@ protected:
         m_MPIntBootCiphertextCompressionLevel = mPIntBootCiphertextCompressionLevel;
     }
 
-    virtual ~CryptoParametersRNS() {}
+    ~CryptoParametersRNS() = default;
+
+    /**
+    * @brief CompareTo() is a method to compare two CryptoParametersRNS objects.
+    *        It is called by CryptoParametersBase::operator==()
+    * @param rhs - the other CryptoParametersRNS object to compare to.
+    * @return whether the two CryptoParametersRNS objects are equivalent.
+    */
+    bool CompareTo(const CryptoParametersBase<DCRTPoly>& rhs) const override {
+        const auto* el = dynamic_cast<const CryptoParametersRNS*>(&rhs);
+        if (el == nullptr)
+            return false;
+
+        return CryptoParametersRLWE<DCRTPoly>::CompareTo(rhs) && m_scalTechnique == el->GetScalingTechnique() &&
+               m_ksTechnique == el->GetKeySwitchTechnique() && m_multTechnique == el->GetMultiplicationTechnique() &&
+               m_encTechnique == el->GetEncryptionTechnique() && m_numPartQ == el->GetNumPartQ() &&
+               m_auxBits == el->GetAuxBits() && m_extraBits == el->GetExtraBits() && m_PREMode == el->GetPREMode() &&
+               m_multipartyMode == el->GetMultipartyMode() && m_executionMode == el->GetExecutionMode();
+    }
 
 public:
     /**
@@ -181,24 +199,6 @@ public:
    */
     static constexpr double EstimateMultipartyFloodingLogQ() {
         return static_cast<double>(NoiseFlooding::MULTIPARTY_MOD_SIZE * NoiseFlooding::NUM_MODULI_MULTIPARTY);
-    }
-
-    /**
-   * == operator to compare to this instance of CryptoParametersBase object.
-   *
-   * @param &rhs CryptoParameters to check equality against.
-   */
-    bool operator==(const CryptoParametersBase<DCRTPoly>& rhs) const override {
-        const auto* el = dynamic_cast<const CryptoParametersRNS*>(&rhs);
-
-        if (el == nullptr)
-            return false;
-
-        return CryptoParametersBase<DCRTPoly>::operator==(rhs) && m_scalTechnique == el->GetScalingTechnique() &&
-               m_ksTechnique == el->GetKeySwitchTechnique() && m_multTechnique == el->GetMultiplicationTechnique() &&
-               m_encTechnique == el->GetEncryptionTechnique() && m_numPartQ == el->GetNumPartQ() &&
-               m_auxBits == el->GetAuxBits() && m_extraBits == el->GetExtraBits() && m_PREMode == el->GetPREMode() &&
-               m_multipartyMode == el->GetMultipartyMode() && m_executionMode == el->GetExecutionMode();
     }
 
     void PrintParameters(std::ostream& os) const override {

--- a/src/pke/include/schemerns/rns-cryptoparameters.h
+++ b/src/pke/include/schemerns/rns-cryptoparameters.h
@@ -140,7 +140,7 @@ protected:
         m_MPIntBootCiphertextCompressionLevel = mPIntBootCiphertextCompressionLevel;
     }
 
-    ~CryptoParametersRNS() = default;
+    ~CryptoParametersRNS() override = default;
 
     /**
     * @brief CompareTo() is a method to compare two CryptoParametersRNS objects.
@@ -158,6 +158,10 @@ protected:
                m_encTechnique == el->GetEncryptionTechnique() && m_numPartQ == el->GetNumPartQ() &&
                m_auxBits == el->GetAuxBits() && m_extraBits == el->GetExtraBits() && m_PREMode == el->GetPREMode() &&
                m_multipartyMode == el->GetMultipartyMode() && m_executionMode == el->GetExecutionMode();
+    }
+
+    void PrintParameters(std::ostream& os) const override {
+        CryptoParametersRLWE<DCRTPoly>::PrintParameters(os);
     }
 
 public:
@@ -199,10 +203,6 @@ public:
    */
     static constexpr double EstimateMultipartyFloodingLogQ() {
         return static_cast<double>(NoiseFlooding::MULTIPARTY_MOD_SIZE * NoiseFlooding::NUM_MODULI_MULTIPARTY);
-    }
-
-    void PrintParameters(std::ostream& os) const override {
-        CryptoParametersBase<DCRTPoly>::PrintParameters(os);
     }
 
     /////////////////////////////////////

--- a/src/pke/unittest/utils/UnitTestMetadataTest.h
+++ b/src/pke/unittest/utils/UnitTestMetadataTest.h
@@ -74,7 +74,7 @@ public:
    * the Clone method.
    *
    */
-    std::shared_ptr<Metadata> Clone() const {
+    std::shared_ptr<Metadata> Clone() const override {
         auto mdata = std::make_shared<MetadataTest>();
         mdata->m_s = this->m_s;
         return mdata;
@@ -97,7 +97,7 @@ public:
     /**
    * Defines how to check equality between objects of this class.
    */
-    bool operator==(const Metadata& mdata) const {
+    bool operator==(const Metadata& mdata) const override {
         try {
             const MetadataTest& mdataTest = dynamic_cast<const MetadataTest&>(mdata);
             return m_s == mdataTest.GetMetadata();  // All Metadata objects without
@@ -106,14 +106,6 @@ public:
         catch (const std::bad_cast& e) {
             OPENFHE_THROW("Tried to downcast an object of different class to MetadataTest");
         }
-    }
-
-    /**
-   * Defines how to print the contents of objects of this class.
-   */
-    std::ostream& print(std::ostream& out) const {
-        out << "[ " << m_s << " ]";
-        return out;
     }
 
     /**
@@ -201,6 +193,14 @@ public:
     }
 
 protected:
+    /**
+    * Defines how to print the contents of objects of this class.
+    */
+    std::ostream& PrintMetadata(std::ostream& out) const override {
+        out << "[ " << m_s << " ]";
+        return out;
+    }
+
     std::string m_s;
 };
 


### PR DESCRIPTION
- Corrected operator== for the family of cryptoparameters classes
- Fixed syntax for multiple virtual functions and virtual destructors
- Made some print functions protected to force users to use operator<<()
- Fixed multiple various issues, etc.