### PR TITLE
Cleartext version of EvalChebyshevFunction

### DIFF
--- a/src/core/include/math/chebyshev.h
+++ b/src/core/include/math/chebyshev.h
@@ -50,9 +50,11 @@ namespace lbcrypto {
 
 /**
  * Method for calculating Chebyshev coefficients for an input function
- * over the range [a,b]. These coefficents can be input into
- * EValChebyshevSeries to evaluate the function.
- *
+ * over the range [a,b]. These coefficents are used in EValChebyshevSeries
+ * to approximate the function func as
+ *   func(x) ~ coeffs[0]/2 + sum_{i=1}^{degree} coeffs[i] * T_{i}(x),
+ * where T_{i}(x) are Chebyshev polynomials of the first kind. (Note that
+ * the 1st coeffiicent is divided by two.)
  * @param func is the function to be approximated
  * @param a - lower bound of argument for which the coefficients were found
  * @param b - upper bound of argument for which the coefficients were found
@@ -60,6 +62,20 @@ namespace lbcrypto {
  * @return the coefficients of the Chebyshev approximation.
  */
 std::vector<double> EvalChebyshevCoefficients(std::function<double(double)> func, double a, double b, uint32_t degree);
+
+/**
+ * A cleartext version of CryptoContext<...>::EvalChebyshevFunction(...).
+ * It evaluates an approximation of func via Chebyshev polynomials of a
+ * bounded degree, over a specified interval [a,b].
+ *
+ * @param func is the function to be approximated
+ * @param ptxt is a vector of plaintext inputs
+ * @param a is the bottom of the interval over chichfunc is approximated
+ * @param b is the top of the interval over chichfunc is approximated
+ * @param degree is the desired degree of approximation
+ * @return Evaluation of the approximated function over the plaintexts.
+ */
+std::vector<double> EvalChebyshevFunctionPtxt(std::function<double(double)> func, const std::vector<double> ptxt, double a, double b, size_t degree);
 
 }  // namespace lbcrypto
 


### PR DESCRIPTION
Added a few lines to the documentation of EvalChebyshevCoefficients, and also added a function EvalChebyshevFunctionPtxt that computes the same thing as CryptoContext->EvalChebyshevFunction but on cleartext vector<double>
