### PR TITLE
Cleartext chebyshev

### DIFF
--- a/src/core/include/math/chebyshev.h
+++ b/src/core/include/math/chebyshev.h
@@ -46,8 +46,6 @@
  */
 namespace lbcrypto {
 
-// move to cryptocontext?
-
 /**
  * Method for calculating Chebyshev coefficients for an input function
  * over the range [a,b]. These coefficents are used in EValChebyshevSeries

--- a/src/core/include/math/chebyshev.h
+++ b/src/core/include/math/chebyshev.h
@@ -50,9 +50,11 @@ namespace lbcrypto {
 
 /**
  * Method for calculating Chebyshev coefficients for an input function
- * over the range [a,b]. These coefficents can be input into
- * EValChebyshevSeries to evaluate the function.
- *
+ * over the range [a,b]. These coefficents are used in EValChebyshevSeries
+ * to approximate the function func as
+ *   func(x) ~ coeffs[0]/2 + sum_{i=1}^{degree} coeffs[i] * T_{i}(x),
+ * where T_{i}(x) are Chebyshev polynomials of the first kind. (Note that
+ * the 1st coeffiicent is divided by two.)
  * @param func is the function to be approximated
  * @param a - lower bound of argument for which the coefficients were found
  * @param b - upper bound of argument for which the coefficients were found
@@ -60,6 +62,20 @@ namespace lbcrypto {
  * @return the coefficients of the Chebyshev approximation.
  */
 std::vector<double> EvalChebyshevCoefficients(std::function<double(double)> func, double a, double b, uint32_t degree);
+
+/**
+ * A cleartext version of CryptoContext<...>::EvalChebyshevFunction(...).
+ * It evaluates an approximation of func via Chebyshev polynomials of a
+ * bounded degree, over a specified interval [a,b].
+ *
+ * @param func is the function to be approximated
+ * @param ptxt is a vector of plaintext inputs
+ * @param a is the bottom of the interval over chichfunc is approximated
+ * @param b is the top of the interval over chichfunc is approximated
+ * @param degree is the desired degree of approximation
+ * @return Evaluation of the approximated function over the plaintexts.
+ */
+std::vector<double> EvalChebyshevFunctionPtxt(std::function<double(double)> func, const std::vector<double> ptxt, double a, double b, size_t degree);
 
 }  // namespace lbcrypto
 

--- a/src/core/lib/math/chebyshev.cpp
+++ b/src/core/lib/math/chebyshev.cpp
@@ -71,11 +71,14 @@ std::vector<double> EvalChebyshevCoefficients(std::function<double(double)> func
 std::vector<double> EvalChebyshevFunctionPtxt(std::function<double(double)> func, const std::vector<double> ptxt, double a, double b, size_t degree)
 {
     auto coeffs = EvalChebyshevCoefficients(func, a, b, degree);
-    coeffs[0] /= 2.0; // For some reason we need this
-
-    // It seems to be standard practice to halve the 1st coeffiicent,
-    // see for example the Chebychev Series section at
+    
+    // The standard practice is to halve the 1st coefficient.
+    // See, for example, the Chebyshev Series section at
     // https://www.cfm.brown.edu/people/dobrush/am34/Mathematica/ch5/chebyshev.html
+    // and derivation of Eq. (6) in https://arxiv.org/pdf/1810.04282.
+    // The halving requirement follows from the discrete orthogonality relation for Chebyshev polynomials, 
+    // i.e., Eq. (4) in https://arxiv.org/pdf/1810.04282.
+    coeffs[0] /= 2.0; 
 
     // Special case for trivial case of a degee-0 approximation
     if (degree == 0) {

--- a/src/core/lib/math/chebyshev.cpp
+++ b/src/core/lib/math/chebyshev.cpp
@@ -67,4 +67,45 @@ std::vector<double> EvalChebyshevCoefficients(std::function<double(double)> func
     return coefficients;
 }
 
+// A cleartext version of CryptoContext<...>::EvalChebyshevFunction(...)
+std::vector<double> EvalChebyshevFunctionPtxt(std::function<double(double)> func, const std::vector<double> ptxt, double a, double b, size_t degree)
+{
+    auto coeffs = EvalChebyshevCoefficients(func, a, b, degree);
+    coeffs[0] /= 2.0; // For some reason we need this
+
+    // It seems to be standard practice to halve the 1st coeffiicent,
+    // see for example the Chebychev Series section at
+    // https://www.cfm.brown.edu/people/dobrush/am34/Mathematica/ch5/chebyshev.html
+
+    // Special case for trivial case of a degee-0 approximation
+    if (degree == 0) {
+        std::vector<double> result(ptxt.size(), coeffs[0]);
+        return result;
+    }
+
+    // If [a,b] is different than [-1,1] then need to scale the input
+    double scaleFactor = 2.0 / (b - a);
+    double offset = (b + a)*scaleFactor / -2.0;
+
+    std::vector<double> result(ptxt.size());
+    for (size_t i = 0; i < ptxt.size(); i++) {
+        double x = ptxt[i]*scaleFactor + offset;
+        double x2 = 2*x;
+
+        double t_prev = 1.0;   // T0(x) = 1
+        double t_j = x;        // T1(x) = x
+        double y = coeffs[0] + coeffs[1]*x;
+        // Use the recursive formula T_{i+1}(X) = 2x T_i(x) - T_{i-1}(x)
+        for (size_t j = 2; j < coeffs.size(); j++) {
+            // Compute T_j(x) and add it to the approximation
+            double t_next = x2*t_j - t_prev;
+            t_prev = t_j;
+            t_j = t_next;
+            y += coeffs[j]*t_next;
+        }
+        result[i] = y;
+    }
+    return result;
+}
+
 }  // namespace lbcrypto

--- a/src/pke/examples/function-evaluation.cpp
+++ b/src/pke/examples/function-evaluation.cpp
@@ -34,6 +34,7 @@
  */
 
 #include "openfhe.h"
+#include "math/chebyshev.h"
 
 using namespace lbcrypto;
 
@@ -168,6 +169,13 @@ void EvalFunctionExample() {
     std::vector<std::complex<double>> expectedOutput(
         {1, 1.414213, 1.732050, 2, 2.236067, 2.449489, 2.645751, 2.828427, 3});
     std::cout << "Expected output\n\t" << expectedOutput << std::endl;
+
+    // Compute the same approximation on cleartext data
+    std::vector<double> inputDouble{1, 2, 3, 4, 5, 6, 7, 8, 9};
+    auto ptxtApprox = EvalChebyshevFunctionPtxt(
+            [](double x) -> double { return std::sqrt(x); },
+            inputDouble, lowerBound, upperBound, polyDegree);
+    std::cout << "Cleartext output\n\t" << ptxtApprox << std::endl;
 
     std::vector<std::complex<double>> finalResult = plaintextDec->GetCKKSPackedValue();
     std::cout << "Actual output\n\t" << finalResult << std::endl << std::endl;


### PR DESCRIPTION
Added a few lines to the documentation of EvalChebyshevCoefficients, and also added a function EvalChebyshevFunctionPtxt that computes the same thing as CryptoContext->EvalChebyshevFunction but on cleartext vector