### PR TITLE
Add missing CCParams values to cryptocontext

### DIFF
--- a/src/pke/include/scheme/bfvrns/bfvrns-cryptoparameters.h
+++ b/src/pke/include/scheme/bfvrns/bfvrns-cryptoparameters.h
@@ -46,6 +46,7 @@ namespace lbcrypto {
 
 class CryptoParametersBFVRNS : public CryptoParametersRNS {
     using ParmType = typename DCRTPoly::Params;
+    #define DISABLED_FOR_BFVRNS_PARAMS OPENFHE_THROW("This parameter is not available for BFVRNS.");
 
 public:
     CryptoParametersBFVRNS() : CryptoParametersRNS() {}
@@ -84,6 +85,14 @@ public:
                              uint32_t extraBits) override;
 
     uint64_t FindAuxPrimeStep() const override;
+
+    uint32_t GetPRENumHops() const override {
+        DISABLED_FOR_BFVRNS_PARAMS;
+    }
+
+    double GetNoiseEstimate() const override {
+        DISABLED_FOR_BFVRNS_PARAMS;
+    }
 
     /////////////////////////////////////
     // SERIALIZATION

--- a/src/pke/include/scheme/bfvrns/gen-cryptocontext-bfvrns-internal.h
+++ b/src/pke/include/scheme/bfvrns/gen-cryptocontext-bfvrns-internal.h
@@ -84,6 +84,9 @@ typename ContextGeneratorType::ContextType genCryptoContextBFVRNSInternal(
 
     // for BFV scheme noise scale is always set to 1
     params->SetNoiseScale(1);
+    params->SetMultiplicativeDepth(parameters.GetMultiplicativeDepth());
+    params->SetEvalAddCount(parameters.GetEvalAddCount());
+    params->SetKeySwitchCount(parameters.GetKeySwitchCount());
 
     auto scheme = std::make_shared<typename ContextGeneratorType::PublicKeyEncryptionScheme>();
     scheme->SetKeySwitchingTechnique(parameters.GetKeySwitchTechnique());

--- a/src/pke/include/scheme/bgvrns/bgvrns-cryptoparameters.h
+++ b/src/pke/include/scheme/bgvrns/bgvrns-cryptoparameters.h
@@ -46,6 +46,7 @@ namespace lbcrypto {
 
 class CryptoParametersBGVRNS : public CryptoParametersRNS {
     using ParmType = typename DCRTPoly::Params;
+    #define DISABLED_FOR_BGVRNS_PARAMS OPENFHE_THROW("This parameter is not available for BGVRNS.");
 
 public:
     CryptoParametersBGVRNS() : CryptoParametersRNS() {}
@@ -84,6 +85,10 @@ public:
                              uint32_t extraBits) override;
 
     uint64_t FindAuxPrimeStep() const override;
+
+    double GetNoiseEstimate() const override {
+        DISABLED_FOR_BGVRNS_PARAMS;
+    }
 
     /////////////////////////////////////
     // SERIALIZATION

--- a/src/pke/include/scheme/bgvrns/bgvrns-leveledshe.h
+++ b/src/pke/include/scheme/bgvrns/bgvrns-leveledshe.h
@@ -69,6 +69,8 @@ public:
 
     void EvalMultCoreInPlace(Ciphertext<DCRTPoly>& ciphertext, const NativeInteger& constant) const;
 
+    void EvalMultInPlace(Ciphertext<DCRTPoly>& ciphertext, ConstPlaintext plaintext) const override;
+    
     void AdjustLevelsAndDepthInPlace(Ciphertext<DCRTPoly>& ciphertext1,
                                      Ciphertext<DCRTPoly>& ciphertext2) const override;
 

--- a/src/pke/include/scheme/bgvrns/gen-cryptocontext-bgvrns-internal.h
+++ b/src/pke/include/scheme/bgvrns/gen-cryptocontext-bgvrns-internal.h
@@ -83,6 +83,10 @@ typename ContextGeneratorType::ContextType genCryptoContextBGVRNSInternal(
 
     // for BGV scheme noise scale is always set to plaintext modulus
     params->SetNoiseScale(parameters.GetPlaintextModulus());
+    params->SetMultiplicativeDepth(parameters.GetMultiplicativeDepth());
+    params->SetEvalAddCount(parameters.GetEvalAddCount());
+    params->SetKeySwitchCount(parameters.GetKeySwitchCount());
+    params->SetPRENumHops(parameters.GetPRENumHops());
 
     auto numLargeDigits = (parameters.GetMultiplicativeDepth() == 0) ?
                               ComputeNumLargeDigitsPRE(parameters.GetNumLargeDigits(), parameters.GetPRENumHops()) :

--- a/src/pke/include/scheme/ckksrns/ckksrns-cryptoparameters.h
+++ b/src/pke/include/scheme/ckksrns/ckksrns-cryptoparameters.h
@@ -46,6 +46,7 @@ namespace lbcrypto {
 
 class CryptoParametersCKKSRNS : public CryptoParametersRNS {
     using ParmType = typename DCRTPoly::Params;
+    #define DISABLED_FOR_CKKSRNS_PARAMS OPENFHE_THROW("This parameter is not available for CKKSRNS.");
 
 public:
     CryptoParametersCKKSRNS() : CryptoParametersRNS() {}
@@ -95,6 +96,11 @@ public:
     uint64_t FindAuxPrimeStep() const override;
 
     void ConfigureCompositeDegree(usint scalingModSize);
+    
+    //PlaintextModulus GetPlaintextModulus() const override {
+        //DISABLED_FOR_CKKSRNS_PARAMS;
+    //}
+
 
     /////////////////////////////////////
     // SERIALIZATION

--- a/src/pke/include/scheme/ckksrns/ckksrns-cryptoparameters.h
+++ b/src/pke/include/scheme/ckksrns/ckksrns-cryptoparameters.h
@@ -101,6 +101,15 @@ public:
         //DISABLED_FOR_CKKSRNS_PARAMS;
     //}
 
+    uint32_t GetEvalAddCount() const override {
+        DISABLED_FOR_CKKSRNS_PARAMS;
+    }
+    uint32_t GetKeySwitchCount() const override {
+        DISABLED_FOR_CKKSRNS_PARAMS;
+    }
+    uint32_t GetPRENumHops() const override {
+        DISABLED_FOR_CKKSRNS_PARAMS;
+    }
 
     /////////////////////////////////////
     // SERIALIZATION

--- a/src/pke/include/scheme/ckksrns/ckksrns-leveledshe.h
+++ b/src/pke/include/scheme/ckksrns/ckksrns-leveledshe.h
@@ -109,6 +109,7 @@ public:
     Ciphertext<DCRTPoly> EvalMult(ConstCiphertext<DCRTPoly> ciphertext, double operand) const override;
 
     void EvalMultInPlace(Ciphertext<DCRTPoly>& ciphertext, double operand) const override;
+    void EvalMultInPlace(Ciphertext<DCRTPoly>& ciphertext, ConstPlaintext plaintext) const override;
 
     Ciphertext<DCRTPoly> EvalMult(ConstCiphertext<DCRTPoly> ciphertext, std::complex<double> operand) const override;
 

--- a/src/pke/include/scheme/ckksrns/gen-cryptocontext-ckksrns-internal.h
+++ b/src/pke/include/scheme/ckksrns/gen-cryptocontext-ckksrns-internal.h
@@ -123,6 +123,8 @@ typename ContextGeneratorType::ContextType genCryptoContextCKKSRNSInternal(
     // for CKKS scheme noise scale is always set to 1
     params->SetNoiseScale(1);
     params->SetFloodingDistributionParameter(floodingNoiseStd);
+    params->SetMultiplicativeDepth(parameters.GetMultiplicativeDepth());
+    params->SetNoiseEstimate(parameters.GetNoiseEstimate());
 
     uint32_t numLargeDigits =
         ComputeNumLargeDigits(parameters.GetNumLargeDigits(), parameters.GetMultiplicativeDepth());

--- a/src/pke/include/schemebase/base-cryptoparameters.h
+++ b/src/pke/include/schemebase/base-cryptoparameters.h
@@ -63,12 +63,14 @@ public:
 
     virtual ~CryptoParametersBase() = default;
 
+    // NOTE: some getters and setters are declared "virtual" as they should be overriden and disabled in
+    // some scheme-specific parameter classes derived from CryptoParametersBase
     /**
    * Returns the value of plaintext modulus p
    *
    * @return the plaintext modulus.
    */
-    PlaintextModulus GetPlaintextModulus() const {
+    virtual PlaintextModulus GetPlaintextModulus() const {
         return m_encodingParams->GetPlaintextModulus();
     }
 
@@ -79,6 +81,10 @@ public:
    */
     const std::shared_ptr<typename Element::Params> GetElementParams() const {
         return m_params;
+    }
+
+    uint32_t GetRingDimension() const {
+        return m_params->GetRingDimension();
     }
 
     virtual const std::shared_ptr<typename Element::Params> GetParamsPK() const = 0;
@@ -201,7 +207,7 @@ protected:
     * @return whether the two CryptoParametersBase objects are equivalent.
     */
     virtual bool CompareTo(const CryptoParametersBase<Element>& rhs) const {
-        return (*m_encodingParams == *(rhs.GetEncodingParams()) && *m_params == *(rhs.GetElementParams()));
+        return (*m_encodingParams == *(rhs.m_encodingParams) && *m_params == *(rhs.m_params));
     }
 
     virtual void PrintParameters(std::ostream& out) const {

--- a/src/pke/include/schemebase/base-leveledshe.h
+++ b/src/pke/include/schemebase/base-leveledshe.h
@@ -854,20 +854,16 @@ protected:
    * @return result of homomorphic multiplication of input ciphertexts.
    */
     Ciphertext<Element> EvalMultCore(ConstCiphertext<Element> ciphertext1, ConstCiphertext<Element> ciphertext2) const;
-
-    Ciphertext<Element> EvalSquareCore(ConstCiphertext<Element> ciphertext) const;
+    Ciphertext<Element> EvalMultCore(ConstCiphertext<Element> ciphertext, const Element& plaintext) const;
+    void EvalMultCoreInPlace(Ciphertext<Element>& ciphertext, const Element& plaintext) const;
 
     virtual Ciphertext<Element> EvalAddCore(ConstCiphertext<Element> ciphertext, const Element& plaintext) const;
-
     void EvalAddCoreInPlace(Ciphertext<Element>& ciphertext, const Element& plaintext) const;
 
     virtual Ciphertext<Element> EvalSubCore(ConstCiphertext<Element> ciphertext1, const Element& plaintext) const;
-
     void EvalSubCoreInPlace(Ciphertext<Element>& ciphertext1, const Element& plaintext) const;
 
-    Ciphertext<Element> EvalMultCore(ConstCiphertext<Element> ciphertext, const Element& plaintext) const;
-
-    void EvalMultCoreInPlace(Ciphertext<Element>& ciphertext, const Element& plaintext) const;
+    Ciphertext<Element> EvalSquareCore(ConstCiphertext<Element> ciphertext) const;
 };
 
 }  // namespace lbcrypto

--- a/src/pke/include/schemebase/rlwe-cryptoparameters.h
+++ b/src/pke/include/schemebase/rlwe-cryptoparameters.h
@@ -70,6 +70,11 @@ public:
         m_assuranceMeasure              = rhs.m_assuranceMeasure;
         m_noiseScale                    = rhs.m_noiseScale;
         m_digitSize                     = rhs.m_digitSize;
+        m_noiseEstimate                 = rhs.m_noiseEstimate;
+        m_multiplicativeDepth           = rhs.m_multiplicativeDepth;
+        m_evalAddCount                  = rhs.m_evalAddCount;
+        m_keySwitchCount                = rhs.m_keySwitchCount;
+        m_PRENumHops                    = rhs.m_PRENumHops;
         m_maxRelinSkDeg                 = rhs.m_maxRelinSkDeg;
         m_secretKeyDist                 = rhs.m_secretKeyDist;
         m_stdLevel                      = rhs.m_stdLevel;
@@ -101,7 +106,7 @@ public:
    * @param noiseScale used in HRA-secure PRE
    */
     CryptoParametersRLWE(std::shared_ptr<typename Element::Params> params, EncodingParams encodingParams,
-                         float distributionParameter, float assuranceMeasure, SecurityLevel stdLevel, usint digitSize,
+                         float distributionParameter, float assuranceMeasure, SecurityLevel stdLevel, uint32_t digitSize,
                          int maxRelinSkDeg = 2, SecretKeyDist secretKeyDist = GAUSSIAN,
                          ProxyReEncryptionMode PREMode = INDCPA, MultipartyMode multipartyMode = FIXED_NOISE_MULTIPARTY,
                          ExecutionMode executionMode             = EXEC_EVALUATION,
@@ -176,6 +181,22 @@ public:
    */
     uint32_t GetDigitSize() const override {
         return m_digitSize;
+    }
+
+    double GetNoiseEstimate() const {
+        return m_noiseEstimate;
+    }
+    uint32_t GetMultiplicativeDepth() const {
+        return m_multiplicativeDepth;
+    }
+    uint32_t GetEvalAddCount() const {
+        return m_evalAddCount;
+    }
+    uint32_t GetKeySwitchCount() const {
+        return m_keySwitchCount;
+    }
+    uint32_t GetPRENumHops() const {
+        return m_PRENumHops;
     }
 
     /**
@@ -337,8 +358,24 @@ public:
    * Sets the value of digit size
    * @param digitSize
    */
-    void SetDigitSize(usint digitSize) {
+    void SetDigitSize(uint32_t digitSize) {
         m_digitSize = digitSize;
+    }
+
+    void SetNoiseEstimate(double noiseEstimate) {
+        m_noiseEstimate = noiseEstimate;
+    }
+    void SetMultiplicativeDepth(uint32_t multiplicativeDepth) {
+        m_multiplicativeDepth = multiplicativeDepth;
+    }
+    void SetEvalAddCount(uint32_t evalAddCount) {
+        m_evalAddCount = evalAddCount;
+    }
+    void SetKeySwitchCount(uint32_t keySwitchCount) {
+        m_keySwitchCount = keySwitchCount;
+    }
+    void SetPRENumHops(uint32_t PRENumHops) {
+        m_PRENumHops = PRENumHops;
     }
 
     /**
@@ -421,6 +458,11 @@ public:
         ar(::cereal::make_nvp("am", m_assuranceMeasure));
         ar(::cereal::make_nvp("ns", m_noiseScale));
         ar(::cereal::make_nvp("rw", m_digitSize));
+        ar(::cereal::make_nvp("nest", m_noiseEstimate));
+        ar(::cereal::make_nvp("muld", m_multiplicativeDepth));
+        ar(::cereal::make_nvp("addc", m_evalAddCount));
+        ar(::cereal::make_nvp("kswc", m_keySwitchCount));
+        ar(::cereal::make_nvp("phops", m_PRENumHops));
         ar(::cereal::make_nvp("md", m_maxRelinSkDeg));
         ar(::cereal::make_nvp("mo", m_secretKeyDist));
         ar(::cereal::make_nvp("pmo", m_PREMode));
@@ -441,6 +483,11 @@ public:
         ar(::cereal::make_nvp("am", m_assuranceMeasure));
         ar(::cereal::make_nvp("ns", m_noiseScale));
         ar(::cereal::make_nvp("rw", m_digitSize));
+        ar(::cereal::make_nvp("nest", m_noiseEstimate));
+        ar(::cereal::make_nvp("muld", m_multiplicativeDepth));
+        ar(::cereal::make_nvp("addc", m_evalAddCount));
+        ar(::cereal::make_nvp("kswc", m_keySwitchCount));
+        ar(::cereal::make_nvp("phops", m_PRENumHops));
         ar(::cereal::make_nvp("md", m_maxRelinSkDeg));
         ar(::cereal::make_nvp("mo", m_secretKeyDist));
         ar(::cereal::make_nvp("pmo", m_PREMode));
@@ -472,6 +519,13 @@ protected:
     PlaintextModulus m_noiseScale = 1;
     // digit size
     uint32_t m_digitSize = 1;
+
+    double m_noiseEstimate{0};
+    uint32_t m_multiplicativeDepth{1};
+    uint32_t m_evalAddCount{0};
+    uint32_t m_keySwitchCount{0};
+    uint32_t m_PRENumHops{0};
+
     // the highest power of secret key for which relinearization key is generated
     uint32_t m_maxRelinSkDeg = 2;
     // specifies whether the secret polynomials are generated from discrete
@@ -505,7 +559,7 @@ protected:
     // security of CKKS in NOISE_FLOODING_DECRYPT mode.
     double m_numAdversarialQueries = 1;
 
-    usint m_thresholdNumOfParties = 1;
+    uint32_t m_thresholdNumOfParties = 1;
 
     /**
     * @brief CompareTo() is a method to compare two CryptoParametersRLWE objects.
@@ -519,19 +573,19 @@ protected:
             return false;
 
         return CryptoParametersBase<Element>::CompareTo(*el) &&
-               this->GetPlaintextModulus() == el->GetPlaintextModulus() &&
-               *this->GetElementParams() == *el->GetElementParams() &&
-               *this->GetEncodingParams() == *el->GetEncodingParams() &&
-               m_distributionParameter == el->GetDistributionParameter() &&
-               m_assuranceMeasure == el->GetAssuranceMeasure() && m_noiseScale == el->GetNoiseScale() &&
-               m_digitSize == el->GetDigitSize() && m_secretKeyDist == el->GetSecretKeyDist() &&
-               m_stdLevel == el->GetStdLevel() && m_maxRelinSkDeg == el->GetMaxRelinSkDeg() &&
-               m_PREMode == el->GetPREMode() && m_multipartyMode == el->GetMultipartyMode() &&
-               m_executionMode == el->GetExecutionMode() &&
-               m_floodingDistributionParameter == el->GetFloodingDistributionParameter() &&
-               m_statisticalSecurity == el->GetStatisticalSecurity() &&
-               m_numAdversarialQueries == el->GetNumAdversarialQueries() &&
-               m_thresholdNumOfParties == el->GetThresholdNumOfParties();
+               m_distributionParameter == el->m_distributionParameter &&
+               m_assuranceMeasure == el->m_assuranceMeasure && m_noiseScale == el->m_noiseScale &&
+               m_digitSize == el->m_digitSize && m_noiseEstimate == el->m_noiseEstimate &&
+               m_multiplicativeDepth == el->m_multiplicativeDepth && m_evalAddCount == el->m_evalAddCount &&
+               m_keySwitchCount == el->m_keySwitchCount && m_PRENumHops == el->m_PRENumHops &&
+               m_secretKeyDist == el->m_secretKeyDist &&
+               m_stdLevel == el->m_stdLevel && m_maxRelinSkDeg == el->m_maxRelinSkDeg &&
+               m_PREMode == el->m_PREMode && m_multipartyMode == el->m_multipartyMode &&
+               m_executionMode == el->m_executionMode &&
+               m_floodingDistributionParameter == el->m_floodingDistributionParameter &&
+               m_statisticalSecurity == el->m_statisticalSecurity &&
+               m_numAdversarialQueries == el->m_numAdversarialQueries &&
+               m_thresholdNumOfParties == el->m_thresholdNumOfParties;
     }
 
     void PrintParameters(std::ostream& os) const override {

--- a/src/pke/include/schemebase/rlwe-cryptoparameters.h
+++ b/src/pke/include/schemebase/rlwe-cryptoparameters.h
@@ -183,19 +183,19 @@ public:
         return m_digitSize;
     }
 
-    double GetNoiseEstimate() const {
+    virtual double GetNoiseEstimate() const {
         return m_noiseEstimate;
     }
-    uint32_t GetMultiplicativeDepth() const {
+    virtual uint32_t GetMultiplicativeDepth() const {
         return m_multiplicativeDepth;
     }
-    uint32_t GetEvalAddCount() const {
+    virtual uint32_t GetEvalAddCount() const {
         return m_evalAddCount;
     }
-    uint32_t GetKeySwitchCount() const {
+    virtual uint32_t GetKeySwitchCount() const {
         return m_keySwitchCount;
     }
-    uint32_t GetPRENumHops() const {
+    virtual uint32_t GetPRENumHops() const {
         return m_PRENumHops;
     }
 

--- a/src/pke/include/schemerns/rns-cryptoparameters.h
+++ b/src/pke/include/schemerns/rns-cryptoparameters.h
@@ -158,13 +158,13 @@ protected:
         if (el == nullptr)
             return false;
 
-        return CryptoParametersRLWE<DCRTPoly>::CompareTo(rhs) && m_scalTechnique == el->GetScalingTechnique() &&
-               m_ksTechnique == el->GetKeySwitchTechnique() && m_multTechnique == el->GetMultiplicationTechnique() &&
-               m_encTechnique == el->GetEncryptionTechnique() && m_numPartQ == el->GetNumPartQ() &&
-               m_auxBits == el->GetAuxBits() && m_extraBits == el->GetExtraBits() && m_PREMode == el->GetPREMode() &&
-               m_multipartyMode == el->GetMultipartyMode() && m_executionMode == el->GetExecutionMode() &&
-               m_compositeDegree == el->GetCompositeDegree() && m_registerWordSize == el->GetRegisterWordSize() &&
-               m_ckksDataType == el->GetCKKSDataType();
+        return CryptoParametersRLWE<DCRTPoly>::CompareTo(rhs) && m_scalTechnique == el->m_scalTechnique &&
+               m_ksTechnique == el->m_ksTechnique && m_multTechnique == el->m_multTechnique &&
+               m_encTechnique == el->m_encTechnique && m_numPartQ == el->m_numPartQ &&
+               m_auxBits == el->m_auxBits && m_extraBits == el->m_extraBits && m_PREMode == el->m_PREMode &&
+               m_multipartyMode == el->m_multipartyMode && m_executionMode == el->m_executionMode &&
+               m_compositeDegree == el->m_compositeDegree && m_registerWordSize == el->m_registerWordSize &&
+               m_ckksDataType == el->m_ckksDataType;
     }
 
     void PrintParameters(std::ostream& os) const override {

--- a/src/pke/lib/scheme/bgvrns/bgvrns-leveledshe.cpp
+++ b/src/pke/lib/scheme/bgvrns/bgvrns-leveledshe.cpp
@@ -252,6 +252,16 @@ void LeveledSHEBGVRNS::EvalMultCoreInPlace(Ciphertext<DCRTPoly>& ciphertext, con
     }
 }
 
+void LeveledSHEBGVRNS::EvalMultInPlace(Ciphertext<DCRTPoly>& ciphertext, ConstPlaintext plaintext) const {
+    LeveledSHERNS::EvalMultInPlace(ciphertext, plaintext);
+    const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersBGVRNS>(ciphertext->GetCryptoParameters());
+    if (cryptoParams->GetScalingTechnique() == FLEXIBLEAUTO || cryptoParams->GetScalingTechnique() == FLEXIBLEAUTOEXT) {
+        const auto plainMod = ciphertext->GetCryptoParameters()->GetPlaintextModulus();
+        ciphertext->SetScalingFactorInt(
+            ciphertext->GetScalingFactorInt().ModMul(ciphertext->GetScalingFactorInt(), plainMod));
+    }
+}
+
 usint LeveledSHEBGVRNS::FindAutomorphismIndex(usint index, usint m) const {
     return FindAutomorphismIndex2n(index, m);
 }

--- a/src/pke/lib/scheme/ckksrns/ckksrns-leveledshe.cpp
+++ b/src/pke/lib/scheme/ckksrns/ckksrns-leveledshe.cpp
@@ -150,6 +150,14 @@ void LeveledSHECKKSRNS::EvalMultInPlace(Ciphertext<DCRTPoly>& ciphertext, std::c
     EvalMultCoreInPlace(ciphertext, operand);
 }
 
+void LeveledSHECKKSRNS::EvalMultInPlace(Ciphertext<DCRTPoly>& ciphertext, ConstPlaintext plaintext) const {
+    LeveledSHERNS::EvalMultInPlace(ciphertext, plaintext);
+
+    const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersCKKSRNS>(ciphertext->GetCryptoParameters());
+    if (cryptoParams->GetScalingTechnique() != NORESCALE)
+        ciphertext->SetScalingFactor(ciphertext->GetScalingFactor() * ciphertext->GetScalingFactor());
+}
+
 /////////////////////////////////////////
 // SHE MULTIPLICATION PLAINTEXT
 /////////////////////////////////////////

--- a/src/pke/lib/schemerns/rns-leveledshe.cpp
+++ b/src/pke/lib/schemerns/rns-leveledshe.cpp
@@ -261,15 +261,6 @@ void LeveledSHERNS::EvalMultInPlace(Ciphertext<DCRTPoly>& ciphertext, ConstPlain
         EvalMultCoreInPlace(ciphertext, ctmorphed->GetElements()[0]);
 
         ciphertext->SetNoiseScaleDeg(ciphertext->GetNoiseScaleDeg() + ctmorphed->GetNoiseScaleDeg());
-        // TODO (Andrey) : This part is only used in CKKS scheme
-        ciphertext->SetScalingFactor(ciphertext->GetScalingFactor() * ctmorphed->GetScalingFactor());
-        // TODO (Andrey) : This part is only used in BGV scheme
-        if (cryptoParams->GetScalingTechnique() == FLEXIBLEAUTO ||
-            cryptoParams->GetScalingTechnique() == FLEXIBLEAUTOEXT) {
-            const auto plainMod = ciphertext->GetCryptoParameters()->GetPlaintextModulus();
-            ciphertext->SetScalingFactorInt(
-                ciphertext->GetScalingFactorInt().ModMul(ctmorphed->GetScalingFactorInt(), plainMod));
-        }
     }
 }
 


### PR DESCRIPTION
Adds to the following parameters to `CryptoParametersRLWE` so that they could be accessed through the Crypto Context.
```
  double m_noiseEstimate{0};
  uint32_t m_multiplicativeDepth{1};
  uint32_t m_evalAddCount{0};
  uint32_t m_keySwitchCount{0};
  uint32_t m_PRENumHops{0};
```