### PR TITLE
Replace CloneZero with CloneEmpty

### DIFF
--- a/src/pke/include/ciphertext.h
+++ b/src/pke/include/ciphertext.h
@@ -126,19 +126,7 @@ public:
    * @param &rhs the CiphertextImpl to assign from
    * @return this CiphertextImpl
    */
-    CiphertextImpl<Element>& operator=(const CiphertextImpl<Element>& rhs) {
-        CryptoObject<Element>::operator=(rhs);
-        m_elements         = rhs.m_elements;
-        m_slots            = rhs.m_slots;
-        m_level            = rhs.m_level;
-        m_hopslevel        = rhs.m_hopslevel;
-        m_noiseScaleDeg    = rhs.m_noiseScaleDeg;
-        m_scalingFactor    = rhs.m_scalingFactor;
-        m_scalingFactorInt = rhs.m_scalingFactorInt;
-        m_encodingType     = rhs.m_encodingType;
-        m_metadataMap      = rhs.m_metadataMap;
-        return *this;
-    }
+    CiphertextImpl<Element>& operator=(const CiphertextImpl<Element>& rhs) = default;
 
     /**
    * Move Assignment Operator.
@@ -146,19 +134,7 @@ public:
    * @param &rhs the CiphertextImpl to move from
    * @return this CiphertextImpl
    */
-    CiphertextImpl<Element>& operator=(CiphertextImpl<Element>&& rhs) noexcept {
-        CryptoObject<Element>::operator=(std::move(rhs));
-        m_elements         = std::move(rhs.m_elements);
-        m_noiseScaleDeg    = std::move(rhs.m_noiseScaleDeg);
-        m_level            = std::move(rhs.m_level);
-        m_hopslevel        = std::move(rhs.m_hopslevel);
-        m_scalingFactor    = std::move(rhs.m_scalingFactor);
-        m_scalingFactorInt = std::move(rhs.m_scalingFactorInt);
-        m_encodingType     = std::move(rhs.m_encodingType);
-        m_slots            = std::move(rhs.m_slots);
-        m_metadataMap      = std::move(rhs.m_metadataMap);
-        return *this;
-    }
+    CiphertextImpl<Element>& operator=(CiphertextImpl<Element>&& rhs) noexcept = default;
 
     /**
    * GetElement - get the ring element for the cases that use only one element

--- a/src/pke/include/ciphertext.h
+++ b/src/pke/include/ciphertext.h
@@ -129,13 +129,13 @@ public:
     CiphertextImpl<Element>& operator=(const CiphertextImpl<Element>& rhs) {
         CryptoObject<Element>::operator=(rhs);
         m_elements         = rhs.m_elements;
-        m_noiseScaleDeg    = rhs.m_noiseScaleDeg;
+        m_slots            = rhs.m_slots;
         m_level            = rhs.m_level;
         m_hopslevel        = rhs.m_hopslevel;
+        m_noiseScaleDeg    = rhs.m_noiseScaleDeg;
         m_scalingFactor    = rhs.m_scalingFactor;
         m_scalingFactorInt = rhs.m_scalingFactorInt;
         m_encodingType     = rhs.m_encodingType;
-        m_slots            = rhs.m_slots;
         m_metadataMap      = rhs.m_metadataMap;
         return *this;
     }
@@ -417,27 +417,21 @@ public:
    * and metadata.
    */
     virtual Ciphertext<Element> CloneEmpty() const {
-        Ciphertext<Element> ct(
-            std::make_shared<CiphertextImpl<Element>>(this->GetCryptoContext(), this->GetKeyTag(), m_encodingType));
-        *(ct->m_metadataMap) = *(m_metadataMap);
+        auto ct(std::make_shared<CiphertextImpl<Element>>(this->GetCryptoContext(), this->GetKeyTag(), m_encodingType));
+        ct->m_slots            = m_slots;
+        ct->m_level            = m_level;
+        ct->m_hopslevel        = m_hopslevel;
+        ct->m_noiseScaleDeg    = m_noiseScaleDeg;
+        ct->m_scalingFactor    = m_scalingFactor;
+        ct->m_scalingFactorInt = m_scalingFactorInt;
+        *(ct->m_metadataMap)   = *(m_metadataMap);
         return ct;
     }
 
     virtual Ciphertext<Element> Clone() const {
-        Ciphertext<Element> cRes = this->CloneZero();
-        cRes->SetElements(m_elements);
-        return cRes;
-    }
-
-    virtual Ciphertext<Element> CloneZero() const {
-        Ciphertext<Element> cRes = this->CloneEmpty();
-        cRes->SetNoiseScaleDeg(this->GetNoiseScaleDeg());
-        cRes->SetLevel(this->GetLevel());
-        cRes->SetHopLevel(this->GetHopLevel());
-        cRes->SetScalingFactor(this->GetScalingFactor());
-        cRes->SetScalingFactorInt(this->GetScalingFactorInt());
-        cRes->SetSlots(this->GetSlots());
-        return cRes;
+        auto ct        = this->CloneEmpty();
+        ct->m_elements = m_elements;
+        return ct;
     }
 
     bool operator==(const CiphertextImpl<Element>& rhs) const {

--- a/src/pke/lib/keyswitch/keyswitch-hybrid.cpp
+++ b/src/pke/lib/keyswitch/keyswitch-hybrid.cpp
@@ -236,20 +236,20 @@ Ciphertext<DCRTPoly> KeySwitchHYBRID::KeySwitchExt(ConstCiphertext<DCRTPoly> cip
     const auto paramsP   = cryptoParams->GetParamsP();
     const auto paramsQlP = cv[0].GetExtendedCRTBasis(paramsP);
 
-    size_t sizeQl = paramsQl->GetParams().size();
-    usint sizeCv  = cv.size();
+    uint32_t sizeQl = paramsQl->GetParams().size();
+    uint32_t sizeCv = cv.size();
     std::vector<DCRTPoly> resultElements(sizeCv);
-    for (usint k = 0; k < sizeCv; k++) {
+    for (uint32_t k = 0; k < sizeCv; ++k) {
         resultElements[k] = DCRTPoly(paramsQlP, Format::EVALUATION, true);
         if ((addFirst) || (k > 0)) {
             auto cMult = cv[k].TimesNoCheck(cryptoParams->GetPModq());
-            for (usint i = 0; i < sizeQl; i++) {
+            for (uint32_t i = 0; i < sizeQl; ++i) {
                 resultElements[k].SetElementAtIndex(i, std::move(cMult.GetElementAtIndex(i)));
             }
         }
     }
 
-    Ciphertext<DCRTPoly> result = ciphertext->CloneZero();
+    auto result = ciphertext->CloneEmpty();
     result->SetElements(std::move(resultElements));
     return result;
 }
@@ -286,8 +286,8 @@ Ciphertext<DCRTPoly> KeySwitchHYBRID::KeySwitchDown(ConstCiphertext<DCRTPoly> ci
                                            cryptoParams->GetModqBarrettMu(), cryptoParams->GettInvModp(),
                                            cryptoParams->GettInvModpPrecon(), t, cryptoParams->GettModqPrecon());
 
-    Ciphertext<DCRTPoly> result = ciphertext->CloneZero();
-    result->SetElements(std::vector<DCRTPoly>{std::move(ct0), std::move(ct1)});
+    auto result = ciphertext->CloneEmpty();
+    result->SetElements({std::move(ct0), std::move(ct1)});
     return result;
 }
 

--- a/src/pke/lib/scheme/bfvrns/bfvrns-leveledshe.cpp
+++ b/src/pke/lib/scheme/bfvrns/bfvrns-leveledshe.cpp
@@ -347,7 +347,7 @@ Ciphertext<DCRTPoly> LeveledSHEBFVRNS::EvalMult(ConstCiphertext<DCRTPoly> cipher
     for (size_t i = 0; i < cv1Size; i++) {
         for (size_t j = 0; j < cv2Size; j++) {
             if (isFirstAdd[i + j] == true) {
-                cvMult[i + j]     = cv1[i] * cv2[j];
+                cvMult[i + j] = cv1[i] * cv2[j];
                 isFirstAdd[i + j] = false;
             }
             else {
@@ -424,7 +424,7 @@ Ciphertext<DCRTPoly> LeveledSHEBFVRNS::EvalMult(ConstCiphertext<DCRTPoly> cipher
         }
     }
 
-    ciphertextMult->SetElements(std::move(cvMult));
+    ciphertextMult->SetElements({std::move(cvMult)});
     ciphertextMult->SetNoiseScaleDeg(std::max(ciphertext1->GetNoiseScaleDeg(), ciphertext2->GetNoiseScaleDeg()) + 1);
     return ciphertextMult;
 }
@@ -617,7 +617,7 @@ Ciphertext<DCRTPoly> LeveledSHEBFVRNS::EvalSquare(ConstCiphertext<DCRTPoly> ciph
                         cvSquare[i + j] = cv[i] * cv[j];
                     }
                     else {
-                        cvtemp          = cv[i] * cv[j];
+                        cvtemp = cv[i] * cv[j];
                         cvSquare[i + j] = cvtemp;
                         cvSquare[i + j] += cvtemp;
                     }
@@ -640,7 +640,7 @@ Ciphertext<DCRTPoly> LeveledSHEBFVRNS::EvalSquare(ConstCiphertext<DCRTPoly> ciph
         for (size_t i = 0; i < cvSize; i++) {
             for (size_t j = 0; j < cvSize; j++) {
                 if (isFirstAdd[i + j] == true) {
-                    cvSquare[i + j]   = cv[i] * cvPoverQ[j];
+                    cvSquare[i + j] = cv[i] * cvPoverQ[j];
                     isFirstAdd[i + j] = false;
                 }
                 else {

--- a/src/pke/lib/scheme/bfvrns/bfvrns-leveledshe.cpp
+++ b/src/pke/lib/scheme/bfvrns/bfvrns-leveledshe.cpp
@@ -424,7 +424,7 @@ Ciphertext<DCRTPoly> LeveledSHEBFVRNS::EvalMult(ConstCiphertext<DCRTPoly> cipher
         }
     }
 
-    ciphertextMult->SetElements({std::move(cvMult)});
+    ciphertextMult->SetElements(std::move(cvMult));
     ciphertextMult->SetNoiseScaleDeg(std::max(ciphertext1->GetNoiseScaleDeg(), ciphertext2->GetNoiseScaleDeg()) + 1);
     return ciphertextMult;
 }

--- a/src/pke/lib/scheme/ckksrns/ckksrns-leveledshe.cpp
+++ b/src/pke/lib/scheme/ckksrns/ckksrns-leveledshe.cpp
@@ -594,10 +594,8 @@ Ciphertext<DCRTPoly> LeveledSHECKKSRNS::EvalFastRotationExt(
     (*cTilda)[0] = (*cTilda)[0].AutomorphismTransform(autoIndex, vec);
     (*cTilda)[1] = (*cTilda)[1].AutomorphismTransform(autoIndex, vec);
 
-    Ciphertext<DCRTPoly> result = ciphertext->CloneZero();
-
+    auto result = ciphertext->CloneEmpty();
     result->SetElements({std::move((*cTilda)[0]), std::move((*cTilda)[1])});
-
     return result;
 }
 
@@ -609,7 +607,7 @@ Ciphertext<DCRTPoly> LeveledSHECKKSRNS::MultByInteger(ConstCiphertext<DCRTPoly> 
     for (const auto& elem : cv)
         resultDCRT.push_back(elem.Times(NativeInteger(integer)));
 
-    Ciphertext<DCRTPoly> result = ciphertext->CloneZero();
+    auto result = ciphertext->CloneEmpty();
     result->SetElements(std::move(resultDCRT));
     return result;
 }

--- a/src/pke/lib/schemebase/base-leveledshe.cpp
+++ b/src/pke/lib/schemebase/base-leveledshe.cpp
@@ -588,16 +588,14 @@ Ciphertext<Element> LeveledSHEBase<Element>::MorphPlaintext(ConstPlaintext plain
                                                             ConstCiphertext<Element> ciphertext) const {
     auto result = ciphertext->CloneEmpty();
 
-    result->SetNoiseScaleDeg(plaintext->GetNoiseScaleDeg());
+    auto elem = plaintext->GetElement<Element>();
+    elem.SetFormat(EVALUATION);
+    result->SetElement(std::move(elem));
+    result->SetSlots(plaintext->GetSlots());
     result->SetLevel(plaintext->GetLevel());
+    result->SetNoiseScaleDeg(plaintext->GetNoiseScaleDeg());
     result->SetScalingFactor(plaintext->GetScalingFactor());
     result->SetScalingFactorInt(plaintext->GetScalingFactorInt());
-    result->SetSlots(plaintext->GetSlots());
-
-    Element pt = plaintext->GetElement<Element>();
-    pt.SetFormat(EVALUATION);
-    result->SetElements({pt});
-
     return result;
 }
 
@@ -606,8 +604,7 @@ Ciphertext<Element> LeveledSHEBase<Element>::MorphPlaintext(ConstPlaintext plain
 /////////////////////////////////////////
 template <class Element>
 void LeveledSHEBase<Element>::VerifyNumOfTowers(ConstCiphertext<Element>& ciphertext1,
-                                                ConstCiphertext<Element>& ciphertext2,
-                                                CALLER_INFO_ARGS_CPP) const {
+                                                ConstCiphertext<Element>& ciphertext2, CALLER_INFO_ARGS_CPP) const {
     uint32_t numTowers1 = ciphertext1->GetElements()[0].GetNumOfElements();
     uint32_t numTowers2 = ciphertext2->GetElements()[0].GetNumOfElements();
     if (numTowers1 != numTowers2) {
@@ -696,7 +693,7 @@ template <class Element>
 Ciphertext<Element> LeveledSHEBase<Element>::EvalMultCore(ConstCiphertext<Element> ciphertext1,
                                                           ConstCiphertext<Element> ciphertext2) const {
     VerifyNumOfTowers(ciphertext1, ciphertext2);
-    Ciphertext<Element> result = ciphertext1->CloneZero();
+    auto result = ciphertext1->CloneEmpty();
 
     std::vector<Element> cv1        = ciphertext1->GetElements();
     const std::vector<Element>& cv2 = ciphertext2->GetElements();
@@ -737,7 +734,7 @@ Ciphertext<Element> LeveledSHEBase<Element>::EvalMultCore(ConstCiphertext<Elemen
 
 template <class Element>
 Ciphertext<Element> LeveledSHEBase<Element>::EvalSquareCore(ConstCiphertext<Element> ciphertext) const {
-    Ciphertext<Element> result = ciphertext->CloneZero();
+    auto result = ciphertext->CloneEmpty();
 
     const std::vector<Element>& cv = ciphertext->GetElements();
 

--- a/src/pke/lib/schemebase/base-multiparty.cpp
+++ b/src/pke/lib/schemebase/base-multiparty.cpp
@@ -40,7 +40,6 @@
 
 #include "schemebase/base-scheme.h"
 
-
 namespace lbcrypto {
 
 // makeSparse is not used by this scheme
@@ -239,8 +238,8 @@ Ciphertext<Element> MultipartyBase<Element>::MultipartyDecryptLead(ConstCipherte
     Element b = cv[0] + s * cv[1] + ns * e;
     //  b.SwitchFormat();
 
-    Ciphertext<Element> result = ciphertext->CloneEmpty();
-    result->SetElements({std::move(b)});
+    auto result = ciphertext->CloneEmpty();
+    result->SetElement(std::move(b));
     return result;
 }
 
@@ -262,8 +261,8 @@ Ciphertext<Element> MultipartyBase<Element>::MultipartyDecryptMain(ConstCipherte
     // e is added to do noise flooding
     Element b = s * cv[1] + es * e;
 
-    Ciphertext<Element> result = ciphertext->CloneEmpty();
-    result->SetElements({std::move(b)});
+    auto result = ciphertext->CloneEmpty();
+    result->SetElement(std::move(b));
     return result;
 }
 

--- a/src/pke/lib/schemerns/rns-multiparty.cpp
+++ b/src/pke/lib/schemerns/rns-multiparty.cpp
@@ -103,16 +103,8 @@ Ciphertext<DCRTPoly> MultipartyRNS::MultipartyDecryptLead(ConstCiphertext<DCRTPo
     // e is added to do noise flooding
     DCRTPoly b = cv[0] + s * cv[1] + ns * noise;
 
-    Ciphertext<DCRTPoly> result = ciphertext->CloneEmpty();
-
-    result->SetElements({std::move(b)});
-
-    result->SetNoiseScaleDeg(ciphertext->GetNoiseScaleDeg());
-    result->SetLevel(ciphertext->GetLevel());
-    result->SetScalingFactor(ciphertext->GetScalingFactor());
-    result->SetScalingFactorInt(ciphertext->GetScalingFactorInt());
-    result->SetSlots(ciphertext->GetSlots());
-
+    auto result = ciphertext->CloneEmpty();
+    result->SetElement(std::move(b));
     return result;
 }
 
@@ -172,16 +164,8 @@ Ciphertext<DCRTPoly> MultipartyRNS::MultipartyDecryptMain(ConstCiphertext<DCRTPo
     // noise is added to do noise flooding
     DCRTPoly b = s * cv[1] + ns * noise;
 
-    Ciphertext<DCRTPoly> result = ciphertext->CloneEmpty();
-
-    result->SetElements({std::move(b)});
-
-    result->SetNoiseScaleDeg(ciphertext->GetNoiseScaleDeg());
-    result->SetLevel(ciphertext->GetLevel());
-    result->SetScalingFactor(ciphertext->GetScalingFactor());
-    result->SetScalingFactorInt(ciphertext->GetScalingFactorInt());
-    result->SetSlots(ciphertext->GetSlots());
-
+    auto result = ciphertext->CloneEmpty();
+    result->SetElement(std::move(b));
     return result;
 }
 
@@ -257,7 +241,7 @@ EvalKey<DCRTPoly> MultipartyRNS::MultiMultEvalKey(PrivateKey<DCRTPoly> privateKe
 // it prevents an overflow during interactive bootstrapping
 void PolynomialRound(DCRTPoly& dcrtpoly) {
     const uint32_t NUM_TOWERS = dcrtpoly.GetNumOfElements();
-    if ( 2 != NUM_TOWERS) {
+    if (2 != NUM_TOWERS) {
         OPENFHE_THROW("The input polynomial has " + std::to_string(NUM_TOWERS) + " instead of 2 RNS limbs");
     }
 
@@ -390,8 +374,8 @@ void ExtendBasis(DCRTPoly& dcrtpoly, const std::shared_ptr<DCRTPoly::Params> par
 Ciphertext<DCRTPoly> MultipartyRNS::IntBootDecrypt(const PrivateKey<DCRTPoly> privateKey,
                                                    ConstCiphertext<DCRTPoly> ciphertext) const {
     const size_t NUM_POLYNOMIALS = ciphertext->NumberCiphertextElements();
-    if(NUM_POLYNOMIALS != 1 && NUM_POLYNOMIALS != 2) {
-        std::string msg ="Ciphertext should contain either one or two polynomials. The input ciphertext has " +
+    if (NUM_POLYNOMIALS != 1 && NUM_POLYNOMIALS != 2) {
+        std::string msg = "Ciphertext should contain either one or two polynomials. The input ciphertext has " +
                           std::to_string(NUM_POLYNOMIALS) + ".";
         OPENFHE_THROW(msg);
     }
@@ -402,7 +386,7 @@ Ciphertext<DCRTPoly> MultipartyRNS::IntBootDecrypt(const PrivateKey<DCRTPoly> pr
     size_t sizeQl = c[0].GetParams()->GetParams().size();
 
     const DCRTPoly& s = privateKey->GetPrivateElement();
-    size_t sizeQ  = s.GetParams()->GetParams().size();
+    size_t sizeQ      = s.GetParams()->GetParams().size();
 
     size_t diffQl = sizeQ - sizeQl;
 
@@ -429,7 +413,6 @@ Ciphertext<DCRTPoly> MultipartyRNS::IntBootEncrypt(const PublicKey<DCRTPoly> pub
     using TugType  = typename DCRTPoly::TugType;
     using ParmType = typename DCRTPoly::Params;
 
-
     const auto cryptoParams =
         std::static_pointer_cast<CryptoParametersRLWE<DCRTPoly>>(publicKey->GetCryptoParameters());
 
@@ -440,7 +423,7 @@ Ciphertext<DCRTPoly> MultipartyRNS::IntBootEncrypt(const PublicKey<DCRTPoly> pub
     ExtendBasis(ptxt, cryptoParams->GetElementParams());
 
     const std::shared_ptr<ParmType> ptxtParams = ptxt.GetParams();
-    const DggType& dgg = cryptoParams->GetDiscreteGaussianGenerator();
+    const DggType& dgg                         = cryptoParams->GetDiscreteGaussianGenerator();
     TugType tug;
 
     // Supports both discrete Gaussian (GAUSSIAN) and ternary uniform distribution (UNIFORM_TERNARY) cases


### PR DESCRIPTION
Cleanup of ciphertext.h
- proper implementation of constructors and assignment operators
- rename encodingType to m_encodingType to match convention of other data members
- reordering of data members for better alignment
- more efficient implementation of operator==
- more efficient return type for various member functions
- formatting

Replace ciphertext::CloneZero() with ciphertext::CloneEmpty()
- new implementation of CloneEmpty() that mimics CloneZero()
- removed CloneZero()
- proper use of new CloneEmpty() everywhere in repo that previously used CloneZero() or CloneEmpty()
- formatting