### PR TITLE
Making BGV/BFV noise estimates more conservative

### DIFF
--- a/src/pke/lib/scheme/bfvrns/bfvrns-leveledshe.cpp
+++ b/src/pke/lib/scheme/bfvrns/bfvrns-leveledshe.cpp
@@ -42,6 +42,13 @@ BFV implementation. See https://eprint.iacr.org/2021/204 for details.
 #include "cryptocontext.h"
 #include "ciphertext.h"
 
+#include <algorithm>
+#include <map>
+#include <utility>
+#include <memory>
+#include <vector>
+#include <string>
+
 namespace lbcrypto {
 
 void LeveledSHEBFVRNS::EvalAddInPlace(Ciphertext<DCRTPoly>& ciphertext, ConstPlaintext plaintext) const {
@@ -110,15 +117,20 @@ uint32_t FindLevelsToDrop(uint32_t multiplicativeDepth, std::shared_ptr<CryptoPa
 
     double w = std::pow(2, relinWindow == 0 ? dcrtBits : relinWindow);
 
-    // expansion factor delta
+    // expansion factor delta for a multiplication of a Gaussian polynomial by a random polynomial
     auto delta = [](uint32_t n) -> double {
         return (2. * std::sqrt(n));
+    };
+
+    // expansion factor delta for modulus switching
+    auto deltaMS = [](uint32_t n) -> double {
+        return (4. * std::sqrt(n));
     };
 
     // norm of fresh ciphertext polynomial (for EXTENDED the noise is reduced to modulus switching noise)
     auto Vnorm = [&](uint32_t n) -> double {
         if (encTech == EXTENDED)
-            return (1. + delta(n) * Bkey) / 2.;
+            return (1. + deltaMS(n) * Bkey) / 2.;
         else
             return Berr * (1. + 2. * delta(n) * Bkey);
     };
@@ -128,7 +140,7 @@ uint32_t FindLevelsToDrop(uint32_t multiplicativeDepth, std::shared_ptr<CryptoPa
 #if defined(WITH_REDUCED_NOISE)
             return k * (numPartQ * delta(n) * Berr + delta(n) * Bkey + 1.0) / 2.0;
 #else
-            return k * (numPartQ * delta(n) * Berr + delta(n) * Bkey + 1.0);
+            return k * (numPartQ * delta(n) * Berr + deltaMS(n) * Bkey + 1.0);
 #endif
         else {
             double numDigitsPerTower = (relinWindow == 0) ? 1 : ((dcrtBits / relinWindow) + 1);
@@ -138,12 +150,12 @@ uint32_t FindLevelsToDrop(uint32_t multiplicativeDepth, std::shared_ptr<CryptoPa
 
     // function used in the EvalMult constraint
     auto C1 = [&](uint32_t n) -> double {
-        return delta(n) * delta(n) * p * Bkey;
+        return delta(n) * deltaMS(n) * p * Bkey;
     };
 
     // function used in the EvalMult constraint
     auto C2 = [&](uint32_t n, double logqPrev) -> double {
-        return delta(n) * delta(n) * Bkey * Bkey / 2.0 + noiseKS(n, logqPrev, w);
+        return delta(n) * deltaMS(n) * Bkey * Bkey / 2.0 + noiseKS(n, logqPrev, w);
     };
 
     // main correctness constraint
@@ -167,7 +179,7 @@ uint32_t FindLevelsToDrop(uint32_t multiplicativeDepth, std::shared_ptr<CryptoPa
     // get an estimate of the error q / (4t)
     double loge = logq / log(2) - 2 - log2(p);
 
-    double logExtra = keySwitch ? log2(noiseKS(n, logq, w)) : log2(delta(n));
+    double logExtra = keySwitch ? log2(noiseKS(n, logq, w)) : log2(deltaMS(n));
 
     // adding the cushon to the error (see Appendix D of https://eprint.iacr.org/2021/204.pdf for details)
     // adjusted empirical parameter to 16 from 4 for threshold scenarios to work correctly, this might need to

--- a/src/pke/lib/scheme/bfvrns/bfvrns-parametergeneration.cpp
+++ b/src/pke/lib/scheme/bfvrns/bfvrns-parametergeneration.cpp
@@ -101,15 +101,20 @@ bool ParameterGenerationBFVRNS::ParamsGenBFVRNSInternal(std::shared_ptr<CryptoPa
         distType = HEStd_ternary;
     }
 
-    // expansion factor delta
+    // expansion factor delta for a multiplication of a Gaussian polynomial by a random polynomial
     auto delta = [](uint32_t n) -> double {
         return (2. * std::sqrt(n));
+    };
+
+    // expansion factor delta for modulus switching
+    auto deltaMS = [](uint32_t n) -> double {
+        return (4. * std::sqrt(n));
     };
 
     // norm of fresh ciphertext polynomial (for EXTENDED the noise is reduced to modulus switching noise)
     auto Vnorm = [&](uint32_t n) -> double {
         if (encTech == EXTENDED)
-            return (1. + delta(n) * Bkey) / 2.;
+            return (1. + deltaMS(n) * Bkey) / 2.;
         else
             return Berr * (1. + 2. * delta(n) * Bkey);
     };
@@ -145,9 +150,9 @@ bool ParameterGenerationBFVRNS::ParamsGenBFVRNSInternal(std::shared_ptr<CryptoPa
             // of digits and moduli at this point and use upper bounds
             double numTowers = std::ceil(logqPrev / dcrtBits);
 #if defined(WITH_REDUCED_NOISE)
-            return numTowers * (delta(n) * Berr + delta(n) * Bkey + 1.0) / 2.0;
+            return numTowers * (delta(n) * Berr + deltaMS(n) * Bkey + 1.0) / 2.0;
 #else
-            return numTowers * (delta(n) * Berr + delta(n) * Bkey + 1.0);
+            return numTowers * (delta(n) * Berr + deltaMS(n) * Bkey + 1.0);
 #endif
         }
         else {
@@ -249,12 +254,12 @@ bool ParameterGenerationBFVRNS::ParamsGenBFVRNSInternal(std::shared_ptr<CryptoPa
 
         // function used in the EvalMult constraint
         auto C1 = [&](uint32_t n) -> double {
-            return delta(n) * delta(n) * p * Bkey;
+            return delta(n) * deltaMS(n) * p * Bkey;
         };
 
         // function used in the EvalMult constraint
         auto C2 = [&](uint32_t n, double logqPrev) -> double {
-            return delta(n) * delta(n) * Bkey * Bkey / 2.0 + noiseKS(n, logqPrev, w, true);
+            return delta(n) * deltaMS(n) * Bkey * Bkey / 2.0 + noiseKS(n, logqPrev, w, true);
         };
 
         // main correctness constraint

--- a/src/pke/lib/scheme/bgvrns/bgvrns-parametergeneration.cpp
+++ b/src/pke/lib/scheme/bgvrns/bgvrns-parametergeneration.cpp
@@ -99,8 +99,10 @@ BGVNoiseEstimates ParameterGenerationBGVRNS::computeNoiseEstimates(
     // Bkey set to thresholdParties * 1 for ternary distribution
     double Bkey =
         (cryptoParamsBGVRNS->GetSecretKeyDist() == GAUSSIAN) ? std::sqrt(thresholdParties) * Berr : thresholdParties;
-    // delta
+    // delta for multiplication of a Gaussian polynomial by a random polynomial
     auto expansionFactor = 2. * std::sqrt(ringDimension);
+    // delta for modulus switching
+    auto expansionFactorMS = 4. * std::sqrt(ringDimension);
     // Vnorm
     auto freshEncryptionNoise = Berr * (1. + 2. * expansionFactor * Bkey);
 
@@ -118,19 +120,19 @@ BGVNoiseEstimates ParameterGenerationBGVRNS::computeNoiseEstimates(
         double numTowersPerDigit = cryptoParamsBGVRNS->GetNumPerPartQ();
         double numDigits         = cryptoParamsBGVRNS->GetNumPartQ();
         keySwitchingNoise        = numTowersPerDigit * numDigits * expansionFactor * Berr;
-        keySwitchingNoise += auxTowers * (1. + expansionFactor * Bkey);
+        keySwitchingNoise += auxTowers * (1. + expansionFactorMS * Bkey);
 #if defined(WITH_REDUCED_NOISE)
         keySwitchingNoise /= 2.0;
 #endif
     }
 
     // V_ms
-    auto modSwitchingNoise = (1. + expansionFactor * Bkey) / 2.;
+    auto modSwitchingNoise = (1. + expansionFactorMS * Bkey) / 2.;
 
     // V_c
     double noisePerLevel = 0;
     if (scalTech == FLEXIBLEAUTOEXT) {
-        noisePerLevel = 1. + expansionFactor * Bkey;
+        noisePerLevel = 1. + expansionFactorMS * Bkey;
     }
     else {
         noisePerLevel = (evalAddCount + 1.) * freshEncryptionNoise + (keySwitchCount + 1.) * keySwitchingNoise;
@@ -313,8 +315,10 @@ void ParameterGenerationBGVRNS::InitializeFloodingDgg(
         noise_param = NoiseFlooding::PRE_SD;
     }
     else if (PREMode == NOISE_FLOODING_HRA) {
-        // expansion factor
+        // delta for multiplication of a Gaussian polynomial by a random polynomial
         auto expansionFactor = 2. * std::sqrt(ringDimension);
+        // delta for modulus switching
+        auto expansionFactorMS = 4. * std::sqrt(ringDimension);
         // re-randomization noise
         auto freshEncryptionNoise = B_e * (1. + 2. * expansionFactor * Bkey);
 
@@ -340,7 +344,7 @@ void ParameterGenerationBGVRNS::InitializeFloodingDgg(
                 // we use numPrimes here as an approximation of numDigits * [towers per digit]
                 noise_param += numPrimes * expansionFactor * B_e / 2.0;
                 // we use numPrimes (larger bound) instead of auxPrimes because we do not know auxPrimes yet
-                noise_param += numPrimes * (1 + expansionFactor * Bkey) / 2.0;
+                noise_param += numPrimes * (1 + expansionFactorMS * Bkey) / 2.0;
                 // sqrt(12*num_queries) * pow(2, stat_sec_half) factor required for security analysis
                 noise_param = std::sqrt(12 * num_queries) * std::pow(2, stat_sec_half) * noise_param;
             }

--- a/src/pke/lib/scheme/bgvrns/bgvrns-parametergeneration.cpp
+++ b/src/pke/lib/scheme/bgvrns/bgvrns-parametergeneration.cpp
@@ -226,14 +226,15 @@ std::pair<std::vector<NativeInteger>, uint32_t> ParameterGenerationBGVRNS::compu
         // Compute bounds.
         double modLowerBound = 0;
         if (scalTech == FLEXIBLEAUTOEXT) {
-            modLowerBound = 2 * noiseEstimates.noisePerLevel + 2 + 1.0 / noiseEstimates.noisePerLevel;
+            modLowerBound =
+                2 * noiseEstimates.noisePerLevel + 2 + std::sqrt(ringDimension) / 2.0 / noiseEstimates.noisePerLevel;
             modLowerBound *= noiseEstimates.expansionFactor * plainModulus * (evalAddCount + 1) / 2.0;
             modLowerBound += (keySwitchCount + 1) * noiseEstimates.keySwitchingNoise / noiseEstimates.noisePerLevel;
             modLowerBound *= 2;
         }
         else {
-            double modLowerBoundNumerator =
-                2 * noiseEstimates.noisePerLevel * noiseEstimates.noisePerLevel + 2 * noiseEstimates.noisePerLevel + 1;
+            double modLowerBoundNumerator = 2 * noiseEstimates.noisePerLevel * noiseEstimates.noisePerLevel +
+                                            2 * noiseEstimates.noisePerLevel + ringDimension;
             modLowerBoundNumerator *= noiseEstimates.expansionFactor * plainModulus / 2. * (evalAddCount + 1);
             modLowerBoundNumerator += (keySwitchCount + 1) * noiseEstimates.keySwitchingNoise;
             double modLowerBoundDenom = noiseEstimates.noisePerLevel - noiseEstimates.modSwitchingNoise;


### PR DESCRIPTION
1. Changed the modulus switching noise expansion factor from $2 \sqrt{N}$ to $4 \sqrt{N}$.
2. Adjusted the BGV multiplication noise to use the worst-case expansion factor in the last term.