### PR TITLE
Address undefined behavior related to hashing enums

### DIFF
--- a/src/pke/unittest/UnitTestENCRYPT.cpp
+++ b/src/pke/unittest/UnitTestENCRYPT.cpp
@@ -42,7 +42,7 @@
 using namespace lbcrypto;
 
 //===========================================================================================================
-enum TEST_CASE_TYPE {
+enum TEST_CASE_TYPE : int {
     STRING_TEST = 0,
     COEF_PACKED_TEST,
 };

--- a/src/pke/unittest/UnitTestEvalMult.cpp
+++ b/src/pke/unittest/UnitTestEvalMult.cpp
@@ -39,7 +39,7 @@
 using namespace lbcrypto;
 
 //===========================================================================================================
-enum TEST_CASE_TYPE {
+enum TEST_CASE_TYPE : int {
     EVAL_MULT_ERROR_HANDLING = 0,
     EVAL_MULT_MANY_ERROR_HANDLING,
     RELIN_TEST,

--- a/src/pke/unittest/UnitTestMultiparty.cpp
+++ b/src/pke/unittest/UnitTestMultiparty.cpp
@@ -42,7 +42,7 @@
 using namespace lbcrypto;
 
 //===========================================================================================================
-enum TEST_CASE_TYPE {
+enum TEST_CASE_TYPE : int {
     CKKSRNS_TEST = 0,
     BFVRNS_TEST,
     BGVRNS_TEST,

--- a/src/pke/unittest/UnitTestPRE.cpp
+++ b/src/pke/unittest/UnitTestPRE.cpp
@@ -44,7 +44,7 @@
 using namespace lbcrypto;
 
 //===========================================================================================================
-enum TEST_CASE_TYPE {
+enum TEST_CASE_TYPE : int {
     RE_ENCRYPT = 0,
 };
 

--- a/src/pke/unittest/UnitTestSHE.cpp
+++ b/src/pke/unittest/UnitTestSHE.cpp
@@ -45,7 +45,7 @@
 using namespace lbcrypto;
 
 //===========================================================================================================
-enum TEST_CASE_TYPE {
+enum TEST_CASE_TYPE : int {
     ADD_PACKED = 0,
     MULT_COEF_PACKED,
     MULT_PACKED,

--- a/src/pke/unittest/utbfvrns/UnitTestBFVrns.cpp
+++ b/src/pke/unittest/utbfvrns/UnitTestBFVrns.cpp
@@ -40,7 +40,7 @@
 using namespace lbcrypto;
 
 //===========================================================================================================
-enum TEST_CASE_TYPE {
+enum TEST_CASE_TYPE : int {
     EVAL_FAST_ROTATION = 0,
     COMPRESSED_BFV     = 1,
 };

--- a/src/pke/unittest/utbgvrns/UnitTestBGVrns.cpp
+++ b/src/pke/unittest/utbgvrns/UnitTestBGVrns.cpp
@@ -41,7 +41,7 @@
 using namespace lbcrypto;
 
 //===========================================================================================================
-enum TEST_CASE_TYPE {
+enum TEST_CASE_TYPE : int {
     ADD_PACKED_UTBGVRNS = 0,
     MULT_PACKED_UTBGVRNS,
     EVALATINDEX_UTBGVRNS,

--- a/src/pke/unittest/utbgvrns/UnitTestBGVrnsAdvancedSHE.cpp
+++ b/src/pke/unittest/utbgvrns/UnitTestBGVrnsAdvancedSHE.cpp
@@ -42,7 +42,7 @@
 using namespace lbcrypto;
 
 //===========================================================================================================
-enum TEST_CASE_TYPE {
+enum TEST_CASE_TYPE : int {
     EVAL_MULT_SINGLE = 0,
     EVAL_ADD_SINGLE,
 };

--- a/src/pke/unittest/utbgvrns/UnitTestBGVrnsAutomorphism.cpp
+++ b/src/pke/unittest/utbgvrns/UnitTestBGVrnsAutomorphism.cpp
@@ -44,7 +44,7 @@ using namespace lbcrypto;
 class Params;
 
 //===========================================================================================================
-enum TEST_CASE_TYPE {
+enum TEST_CASE_TYPE : int {
     BGVRNS_AUTOMORPHISM = 0,
     EVAL_AT_INDX_PACKED_ARRAY,
     EVAL_SUM_PACKED_ARRAY,

--- a/src/pke/unittest/utbgvrns/UnitTestBGVrnsSerialize.cpp
+++ b/src/pke/unittest/utbgvrns/UnitTestBGVrnsSerialize.cpp
@@ -49,7 +49,7 @@
 using namespace lbcrypto;
 
 //===========================================================================================================
-enum TEST_CASE_TYPE {
+enum TEST_CASE_TYPE : int {
     CONTEXT = 0,
     KEYS_AND_CIPHERTEXTS,
 };

--- a/src/pke/unittest/utckksrns/UnitTestBootstrap.cpp
+++ b/src/pke/unittest/utckksrns/UnitTestBootstrap.cpp
@@ -49,7 +49,7 @@ using namespace lbcrypto;
 using namespace std::literals;
 
 //===========================================================================================================
-enum TEST_CASE_TYPE {
+enum TEST_CASE_TYPE : int {
     BOOTSTRAP_FULL = 0,
     BOOTSTRAP_EDGE,
     BOOTSTRAP_SPARSE,

--- a/src/pke/unittest/utckksrns/UnitTestCKKSrns.cpp
+++ b/src/pke/unittest/utckksrns/UnitTestCKKSrns.cpp
@@ -50,7 +50,7 @@ using namespace lbcrypto;
 using namespace std::literals;
 
 //===========================================================================================================
-enum TEST_CASE_TYPE {
+enum TEST_CASE_TYPE : int {
     ADD_PACKED = 0,
     MULT_PACKED,
     SCALE_FACTOR_ADJUSTMENTS,

--- a/src/pke/unittest/utckksrns/UnitTestCKKSrnsAutomorphism.cpp
+++ b/src/pke/unittest/utckksrns/UnitTestCKKSrnsAutomorphism.cpp
@@ -43,7 +43,7 @@
 using namespace lbcrypto;
 
 //===========================================================================================================
-enum TEST_CASE_TYPE {
+enum TEST_CASE_TYPE : int {
     EVAL_AT_INDX_PACKED_ARRAY = 0,
     EVAL_SUM_PACKED_ARRAY,
     EVAL_SUM_ROWS,

--- a/src/pke/unittest/utckksrns/UnitTestCKKSrnsCompositeScaling.cpp
+++ b/src/pke/unittest/utckksrns/UnitTestCKKSrnsCompositeScaling.cpp
@@ -50,7 +50,7 @@ using namespace lbcrypto;
 
 #if NATIVEINT == 64
 //===========================================================================================================
-enum TEST_CASE_TYPE {
+enum TEST_CASE_TYPE : int {
     ADD_PACKED = 0,
     MULT_PACKED,
     SCALE_FACTOR_ADJUSTMENTS,

--- a/src/pke/unittest/utckksrns/UnitTestCKKSrnsCompositeScalingBootstrap.cpp
+++ b/src/pke/unittest/utckksrns/UnitTestCKKSrnsCompositeScalingBootstrap.cpp
@@ -50,7 +50,7 @@ using namespace lbcrypto;
 
 #if NATIVEINT == 64
 //===========================================================================================================
-enum TEST_CASE_TYPE {
+enum TEST_CASE_TYPE : int {
     BOOTSTRAP_FULL = 0,
     BOOTSTRAP_EDGE,
     BOOTSTRAP_SPARSE,

--- a/src/pke/unittest/utckksrns/UnitTestCKKSrnsSerialize.cpp
+++ b/src/pke/unittest/utckksrns/UnitTestCKKSrnsSerialize.cpp
@@ -46,7 +46,7 @@
 using namespace lbcrypto;
 
 //===========================================================================================================
-enum TEST_CASE_TYPE {
+enum TEST_CASE_TYPE : int {
     CONTEXT_WITH_SERTYPE = 0,
     KEYS_AND_CIPHERTEXTS,
     NO_CRT_TABLES,

--- a/src/pke/unittest/utckksrns/UnitTestFBT.cpp
+++ b/src/pke/unittest/utckksrns/UnitTestFBT.cpp
@@ -58,7 +58,7 @@
 
 using namespace lbcrypto;
 
-enum TEST_CASE_TYPE {
+enum TEST_CASE_TYPE : int {
     FBT_ARBLUT = 0,
     FBT_SIGNDIGIT,
     FBT_CONSECLEV,

--- a/src/pke/unittest/utckksrns/UnitTestInteractiveBootstrap.cpp
+++ b/src/pke/unittest/utckksrns/UnitTestInteractiveBootstrap.cpp
@@ -45,7 +45,7 @@ using namespace lbcrypto;
 class Params;
 
 //===========================================================================================================
-enum TEST_CASE_TYPE {
+enum TEST_CASE_TYPE : int {
     INTERACTIVE_MP_BOOT = 0,
     INTERACTIVE_MP_BOOT_CHEBYSHEV,
     INTERACTIVE_MP_BOOT_ENCRYPT_2PARTY_ONLY,

--- a/src/pke/unittest/utckksrns/UnitTestNoiseFlooding.cpp
+++ b/src/pke/unittest/utckksrns/UnitTestNoiseFlooding.cpp
@@ -45,7 +45,7 @@
 using namespace lbcrypto;
 
 //===========================================================================================================
-enum TEST_CASE_TYPE { NOISE_ESTIMATION, FULL_NOISE_FLOODING, MULTIPARTY_NOISE_FLOODING };
+enum TEST_CASE_TYPE : int { NOISE_ESTIMATION, FULL_NOISE_FLOODING, MULTIPARTY_NOISE_FLOODING };
 
 static std::ostream& operator<<(std::ostream& os, const TEST_CASE_TYPE& type) {
     std::string typeName;

--- a/src/pke/unittest/utckksrns/UnitTestPoly.cpp
+++ b/src/pke/unittest/utckksrns/UnitTestPoly.cpp
@@ -45,7 +45,7 @@
 using namespace lbcrypto;
 
 //===========================================================================================================
-enum TEST_CASE_TYPE {
+enum TEST_CASE_TYPE : int {
     EVAL_POLY = 0,
     EVAL_CHEB_DIVISION,
     EVAL_CHEB_LOGIT,

--- a/src/pke/unittest/utckksrns/UnitTestSchemeSwitch.cpp
+++ b/src/pke/unittest/utckksrns/UnitTestSchemeSwitch.cpp
@@ -51,7 +51,7 @@
 using namespace lbcrypto;
 
 //===========================================================================================================
-enum TEST_CASE_TYPE {
+enum TEST_CASE_TYPE : int {
     SCHEME_SWITCH_CKKS_FHEW,
     SCHEME_SWITCH_FHEW_CKKS,
     SCHEME_SWITCH_COMPARISON,


### PR DESCRIPTION
The hashing of this untyped enum was flagged as undefined behavior in v1.4.0 by ubsan. The compiler is allowed to pick the type of the enum, and static_cast from an int to the enum (as performed by unordered_map) is UB.