### PR TITLE
Make cushion in BFV HPSPOVERQLEVELED mode larger

### DIFF
--- a/src/pke/lib/scheme/bfvrns/bfvrns-leveledshe.cpp
+++ b/src/pke/lib/scheme/bfvrns/bfvrns-leveledshe.cpp
@@ -184,7 +184,7 @@ uint32_t FindLevelsToDrop(uint32_t multiplicativeDepth, std::shared_ptr<CryptoPa
     // adding the cushon to the error (see Appendix D of https://eprint.iacr.org/2021/204.pdf for details)
     // adjusted empirical parameter to 16 from 4 for threshold scenarios to work correctly, this might need to
     // be further refined
-    int32_t levels = std::floor((loge - 2 * multiplicativeDepth - 16 - logExtra) / dcrtBits);
+    int32_t levels = std::floor((loge - 4 * multiplicativeDepth - 16 - logExtra) / dcrtBits);
     size_t sizeQ   = cryptoParamsBFVrns->GetElementParams()->GetParams().size();
 
     if (levels < 0)

--- a/src/pke/lib/scheme/bfvrns/bfvrns-leveledshe.cpp
+++ b/src/pke/lib/scheme/bfvrns/bfvrns-leveledshe.cpp
@@ -184,7 +184,7 @@ uint32_t FindLevelsToDrop(uint32_t multiplicativeDepth, std::shared_ptr<CryptoPa
     // adding the cushon to the error (see Appendix D of https://eprint.iacr.org/2021/204.pdf for details)
     // adjusted empirical parameter to 16 from 4 for threshold scenarios to work correctly, this might need to
     // be further refined
-    int32_t levels = std::floor((loge - 4 * multiplicativeDepth - 16 - logExtra) / dcrtBits);
+    int32_t levels = std::floor((loge - 3 * multiplicativeDepth - 16 - logExtra) / dcrtBits);
     size_t sizeQ   = cryptoParamsBFVrns->GetElementParams()->GetParams().size();
 
     if (levels < 0)


### PR DESCRIPTION
Fixes #1066

Implements the fix suggested below:

> An interpretation of https://github.com/openfheorg/openfhe-development/pull/1007 is that for each BFV mulplicativeDepth we will have one bit more estimate. @yspolyakov suggested changing the cushion formula from 2 * mulDepth to 4 * mulDepth, and it did make the noise in my experiment to behave similarly as before.
