### PR TITLE
Add include guard for rlwe-mp.h

### DIFF
--- a/src/pke/include/schemelet/rlwe-mp.h
+++ b/src/pke/include/schemelet/rlwe-mp.h
@@ -29,6 +29,9 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
 
+#ifndef LBCRYPTO_CRYPTO_RLWE_MP_H
+#define LBCRYPTO_CRYPTO_RLWE_MP_H
+
 #include "openfhe.h"
 
 #include <memory>
@@ -68,3 +71,5 @@ public:
 };
 
 }  // namespace lbcrypto
+
+#endif  // LBCRYPTO_CRYPTO_RLWE_MP_H

--- a/src/pke/include/schemelet/rlwe-mp.h
+++ b/src/pke/include/schemelet/rlwe-mp.h
@@ -32,7 +32,10 @@
 #ifndef LBCRYPTO_CRYPTO_RLWE_MP_H
 #define LBCRYPTO_CRYPTO_RLWE_MP_H
 
-#include "openfhe.h"
+#include "ciphertext.h"
+#include "cryptocontext.h"
+#include "key/keypair.h"
+#include "openfhecore.h"
 
 #include <memory>
 #include <vector>


### PR DESCRIPTION
Otherwise it could not be included twice.

I think this one is trivial enough to directly open a PR without raising issue first.