### PR TITLE
Fix evaluation of linear functions with `EvalPoly`

### DIFF
--- a/src/pke/lib/scheme/ckksrns/ckksrns-advancedshe.cpp
+++ b/src/pke/lib/scheme/ckksrns/ckksrns-advancedshe.cpp
@@ -361,14 +361,14 @@ std::shared_ptr<seriesPowers<DCRTPoly>> AdvancedSHECKKSRNS::EvalPowers(
 }
 
 template <typename VectorDataType>
-Ciphertext<DCRTPoly> internalEvalPolyLinearWithPrecomp(std::vector<Ciphertext<DCRTPoly>>& powers,
-                                                       const std::vector<VectorDataType>& coefficients) {
-    const uint32_t k = coefficients.size() - 1;
-    if (k <= 1)
+static inline Ciphertext<DCRTPoly> internalEvalPolyLinearWithPrecomp(std::vector<Ciphertext<DCRTPoly>>& powers,
+                                                                     const std::vector<VectorDataType>& coefficients) {
+    if (coefficients.size() < 2)
         OPENFHE_THROW("The coefficients vector should contain at least 2 elements");
 
+    const uint32_t k = coefficients.size() - 1;
     if (!IsNotEqualZero(coefficients[k]))
-        OPENFHE_THROW("EvalPolyLinear: The highest-order coefficient cannot be set to 0.");
+        OPENFHE_THROW("The highest-order coefficient cannot be set to 0");
 
     auto cc = powers[0]->GetCryptoContext();
 
@@ -376,10 +376,10 @@ Ciphertext<DCRTPoly> internalEvalPolyLinearWithPrecomp(std::vector<Ciphertext<DC
     auto result = cc->EvalMult(powers[k - 1], coefficients[k]);
 
     // perform scalar multiplication for all other terms and sum them up
-    for (uint32_t i = 0; i < k - 1; ++i) {
-        if (IsNotEqualZero(coefficients[i + 1])) {
-            cc->EvalMultInPlace(powers[i], coefficients[i + 1]);
-            cc->EvalAddInPlace(result, powers[i]);
+    for (uint32_t i = 1; i < k; ++i) {
+        if (IsNotEqualZero(coefficients[i])) {
+            cc->EvalMultInPlace(powers[i - 1], coefficients[i]);
+            cc->EvalAddInPlace(result, powers[i - 1]);
         }
     }
 

--- a/src/pke/unittest/utckksrns/UnitTestCKKSrns.cpp
+++ b/src/pke/unittest/utckksrns/UnitTestCKKSrns.cpp
@@ -1801,6 +1801,9 @@ protected:
             // x + x^2 - x^3
             // low-degree function to check linear implementation
             std::vector<double> coefficients5{0, 1, 1, -1};
+            // 1 + 2x
+            // linear function to check linear implementation
+            std::vector<double> coefficients6{1.0, 2.0};
 
             Plaintext plaintext1 = cc->MakeCKKSPackedPlaintext(input);
 
@@ -1818,6 +1821,9 @@ protected:
 
             std::vector<std::complex<double>> output5{0.625, 0.847, 0.9809999999, 0.995125, 0.990543};
             Plaintext plaintextResult5 = cc->MakeCKKSPackedPlaintext(output5);
+
+            std::vector<std::complex<double>> output6{2.0, 2.4, 2.8, 2.9, 2.86};
+            Plaintext plaintextResult6 = cc->MakeCKKSPackedPlaintext(output6);
 
             // Generate encryption keys
             KeyPair<Element> kp = cc->KeyGen();
@@ -1878,6 +1884,16 @@ protected:
                     << " - we get: " << results5->GetCKKSPackedValue();
             checkEquality(plaintextResult5->GetCKKSPackedValue(), results5->GetCKKSPackedValue(), epsHigh,
                           failmsg + " EvalPoly for low-degree polynomial failed: " + buffer5.str());
+
+            Ciphertext<Element> cResult6 = cc->EvalPolyLinear(ciphertext1, coefficients6);
+            Plaintext results6;
+            cc->Decrypt(kp.secretKey, cResult6, &results6);
+            results6->SetLength(encodedLength);
+            std::stringstream buffer6;
+            buffer6 << "should be: " << plaintextResult6->GetCKKSPackedValue()
+                    << " - we get: " << results6->GetCKKSPackedValue();
+            checkEquality(plaintextResult6->GetCKKSPackedValue(), results6->GetCKKSPackedValue(), epsHigh,
+                          failmsg + " EvalPoly for linear polynomial failed: " + buffer6.str());
         }
         catch (std::exception& e) {
             std::cerr << "Exception thrown from " << __func__ << "(): " << e.what() << std::endl;


### PR DESCRIPTION
The `internalEvalPolyLinearWithPrecomp` contained an off-by-one error that caused it to throw an exception when the polynomial to evaluate was a linear function. This patch fixes that mistake, and adds a test that evaluates a linear polynomial on a CKKS ciphertext.

Bug discovered and patched at AccelCom, Barcelona Supercomputing Center.