### PR TITLE
Throw an error if cryptocontext-ser.h is not included for cryptocontext serialization

### DIFF
--- a/src/core/include/utils/serial.h
+++ b/src/core/include/utils/serial.h
@@ -1,7 +1,7 @@
 //==================================================================================
 // BSD 2-Clause License
 //
-// Copyright (c) 2014-2022, NJIT, Duality Technologies Inc. and other contributors
+// Copyright (c) 2014-2025, NJIT, Duality Technologies Inc. and other contributors
 //
 // All rights reserved.
 //
@@ -33,12 +33,8 @@
   Serialization utilities
  */
 
-#ifndef LBCRYPTO_SERIAL_H
-#define LBCRYPTO_SERIAL_H
-
-#include "utils/sertype.h"
-
-#include <iostream>
+#ifndef __SERIAL_H__
+#define __SERIAL_H__
 
 #ifndef CEREAL_RAPIDJSON_HAS_STDSTRING
     #define CEREAL_RAPIDJSON_HAS_STDSTRING 1
@@ -83,20 +79,61 @@
     #pragma clang diagnostic pop
 #endif
 
+#include "utils/sertype.h"
+
+#include <type_traits>
+#include <istream>
 #include <fstream>
 #include <sstream>
 #include <string>
+#include <memory>
 
 namespace lbcrypto {
+
+// ATTN: the code below (including "namespace internal_cc_traits") was added to make sure that some functions
+// from this file are NOT called if the object type they get as a parameter is CryptoContextImpl/CryptoContext.
+// An error is generated, if those functions are called instead of the ones defined in cryptocontext-ser.h
+template <typename Element>
+class CryptoContextImpl;
+template <typename Element>
+using CryptoContext = std::shared_ptr<CryptoContextImpl<Element>>;
+
+namespace internal_cc_traits {
+template <typename T>
+struct cc_ser_enabled : std::false_type {};
+
+template <typename T>
+struct is_crypto_context_like : std::false_type {};
+
+template <typename Element>
+struct is_crypto_context_like<CryptoContextImpl<Element>> : std::true_type {};
+template <typename Element>
+struct is_crypto_context_like<std::shared_ptr<CryptoContextImpl<Element>>> : std::true_type {};
+
+// public trait: strips const/volatile and references
+template <typename T>
+struct is_crypto_context_impl : is_crypto_context_like<std::decay_t<T>> {};
+}  // namespace internal_cc_traits
+
+// Helper macro: ensure that CryptoContext serialization is only used
+// when cryptocontext-ser.h has been included and the type has been enabled.
+#define CHECK_CC_SERIALIZATION_ENABLED(T)                                                             \
+    do {                                                                                              \
+        if constexpr (::lbcrypto::internal_cc_traits::is_crypto_context_impl<T>::value) {             \
+            using DecayedT = std::decay_t<T>;                                                         \
+            static_assert(::lbcrypto::internal_cc_traits::cc_ser_enabled<DecayedT>::value,            \
+                          "CryptoContext serialization is disabled. Include <cryptocontext-ser.h>."); \
+        }                                                                                             \
+    } while (0)
 
 namespace Serial {
 //========================== BINARY serialization ==========================
 /**
-		 * Serialize an object
-		 * @param obj - object to serialize
-		 * @param stream - Stream to serialize to
-		 * @param sertype - type of serialization; default is BINARY
-		 */
+ * Serialize an object
+ * @param obj - object to serialize
+ * @param stream - Stream to serialize to
+ * @param sertype - type of serialization; default is BINARY
+ */
 template <typename T>
 void Serialize(const T& obj, std::ostream& stream, const SerType::SERBINARY& st) {
     cereal::PortableBinaryOutputArchive archive(stream);
@@ -104,19 +141,23 @@ void Serialize(const T& obj, std::ostream& stream, const SerType::SERBINARY& st)
 }
 
 /**
-		 * Deserialize an object
-		 * @param obj - object to deserialize into
-		 * @param stream - Stream to deserialize from
-		 * @param sertype - type of de-serialization; default is BINARY
-		 */
+ * Deserialize an object
+ * @param obj - object to deserialize into
+ * @param stream - Stream to deserialize from
+ * @param sertype - type of de-serialization; default is BINARY
+ */
 template <typename T>
 void Deserialize(T& obj, std::istream& stream, const SerType::SERBINARY& st) {
+    CHECK_CC_SERIALIZATION_ENABLED(T);
+
     cereal::PortableBinaryInputArchive archive(stream);
     archive(obj);
 }
 
 template <typename T>
 bool SerializeToFile(const std::string& filename, const T& obj, const SerType::SERBINARY& sertype) {
+    CHECK_CC_SERIALIZATION_ENABLED(T);
+
     std::ofstream file(filename, std::ios::out | std::ios::binary);
     if (file.is_open()) {
         Serial::Serialize(obj, file, sertype);
@@ -128,6 +169,8 @@ bool SerializeToFile(const std::string& filename, const T& obj, const SerType::S
 
 template <typename T>
 bool DeserializeFromFile(const std::string& filename, T& obj, const SerType::SERBINARY& sertype) {
+    CHECK_CC_SERIALIZATION_ENABLED(T);
+
     std::ifstream file(filename, std::ios::in | std::ios::binary);
     if (file.is_open()) {
         Serial::Deserialize(obj, file, sertype);
@@ -139,11 +182,11 @@ bool DeserializeFromFile(const std::string& filename, T& obj, const SerType::SER
 
 //========================== JSON serialization ==========================
 /**
-		 * Serialize an object
-		 * @param obj - object to serialize
-		 * @param stream - Stream to serialize to
-		 * @param sertype - type of serialization; default is BINARY
-		 */
+ * Serialize an object
+ * @param obj - object to serialize
+ * @param stream - Stream to serialize to
+ * @param sertype - type of serialization; default is BINARY
+ */
 template <typename T>
 void Serialize(const T& obj, std::ostream& stream, const SerType::SERJSON& ser) {
     cereal::JSONOutputArchive archive(stream);
@@ -151,19 +194,23 @@ void Serialize(const T& obj, std::ostream& stream, const SerType::SERJSON& ser) 
 }
 
 /**
-		 * Deserialize an object
-		 * @param obj - object to deserialize into
-		 * @param stream - Stream to deserialize from
-		 * @param sertype - type of serialization; default is BINARY
-		 */
+ * Deserialize an object
+ * @param obj - object to deserialize into
+ * @param stream - Stream to deserialize from
+ * @param sertype - type of serialization; default is BINARY
+ */
 template <typename T>
 void Deserialize(T& obj, std::istream& stream, const SerType::SERJSON& ser) {
+    CHECK_CC_SERIALIZATION_ENABLED(T);
+
     cereal::JSONInputArchive archive(stream);
     archive(obj);
 }
 
 template <typename T>
 bool SerializeToFile(const std::string& filename, const T& obj, const SerType::SERJSON& sertype) {
+    CHECK_CC_SERIALIZATION_ENABLED(T);
+
     std::ofstream file(filename, std::ios::out | std::ios::binary);
     if (file.is_open()) {
         Serial::Serialize(obj, file, sertype);
@@ -175,6 +222,8 @@ bool SerializeToFile(const std::string& filename, const T& obj, const SerType::S
 
 template <typename T>
 bool DeserializeFromFile(const std::string& filename, T& obj, const SerType::SERJSON& sertype) {
+    CHECK_CC_SERIALIZATION_ENABLED(T);
+
     std::ifstream file(filename, std::ios::in | std::ios::binary);
     if (file.is_open()) {
         Serial::Deserialize(obj, file, sertype);
@@ -185,25 +234,29 @@ bool DeserializeFromFile(const std::string& filename, T& obj, const SerType::SER
 }
 
 /**
-		 * SerializeToString - serialize the object to a JSON string and return the
-		 * string
-		 * @param t - any serializable object
-		 * @return JSON string
-		 */
+ * SerializeToString - serialize the object to a JSON string and return the
+ * string
+ * @param t - any serializable object
+ * @return JSON string
+ */
 template <typename T>
 std::string SerializeToString(const T& t) {
+    CHECK_CC_SERIALIZATION_ENABLED(T);
+
     std::stringstream s;
     Serialize(t, s, SerType::JSON);
     return s.str();
 }
 
 /**
-		 * DeserializeFromString - deserialize the object from a JSON string
-		 * @param obj - any object to deserialize into
-		 * @param json - JSON string
-		 */
+ * DeserializeFromString - deserialize the object from a JSON string
+ * @param obj - any object to deserialize into
+ * @param json - JSON string
+ */
 template <typename T>
 void DeserializeFromString(T& obj, const std::string& json) {
+    CHECK_CC_SERIALIZATION_ENABLED(T);
+
     std::stringstream s;
     s << json;
     Serial::Deserialize(obj, s, SerType::JSON);
@@ -213,4 +266,4 @@ void DeserializeFromString(T& obj, const std::string& json) {
 
 }  // namespace lbcrypto
 
-#endif
+#endif  // __SERIAL_H__

--- a/src/core/include/utils/serializable.h
+++ b/src/core/include/utils/serializable.h
@@ -28,8 +28,8 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
-#ifndef LBCRYPTO_SERIALIZABLE_H
-#define LBCRYPTO_SERIALIZABLE_H
+#ifndef __SERIALIZABLE_H__
+#define __SERIALIZABLE_H__
 
 #ifndef CEREAL_RAPIDJSON_HAS_STDSTRING
     #define CEREAL_RAPIDJSON_HAS_STDSTRING 1
@@ -58,7 +58,6 @@
 #endif
 
 #include "cereal/cereal.hpp"
-#include "cereal/types/polymorphic.hpp"
 
 #if defined(__GNUC__) && !defined(__clang__)
     #if __GNUC__ >= 8
@@ -102,4 +101,4 @@ std::ostream& operator<<(std::ostream& os, const std::vector<T>& v) {
 
 }  // namespace lbcrypto
 
-#endif
+#endif  // __SERIALIZABLE_H__

--- a/src/pke/include/ciphertext-ser.h
+++ b/src/pke/include/ciphertext-ser.h
@@ -33,8 +33,8 @@
   serialize ciphertexts; include this in any app that needs to serialize them
  */
 
-#ifndef LBCRYPTO_CRYPTO_CIPHERTEXTSER_H
-#define LBCRYPTO_CRYPTO_CIPHERTEXTSER_H
+#ifndef __CIPHERTEXT_SER_H__
+#define __CIPHERTEXT_SER_H__
 
 #include "ciphertext.h"
 #include "utils/serial.h"
@@ -50,4 +50,4 @@ CEREAL_CLASS_VERSION(lbcrypto::CiphertextImpl<lbcrypto::NativePoly>,
 CEREAL_CLASS_VERSION(lbcrypto::CiphertextImpl<lbcrypto::DCRTPoly>,
                      lbcrypto::CiphertextImpl<lbcrypto::DCRTPoly>::SerializedVersion());
 
-#endif
+#endif  // __CIPHERTEXT_SER_H__

--- a/src/pke/include/cryptocontext-ser.h
+++ b/src/pke/include/cryptocontext-ser.h
@@ -1,7 +1,7 @@
 //==================================================================================
 // BSD 2-Clause License
 //
-// Copyright (c) 2014-2022, NJIT, Duality Technologies Inc. and other contributors
+// Copyright (c) 2014-2025, NJIT, Duality Technologies Inc. and other contributors
 //
 // All rights reserved.
 //
@@ -33,10 +33,11 @@
   serialize cryptocontext; include this in any app that needs to serialize them
  */
 
-#ifndef LBCRYPTO_CRYPTO_CRYPTOCONTEXTSER_H
-#define LBCRYPTO_CRYPTO_CRYPTOCONTEXTSER_H
+#ifndef __CRYPTOCONTEXT_SER_H__
+#define __CRYPTOCONTEXT_SER_H__
 
 #include "cryptocontext.h"
+#include "utils/serial.h"
 #include "scheme/ckksrns/ckksrns-ser.h"
 #include "scheme/bgvrns/bgvrns-ser.h"
 #include "scheme/bfvrns/bfvrns-ser.h"
@@ -53,6 +54,19 @@ CEREAL_CLASS_VERSION(lbcrypto::CryptoContextImpl<lbcrypto::DCRTPoly>,
 // serialize-*.h file
 
 namespace lbcrypto {
+
+namespace internal_cc_traits {
+
+// enable CryptoContextImpl<Element>
+template <typename Element>
+struct cc_ser_enabled<CryptoContextImpl<Element>> : std::true_type {};
+
+// enable shared_ptr<CryptoContextImpl<Element>>
+template <typename Element>
+struct cc_ser_enabled<std::shared_ptr<CryptoContextImpl<Element>>> : std::true_type {};
+
+}  // namespace internal_cc_traits
+
 // ================================= JSON serialization/deserialization
 namespace Serial {
 /**
@@ -208,4 +222,4 @@ template bool CryptoContextImpl<DCRTPoly>::DeserializeEvalAutomorphismKey<SerTyp
 
 }  // namespace lbcrypto
 
-#endif
+#endif  // __CRYPTOCONTEXT_SER_H__

--- a/src/pke/include/cryptocontext.h
+++ b/src/pke/include/cryptocontext.h
@@ -1,7 +1,7 @@
 //==================================================================================
 // BSD 2-Clause License
 //
-// Copyright (c) 2014-2022, NJIT, Duality Technologies Inc. and other contributors
+// Copyright (c) 2014-2025, NJIT, Duality Technologies Inc. and other contributors
 //
 // All rights reserved.
 //
@@ -33,8 +33,8 @@
   Control for encryption operations
  */
 
-#ifndef SRC_PKE_CRYPTOCONTEXT_H_
-#define SRC_PKE_CRYPTOCONTEXT_H_
+#ifndef __CRYPTOCONTEXT_H__
+#define __CRYPTOCONTEXT_H__
 
 #include "binfhecontext.h"
 #include "ciphertext.h"
@@ -48,7 +48,6 @@
 #include "schemebase/base-scheme.h"
 #include "schemerns/rns-cryptoparameters.h"
 #include "utils/caller_info.h"
-#include "utils/serial.h"
 #include "utils/type_name.h"
 
 #include <algorithm>
@@ -4032,4 +4031,4 @@ std::unordered_map<uint32_t, DCRTPoly> CryptoContextImpl<DCRTPoly>::ShareKeys(co
                                                                               const std::string& shareType) const;
 }  // namespace lbcrypto
 
-#endif /* SRC_PKE_CRYPTOCONTEXT_H_ */
+#endif  // __CRYPTOCONTEXT_H__

--- a/src/pke/include/key/key-ser.h
+++ b/src/pke/include/key/key-ser.h
@@ -33,8 +33,8 @@
   serialize keys; include this in any app that needs to serialize these objects
  */
 
-#ifndef LBCRYPTO_CRYPTO_KEY_KEY_SER_H
-#define LBCRYPTO_CRYPTO_KEY_KEY_SER_H
+#ifndef __KEY_SER_H__
+#define __KEY_SER_H__
 
 #include "key/evalkeyrelin.h"
 #include "utils/serial.h"
@@ -45,4 +45,4 @@ CEREAL_REGISTER_TYPE(lbcrypto::EvalKeyRelinImpl<lbcrypto::DCRTPoly>);
 CEREAL_REGISTER_POLYMORPHIC_RELATION(lbcrypto::EvalKeyImpl<lbcrypto::DCRTPoly>,
                                      lbcrypto::EvalKeyRelinImpl<lbcrypto::DCRTPoly>);
 
-#endif
+#endif  // __KEY_SER_H__

--- a/src/pke/include/metadata-ser.h
+++ b/src/pke/include/metadata-ser.h
@@ -29,8 +29,8 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
 
-#ifndef LBCRYPTO_CRYPTO_METADATASER_H
-#define LBCRYPTO_CRYPTO_METADATASER_H
+#ifndef __METADATA_SER_H__
+#define __METADATA_SER_H__
 
 #include "metadata.h"
 #include "utils/serial.h"
@@ -38,4 +38,4 @@
 CEREAL_CLASS_VERSION(lbcrypto::Metadata, lbcrypto::Metadata::SerializedVersion());
 CEREAL_REGISTER_TYPE(lbcrypto::Metadata);
 
-#endif
+#endif  // __METADATA_SER_H__

--- a/src/pke/include/scheme/bfvrns/bfvrns-ser.h
+++ b/src/pke/include/scheme/bfvrns/bfvrns-ser.h
@@ -33,8 +33,8 @@
   serialize BFVrns; include this in any app that needs to serialize this scheme
  */
 
-#ifndef LBCRYPTO_CRYPTO_BFVRNSSER_H
-#define LBCRYPTO_CRYPTO_BFVRNSSER_H
+#ifndef __BFVRNS_SER_H__
+#define __BFVRNS_SER_H__
 
 #include "scheme/bfvrns/bfvrns-scheme.h"
 #include "utils/serial.h"
@@ -46,4 +46,4 @@ CEREAL_REGISTER_TYPE(lbcrypto::FHEBFVRNS);
 CEREAL_REGISTER_POLYMORPHIC_RELATION(lbcrypto::CryptoParametersRNS, lbcrypto::CryptoParametersBFVRNS);
 CEREAL_REGISTER_POLYMORPHIC_RELATION(lbcrypto::FHERNS, lbcrypto::FHEBFVRNS);
 
-#endif
+#endif  // __BFVRNS_SER_H__

--- a/src/pke/include/scheme/bgvrns/bgvrns-ser.h
+++ b/src/pke/include/scheme/bgvrns/bgvrns-ser.h
@@ -33,8 +33,8 @@
   serialize bgvrns; include this in any app that needs to serialize this scheme
  */
 
-#ifndef LBCRYPTO_CRYPTO_BGVRNSSER_H
-#define LBCRYPTO_CRYPTO_BGVRNSSER_H
+#ifndef __BGVRNS_SER_H__
+#define __BGVRNS_SER_H__
 
 #include "scheme/bgvrns/bgvrns-scheme.h"
 #include "scheme/bgvrns/bgvrns-fhe.h"
@@ -47,4 +47,5 @@ CEREAL_REGISTER_TYPE(lbcrypto::FHEBGVRNS);
 
 CEREAL_REGISTER_POLYMORPHIC_RELATION(lbcrypto::FHERNS, lbcrypto::FHEBGVRNS);
 CEREAL_REGISTER_POLYMORPHIC_RELATION(lbcrypto::CryptoParametersRNS, lbcrypto::CryptoParametersBGVRNS);
-#endif
+
+#endif  // __BGVRNS_SER_H__

--- a/src/pke/include/scheme/ckksrns/ckksrns-ser.h
+++ b/src/pke/include/scheme/ckksrns/ckksrns-ser.h
@@ -33,8 +33,8 @@
   serialize ckks; include this in any app that needs to serialize this scheme
  */
 
-#ifndef LBCRYPTO_CRYPTO_CKKSRNS_SER_H
-#define LBCRYPTO_CRYPTO_CKKSRNS_SER_H
+#ifndef __CKKSRNS_SER_H__
+#define __CKKSRNS_SER_H__
 
 #include "scheme/ckksrns/ckksrns-scheme.h"
 #include "utils/serial.h"
@@ -48,4 +48,5 @@ CEREAL_REGISTER_TYPE(lbcrypto::SWITCHCKKSRNS);
 CEREAL_REGISTER_POLYMORPHIC_RELATION(lbcrypto::CryptoParametersRNS, lbcrypto::CryptoParametersCKKSRNS);
 CEREAL_REGISTER_POLYMORPHIC_RELATION(lbcrypto::FHERNS, lbcrypto::FHECKKSRNS);
 CEREAL_REGISTER_POLYMORPHIC_RELATION(lbcrypto::FHERNS, lbcrypto::SWITCHCKKSRNS);
-#endif
+
+#endif  // __CKKSRNS_SER_H__

--- a/src/pke/include/scheme/ckksrns/gen-cryptocontext-ckksrns-internal.h
+++ b/src/pke/include/scheme/ckksrns/gen-cryptocontext-ckksrns-internal.h
@@ -33,11 +33,11 @@
   API to generate CKKS crypto context. MUST NOT (!) be used without a wrapper function
  */
 
-#ifndef _GEN_CRYPTOCONTEXT_CKKSRNS_INTERNAL_H_
-#define _GEN_CRYPTOCONTEXT_CKKSRNS_INTERNAL_H_
+#ifndef __GEN_CRYPTOCONTEXT_CKKSRNS_INTERNAL_H__
+#define __GEN_CRYPTOCONTEXT_CKKSRNS_INTERNAL_H__
 
 #include "constants.h"
-#include "cryptocontext.h"
+#include "cryptocontext-fwd.h"
 #include "encoding/encodingparams.h"
 #include "scheme/scheme-id.h"
 #include "scheme/scheme-utils.h"
@@ -148,4 +148,4 @@ typename ContextGeneratorType::ContextType genCryptoContextCKKSRNSInternal(
 }
 }  // namespace lbcrypto
 
-#endif  // _GEN_CRYPTOCONTEXT_CKKSRNS_INTERNAL_H_
+#endif  // __GEN_CRYPTOCONTEXT_CKKSRNS_INTERNAL_H__

--- a/src/pke/include/schemebase/base-ser.h
+++ b/src/pke/include/schemebase/base-ser.h
@@ -33,8 +33,8 @@
   serialize keys; include this in any app that needs to serialize these objects
  */
 
-#ifndef LBCRYPTO_CRYPTO_BASE_SER_H
-#define LBCRYPTO_CRYPTO_BASE_SER_H
+#ifndef __BASE_SER_H__
+#define __BASE_SER_H__
 
 #include "lattice/hal/default/lat-backend-default.h"
 #include "utils/serial.h"
@@ -50,6 +50,8 @@ CEREAL_REGISTER_TYPE(lbcrypto::CryptoParametersRLWE<lbcrypto::DCRTPoly>);
 CEREAL_REGISTER_TYPE(lbcrypto::SchemeBase<lbcrypto::DCRTPoly>);
 CEREAL_REGISTER_TYPE(lbcrypto::FHEBase<lbcrypto::DCRTPoly>);
 
-CEREAL_REGISTER_POLYMORPHIC_RELATION(lbcrypto::CryptoParametersBase<lbcrypto::DCRTPoly>, lbcrypto::CryptoParametersRLWE<lbcrypto::DCRTPoly>);
+CEREAL_REGISTER_POLYMORPHIC_RELATION(lbcrypto::CryptoParametersBase<lbcrypto::DCRTPoly>,
+                                     lbcrypto::CryptoParametersRLWE<lbcrypto::DCRTPoly>);
 CEREAL_REGISTER_POLYMORPHIC_RELATION(lbcrypto::Serializable, lbcrypto::CryptoParametersBase<lbcrypto::DCRTPoly>);
-#endif
+
+#endif  // __BASE_SER_H__

--- a/src/pke/include/schemelet/rlwe-mp.h
+++ b/src/pke/include/schemelet/rlwe-mp.h
@@ -29,11 +29,11 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
 
-#ifndef LBCRYPTO_CRYPTO_RLWE_MP_H
-#define LBCRYPTO_CRYPTO_RLWE_MP_H
+#ifndef __RLWE_MP_H_
+#define __RLWE_MP_H_
 
-#include "ciphertext.h"
-#include "cryptocontext.h"
+#include "ciphertext-fwd.h"
+#include "cryptocontext-fwd.h"
 #include "key/keypair.h"
 #include "openfhecore.h"
 
@@ -75,4 +75,4 @@ public:
 
 }  // namespace lbcrypto
 
-#endif  // LBCRYPTO_CRYPTO_RLWE_MP_H
+#endif  // __RLWE_MP_H_

--- a/src/pke/include/schemerns/rns-ser.h
+++ b/src/pke/include/schemerns/rns-ser.h
@@ -33,8 +33,8 @@
   serialize ckks; include this in any app that needs to serialize this scheme
  */
 
-#ifndef LBCRYPTO_CRYPTO_RNS_SER_H
-#define LBCRYPTO_CRYPTO_RNS_SER_H
+#ifndef __RNS_SER_H__
+#define __RNS_SER_H__
 
 #include "schemerns/rns-scheme.h"
 #include "utils/serial.h"
@@ -46,4 +46,4 @@ CEREAL_REGISTER_TYPE(lbcrypto::FHERNS);
 CEREAL_REGISTER_POLYMORPHIC_RELATION(lbcrypto::FHEBase<DCRTPoly>, lbcrypto::FHERNS);
 CEREAL_REGISTER_POLYMORPHIC_RELATION(lbcrypto::CryptoParametersRLWE<DCRTPoly>, lbcrypto::CryptoParametersRNS);
 
-#endif
+#endif  // __RNS_SER_H__

--- a/src/pke/lib/key/evalkey.cpp
+++ b/src/pke/lib/key/evalkey.cpp
@@ -28,7 +28,6 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
-#include "cryptocontext.h"
 #include "key/evalkey.h"
 
 // the code below is from evalkey-impl.cpp

--- a/src/pke/lib/key/evalkeyrelin.cpp
+++ b/src/pke/lib/key/evalkeyrelin.cpp
@@ -28,7 +28,6 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
-#include "cryptocontext.h"
 #include "key/evalkeyrelin.h"
 
 // the code below is from evalkeyrelin-impl.cpp

--- a/src/pke/lib/key/privatekey.cpp
+++ b/src/pke/lib/key/privatekey.cpp
@@ -28,7 +28,6 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
-#include "cryptocontext.h"
 #include "key/privatekey.h"
 
 // the code below is from privatekey-impl.cpp

--- a/src/pke/lib/key/publickey.cpp
+++ b/src/pke/lib/key/publickey.cpp
@@ -28,7 +28,6 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
-#include "cryptocontext.h"
 #include "key/publickey.h"
 
 // the code below is from publickey-impl.cpp

--- a/src/pke/lib/keyswitch/keyswitch-bv.cpp
+++ b/src/pke/lib/keyswitch/keyswitch-bv.cpp
@@ -37,7 +37,7 @@
  *  see the Appendix of https://eprint.iacr.org/2021/204 for more details
  */
 
-#include "cryptocontext.h"
+#include "ciphertext.h"
 #include "key/evalkeyrelin.h"
 #include "key/privatekey.h"
 #include "key/publickey.h"

--- a/src/pke/lib/scheme/bfvrns/bfvrns-cryptoparameters.cpp
+++ b/src/pke/lib/scheme/bfvrns/bfvrns-cryptoparameters.cpp
@@ -35,7 +35,6 @@ BFV implementation. See https://eprint.iacr.org/2021/204 for details.
 
 #define PROFILE
 
-#include "cryptocontext.h"
 #include "scheme/bfvrns/bfvrns-cryptoparameters.h"
 
 namespace lbcrypto {

--- a/src/pke/lib/scheme/bfvrns/bfvrns-parametergeneration.cpp
+++ b/src/pke/lib/scheme/bfvrns/bfvrns-parametergeneration.cpp
@@ -35,7 +35,6 @@ BFV implementation. See https://eprint.iacr.org/2021/204 for details.
 
 #define PROFILE
 
-#include "cryptocontext.h"
 #include "scheme/bfvrns/bfvrns-cryptoparameters.h"
 #include "scheme/bfvrns/bfvrns-parametergeneration.h"
 #include "scheme/scheme-utils.h"

--- a/src/pke/lib/scheme/bgvrns/bgvrns-cryptoparameters.cpp
+++ b/src/pke/lib/scheme/bgvrns/bgvrns-cryptoparameters.cpp
@@ -35,7 +35,6 @@ BGV implementation. See https://eprint.iacr.org/2021/204 for details.
 
 #define PROFILE
 
-#include "cryptocontext.h"
 #include "scheme/bgvrns/bgvrns-cryptoparameters.h"
 
 namespace lbcrypto {

--- a/src/pke/lib/scheme/bgvrns/bgvrns-parametergeneration.cpp
+++ b/src/pke/lib/scheme/bgvrns/bgvrns-parametergeneration.cpp
@@ -35,7 +35,6 @@ BGV implementation. See https://eprint.iacr.org/2021/204 for details.
 
 #define PROFILE
 
-#include "cryptocontext.h"
 #include "scheme/bgvrns/bgvrns-cryptoparameters.h"
 #include "scheme/bgvrns/bgvrns-parametergeneration.h"
 

--- a/src/pke/lib/scheme/bgvrns/bgvrns-pke.cpp
+++ b/src/pke/lib/scheme/bgvrns/bgvrns-pke.cpp
@@ -35,7 +35,7 @@ BGV implementation. See https://eprint.iacr.org/2021/204 for details.
 
 #define PROFILE
 
-#include "cryptocontext.h"
+#include "ciphertext.h"
 #include "scheme/bgvrns/bgvrns-cryptoparameters.h"
 #include "scheme/bgvrns/bgvrns-pke.h"
 

--- a/src/pke/lib/scheme/ckksrns/ckksrns-cryptoparameters.cpp
+++ b/src/pke/lib/scheme/ckksrns/ckksrns-cryptoparameters.cpp
@@ -35,7 +35,6 @@ CKKS implementation. See https://eprint.iacr.org/2020/1118 for details.
 
 #define PROFILE
 
-#include "cryptocontext.h"
 #include "scheme/ckksrns/ckksrns-cryptoparameters.h"
 
 #include <vector>

--- a/src/pke/lib/scheme/ckksrns/ckksrns-parametergeneration.cpp
+++ b/src/pke/lib/scheme/ckksrns/ckksrns-parametergeneration.cpp
@@ -35,7 +35,6 @@ CKKS implementation. See https://eprint.iacr.org/2020/1118 for details.
 
 #define PROFILE
 
-#include "cryptocontext.h"
 #include "scheme/ckksrns/ckksrns-cryptoparameters.h"
 #include "scheme/ckksrns/ckksrns-parametergeneration.h"
 

--- a/src/pke/lib/scheme/ckksrns/ckksrns-pke.cpp
+++ b/src/pke/lib/scheme/ckksrns/ckksrns-pke.cpp
@@ -35,7 +35,7 @@ CKKS implementation. If NOISE_FLOODING_DECRYPT is set, we flood the decryption b
 
 #define PROFILE
 
-#include "cryptocontext.h"
+#include "ciphertext.h"
 #include "scheme/ckksrns/ckksrns-cryptoparameters.h"
 #include "scheme/ckksrns/ckksrns-pke.h"
 

--- a/src/pke/lib/schemebase/base-cryptoparameters.cpp
+++ b/src/pke/lib/schemebase/base-cryptoparameters.cpp
@@ -28,7 +28,6 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
-#include "cryptocontext.h"
 #include "schemebase/base-cryptoparameters.h"
 
 // the code below is from base-cryptoparameters-impl.cpp

--- a/src/pke/lib/schemebase/base-fhe.cpp
+++ b/src/pke/lib/schemebase/base-fhe.cpp
@@ -29,7 +29,6 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
 
-#include "cryptocontext.h"
 #include "schemebase/base-fhe.h"
 
 namespace lbcrypto {

--- a/src/pke/lib/schemebase/base-parametergeneration.cpp
+++ b/src/pke/lib/schemebase/base-parametergeneration.cpp
@@ -28,7 +28,6 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
-#include "cryptocontext.h"
 #include "schemebase/base-parametergeneration.h"
 
 // the code below is from base-parametergeneration-impl.cpp

--- a/src/pke/lib/schemebase/rlwe-cryptoparameters-impl.cpp
+++ b/src/pke/lib/schemebase/rlwe-cryptoparameters-impl.cpp
@@ -29,7 +29,6 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
 
-#include "cryptocontext.h"
 #include "schemebase/rlwe-cryptoparameters.h"
 
 namespace lbcrypto {

--- a/src/pke/lib/schemelet/rlwe-mp.cpp
+++ b/src/pke/lib/schemelet/rlwe-mp.cpp
@@ -31,6 +31,7 @@
 
 #include "schemebase/rlwe-cryptoparameters.h"
 #include "schemelet/rlwe-mp.h"
+#include "cryptocontext.h"
 
 #include <stdint.h>
 #include <vector>

--- a/src/pke/lib/schemerns/rns-cryptoparameters.cpp
+++ b/src/pke/lib/schemerns/rns-cryptoparameters.cpp
@@ -32,7 +32,6 @@
 #define PROFILE
 
 #include "math/dftransform.h"
-#include "cryptocontext.h"
 #include "schemerns/rns-cryptoparameters.h"
 
 #include <vector>

--- a/src/pke/lib/schemerns/rns-multiparty.cpp
+++ b/src/pke/lib/schemerns/rns-multiparty.cpp
@@ -39,6 +39,7 @@
 #include <vector>
 #include <utility>
 #include <string>
+#include <cstring>
 
 namespace lbcrypto {
 

--- a/src/pke/lib/schemerns/rns-pke.cpp
+++ b/src/pke/lib/schemerns/rns-pke.cpp
@@ -30,9 +30,10 @@
 //==================================================================================
 #include "schemerns/rns-pke.h"
 
+#include "ciphertext.h"
 #include "key/privatekey.h"
 #include "key/publickey.h"
-#include "cryptocontext.h"
+#include "schemerns/rns-cryptoparameters.h"
 
 namespace lbcrypto {
 

--- a/src/pke/unittest/utils/UnitTestSer.h
+++ b/src/pke/unittest/utils/UnitTestSer.h
@@ -33,8 +33,8 @@
   helper function to test serialization
  */
 
-#ifndef __UNITTESTSER_H__
-#define __UNITTESTSER_H__
+#ifndef __UNITTEST_SER_H__
+#define __UNITTEST_SER_H__
 
 #include "UnitTestException.h"
 #include "cryptocontext-ser.h"
@@ -102,4 +102,4 @@ void UnitTestContextWithSertype(CryptoContext<Element> cc, const ST& sertype,
     }
 }
 
-#endif  // __UNITTESTSER_H__
+#endif  // __UNITTEST_SER_H__


### PR DESCRIPTION
Removed and/or corrected header file includes, modified serial.h to throw an error if cryptocontext-ser.h is not included for cryptocontext serialization