### PR TITLE
adjust plaintext modulus for large precision scheme switching

### DIFF
--- a/src/pke/examples/SCHEME_SWITCHING_CAPABILITY.md
+++ b/src/pke/examples/SCHEME_SWITCHING_CAPABILITY.md
@@ -38,7 +38,8 @@ in most cases should be chosen by the user to be 1 / p, where p is the desired F
 transformed to Q / (scFactor * p), where Q is the CKKS ciphertext modulus on level 0, scFactor is the CKKS scaling factor for that level.
 If the scale is left to be the default value of 1, the implicit FHEW plaintext modulus will be Q / scFactor, and the user should take this
 into account. Finally, the user can also divide separately the messages by p, and input plaintexts in the unit circle (which translates
-to an internal scaling only by Q / scFactor) and recover the initial message in FHEW.
+to an internal scaling only by Q / scFactor) and recover the initial message in FHEW. The value of p should be approximately 10 - 12 bits
+smaller than Q to allow for better accuracy with the sin(x) ~ x approximation of mod x.
 
 After the setup and precomputation, the user should call `EvalCKKStoFHEW`. The number of slots to be converted is specified by the user,
 otherwise it defaults to the number of slots specified in the CKKS scheme. Note that FHEW plaintexts are integers, so the messages from
@@ -143,4 +144,3 @@ Additional example demonstrating serialization
 
 The code for this example is located in [scheme-switching-serial.cpp](scheme-switching-serial.cpp). The file provides a simple setup for real number serialization before progressing into the next logical step - serialization and communication between 2 separate entities.
 All generated files containing serialized data are stored in the DATAFOLDER directory, which is defined in [scheme-switching-serial.cpp](scheme-switching-serial.cpp). If you want to rename any of those files, you can do so in [src/pke/unittest/utils/schemeswitching-data-serializer.h](src/pke/unittest/utils/schemeswitching-data-serializer.h).
-

--- a/src/pke/examples/scheme-switching.cpp
+++ b/src/pke/examples/scheme-switching.cpp
@@ -311,9 +311,10 @@ void SwitchFHEWtoCKKS() {
     uint32_t pLWE2 = 256;                                           // Medium precision
 
     // Messages encoded as [0000000MMMMM0000000EEEEE]
-    // Number of leading zeros determined by the ratio of ciphertext modulus to plaintext modulus
-    // Number of zeros between message and error determined by the ratio of plaintext modulus to magnitude of max value in message
-    // For correct CKKS decryption, the message magnitude should be much smaller than the plaintext modulus and the plaintext modulus should be much smaller than the ciphertext modulus
+    // High level idea is to have enough 0's both before and after message for CKKS-bootstrapped result to achieve reasonable accuracy.
+    // Number of leading zeros determined by ratio of ciphertext modulus to plaintext modulus; Need 10 - 12 bits for better accuracy with sin(x) ~ x approximation of mod x.
+    // Number of zeros between message and error determined by the ratio of plaintext modulus to magnitude of max value in message; Need gap between message and error
+    //   large enough for correctly rounded message even after leveled computations in the linear transformation before evaluating sin(x).
 
     uint32_t gap_bits = (logQ_ccLWE - std::log2(2 * (*std::max_element(x2.begin(), x2.end())))) / 2;
     uint32_t pLWE3    = 1 << (logQ_ccLWE - gap_bits);  // Large precision
@@ -331,16 +332,15 @@ void SwitchFHEWtoCKKS() {
         ctxtsLWE2[i] = ccLWE->Encrypt(lwesk, x1[i], LARGE_DIM, pLWE1);
     }
 
-    // Here, ratio between plaintext modulus and message magnitude is small
     std::vector<LWECiphertext> ctxtsLWE3(slots);
     for (uint32_t i = 0; i < slots; i++) {
-        // encrypted under larger plaintext modulus and large ciphertext modulus
+        // here, ratio between plaintext modulus and message magnitude is small, resulting in higher error
         ctxtsLWE3[i] = ccLWE->Encrypt(lwesk, x2[i], LARGE_DIM, pLWE2, modulus_LWE);
     }
 
     std::vector<LWECiphertext> ctxtsLWE4(slots);
     for (uint32_t i = 0; i < slots; i++) {
-        // encrypted under large plaintext modulus and large ciphertext modulus
+        // here, ratio between plaintext modulus and message magnitude is high, resulting in better accuracy
         ctxtsLWE4[i] = ccLWE->Encrypt(lwesk, x2[i], LARGE_DIM, pLWE3, modulus_LWE);
     }
 

--- a/src/pke/examples/scheme-switching.cpp
+++ b/src/pke/examples/scheme-switching.cpp
@@ -33,8 +33,10 @@
   Examples for scheme switching between CKKS and FHEW and back, with intermediate computations
  */
 
-#include "openfhe.h"
 #include "binfhecontext.h"
+#include "openfhe.h"
+
+#include <algorithm>
 
 using namespace lbcrypto;
 
@@ -226,6 +228,8 @@ void SwitchCKKSToFHEW() {
         }
         std::cout << std::endl;
     }
+
+    cc->ClearStaticMapsAndVectors();
 }
 
 void SwitchFHEWtoCKKS() {
@@ -275,7 +279,7 @@ void SwitchFHEWtoCKKS() {
 
     // Step 2: Prepare the FHEW cryptocontext and keys for FHEW and scheme switching
     auto ccLWE = std::make_shared<BinFHEContext>();
-    ccLWE->BinFHEContext::GenerateBinFHEContext(TOY, false, logQ_ccLWE, 0, GINX, false);
+    ccLWE->BinFHEContext::GenerateBinFHEContext(STD128, false, logQ_ccLWE, 0, GINX, false);
 
     // LWE private key
     LWEPrivateKey lwesk;
@@ -292,14 +296,7 @@ void SwitchFHEWtoCKKS() {
     cc->EvalFHEWtoCKKSKeyGen(keys, lwesk);
 
     // Step 4: Encoding and encryption of inputs
-    // For correct CKKS decryption, the messages have to be much smaller than the FHEW plaintext modulus!
 
-    auto pLWE1       = ccLWE->GetMaxPlaintextSpace().ConvertToInt();  // Small precision
-    uint32_t pLWE2   = 256;                                           // Medium precision
-    auto modulus_LWE = 1 << logQ_ccLWE;
-    auto beta        = ccLWE->GetBeta().ConvertToInt();
-    auto pLWE3       = modulus_LWE / (2 * beta);  // Large precision
-    // Inputs
     std::vector<int> x1 = {1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0};
     std::vector<int> x2 = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
     if (x1.size() < slots) {
@@ -307,6 +304,19 @@ void SwitchFHEWtoCKKS() {
         x1.insert(x1.end(), zeros.begin(), zeros.end());
         x2.insert(x2.end(), zeros.begin(), zeros.end());
     }
+
+    uint32_t modulus_LWE = 1 << logQ_ccLWE;
+
+    uint32_t pLWE1 = ccLWE->GetMaxPlaintextSpace().ConvertToInt();  // Small precision
+    uint32_t pLWE2 = 256;                                           // Medium precision
+
+    // Messages encoded as [0000000MMMMM0000000EEEEE]
+    // Number of leading zeros determined by the ratio of ciphertext modulus to plaintext modulus
+    // Number of zeros between message and error determined by the ratio of plaintext modulus to magnitude of max value in message
+    // For correct CKKS decryption, the message magnitude should be much smaller than the plaintext modulus and the plaintext modulus should be much smaller than the ciphertext modulus
+
+    uint32_t gap_bits = (logQ_ccLWE - std::log2(2 * (*std::max_element(x2.begin(), x2.end())))) / 2;
+    uint32_t pLWE3    = 1 << (logQ_ccLWE - gap_bits);  // Large precision
 
     // Encrypt
     std::vector<LWECiphertext> ctxtsLWE1(slots);
@@ -321,6 +331,7 @@ void SwitchFHEWtoCKKS() {
         ctxtsLWE2[i] = ccLWE->Encrypt(lwesk, x1[i], LARGE_DIM, pLWE1);
     }
 
+    // Here, ratio between plaintext modulus and message magnitude is small
     std::vector<LWECiphertext> ctxtsLWE3(slots);
     for (uint32_t i = 0; i < slots; i++) {
         // encrypted under larger plaintext modulus and large ciphertext modulus
@@ -379,6 +390,8 @@ void SwitchFHEWtoCKKS() {
     cc->Decrypt(keys.secretKey, cTemp2, &plaintextDec2);
     plaintextDec2->SetLength(slots);
     std::cout << "Switched CKKS decryption 4: " << plaintextDec2 << std::endl;
+
+    cc->ClearStaticMapsAndVectors();
 }
 
 void FloorViaSchemeSwitching() {
@@ -495,6 +508,8 @@ void FloorViaSchemeSwitching() {
     plaintextDec2->SetLength(slots);
     std::cout << "Switched floor decryption modulus_LWE mod " << NativeInteger(pLWE) / (1 << bits) << ": "
               << plaintextDec2 << std::endl;
+
+    cc->ClearStaticMapsAndVectors();
 }
 
 void FuncViaSchemeSwitching() {
@@ -635,6 +650,8 @@ void FuncViaSchemeSwitching() {
         std::cout << std::asin(x) * pLWE / (2 * M_PI) << " ";
     }
     std::cout << "\n";
+
+    cc->ClearStaticMapsAndVectors();
 }
 
 void ComparisonViaSchemeSwitching() {
@@ -847,6 +864,8 @@ void ComparisonViaSchemeSwitching() {
     cc->Decrypt(keys.secretKey, cResult, &plaintextDec3);
     plaintextDec3->SetLength(slots);
     std::cout << "Decrypted switched result: " << plaintextDec3 << std::endl;
+
+    cc->ClearStaticMapsAndVectors();
 }
 
 void ArgminViaSchemeSwitching() {
@@ -977,6 +996,8 @@ void ArgminViaSchemeSwitching() {
         ptxtMax->SetLength(1);
         std::cout << "Argmax: " << ptxtMax << std::endl;
     }
+
+    cc->ClearStaticMapsAndVectors();
 }
 
 void ArgminViaSchemeSwitchingAlt() {
@@ -1109,6 +1130,8 @@ void ArgminViaSchemeSwitchingAlt() {
         ptxtMax->SetLength(1);
         std::cout << "Argmax: " << ptxtMax << std::endl;
     }
+
+    cc->ClearStaticMapsAndVectors();
 }
 
 void ArgminViaSchemeSwitchingUnit() {
@@ -1243,6 +1266,8 @@ void ArgminViaSchemeSwitchingUnit() {
         ptxtMax->SetLength(1);
         std::cout << "Argmax: " << ptxtMax << std::endl;
     }
+
+    cc->ClearStaticMapsAndVectors();
 }
 
 void ArgminViaSchemeSwitchingAltUnit() {
@@ -1378,6 +1403,8 @@ void ArgminViaSchemeSwitchingAltUnit() {
         ptxtMax->SetLength(1);
         std::cout << "Argmax: " << ptxtMax << std::endl;
     }
+
+    cc->ClearStaticMapsAndVectors();
 }
 
 void PolyViaSchemeSwitching() {

--- a/src/pke/extras/scheme-switching-timing.cpp
+++ b/src/pke/extras/scheme-switching-timing.cpp
@@ -52,17 +52,17 @@ void Comparison(uint32_t depth, uint32_t slots, uint32_t numValues, uint32_t rin
 
 int main() {
     // // all examples set 128-bit security
-    // SwitchCKKSToFHEW(24, 1024, 1024);
-    // SwitchFHEWtoCKKS(24, 1024, 1024);
-    // ComparisonViaSchemeSwitching(24, 1024, 1024);
+    SwitchCKKSToFHEW(24, 1024, 1024);
+    SwitchFHEWtoCKKS(24, 1024, 1024);
+    ComparisonViaSchemeSwitching(24, 1024, 1024);
 
     // // depth >= 13 + log2(numValues);
-    // ArgminViaSchemeSwitching(24, 1024, 1024);
-    // ArgminViaSchemeSwitchingAlt(24, 1024, 1024);
+    ArgminViaSchemeSwitching(24, 1024, 1024);
+    ArgminViaSchemeSwitchingAlt(24, 1024, 1024);
 
     Argmin(39, 256, 256, 1 << 17);
-    // ArgminAlt(39, 256, 256, 1 << 17);
-    // Comparison(39, 256, 256, 1 << 17);
+    ArgminAlt(39, 256, 256, 1 << 17);
+    Comparison(39, 256, 256, 1 << 17);
 
     return 0;
 }
@@ -141,9 +141,7 @@ void SwitchCKKSToFHEW(uint32_t depth, uint32_t slots, uint32_t numValues) {
     auto paramsQ                                  = elementParams.GetParams();
     auto modulus_CKKS_from                        = paramsQ[0]->GetModulus();
 
-    auto modulus_LWE = 1 << logQ_ccLWE;
-    auto beta        = ccLWE->GetBeta().ConvertToInt();
-    auto pLWE        = modulus_LWE / (2 * beta);  // Large precision
+    auto pLWE = 1 << (logQ_ccLWE - 12);  // Large precision
 
     double scFactor = cryptoParams->GetScalingFactorReal(0);
     if (cryptoParams->GetScalingTechnique() == FLEXIBLEAUTOEXT)
@@ -278,8 +276,8 @@ void SwitchFHEWtoCKKS(uint32_t depth, uint32_t slots, uint32_t numValues) {
     // Step 4: Encoding and encryption of inputs
     // For correct CKKS decryption, the messages have to be much smaller than the FHEW plaintext modulus!
     auto modulus_LWE = 1 << logQ_ccLWE;
-    auto beta        = ccLWE->GetBeta().ConvertToInt();
-    auto pLWE        = modulus_LWE / (2 * beta);  // Large precision
+    auto pLWE        = 1 << (logQ_ccLWE - 12);  // Large precision
+
     // Inputs
     std::vector<int> x = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
     if (x.size() < slots) {
@@ -531,9 +529,7 @@ void ArgminViaSchemeSwitching(uint32_t depth, uint32_t slots, uint32_t numValues
     TIC(t);
     // Scale the inputs to ensure their difference is correctly represented after switching to FHEW
     double scaleSign = 512.0;
-    auto modulus_LWE = 1 << logQ_ccLWE;
-    auto beta        = ccLWE->GetBeta().ConvertToInt();
-    auto pLWE        = modulus_LWE / (2 * beta);  // Large precision
+    auto pLWE        = 1 << (logQ_ccLWE - 12);  // Large precision
     cc->EvalCompareSwitchPrecompute(pLWE, scaleSign);
     timePrecomp = TOC(t);
     std::cout << "Time to do the precomputations: " << timePrecomp / 1000 << " s" << std::endl;
@@ -682,9 +678,7 @@ void ArgminViaSchemeSwitchingAlt(uint32_t depth, uint32_t slots, uint32_t numVal
     TIC(t);
     // Scale the inputs to ensure their difference is correctly represented after switching to FHEW
     double scaleSign = 512.0;
-    auto modulus_LWE = 1 << logQ_ccLWE;
-    auto beta        = ccLWE->GetBeta().ConvertToInt();
-    auto pLWE        = modulus_LWE / (2 * beta);  // Large precision
+    auto pLWE        = 1 << (logQ_ccLWE - 12);  // Large precision
     cc->EvalCompareSwitchPrecompute(pLWE, scaleSign);
     timePrecomp = TOC(t);
     std::cout << "Time to do the precomputations: " << timePrecomp / 1000 << " s" << std::endl;
@@ -835,9 +829,7 @@ void Argmin(uint32_t depth, uint32_t slots, uint32_t numValues, uint32_t ringDim
     TIC(t);
     // Scale the inputs to ensure their difference is correctly represented after switching to FHEW
     double scaleSign = 512.0;
-    auto modulus_LWE = 1 << logQ_ccLWE;
-    auto beta        = ccLWE->GetBeta().ConvertToInt();
-    auto pLWE        = modulus_LWE / (2 * beta);  // Large precision
+    auto pLWE        = 1 << (logQ_ccLWE - 12);  // Large precision
     cc->EvalCompareSwitchPrecompute(pLWE, scaleSign);
     timePrecomp = TOC(t);
     std::cout << "Time to do the precomputations: " << timePrecomp / 1000 << " s" << std::endl;
@@ -988,9 +980,7 @@ void ArgminAlt(uint32_t depth, uint32_t slots, uint32_t numValues, uint32_t ring
     TIC(t);
     // Scale the inputs to ensure their difference is correctly represented after switching to FHEW
     double scaleSign = 512.0;
-    auto modulus_LWE = 1 << logQ_ccLWE;
-    auto beta        = ccLWE->GetBeta().ConvertToInt();
-    auto pLWE        = modulus_LWE / (2 * beta);  // Large precision
+    auto pLWE        = 1 << (logQ_ccLWE - 12);  // Large precision
 
     uint32_t init_level     = 0;
     const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersCKKSRNS>(cc->GetCryptoParameters());

--- a/src/pke/extras/scheme-switching-timing.cpp
+++ b/src/pke/extras/scheme-switching-timing.cpp
@@ -200,6 +200,8 @@ void SwitchCKKSToFHEW(uint32_t depth, uint32_t slots, uint32_t numValues) {
 
     double totalTime = TOC(tTotal);
     std::cout << "\nTotal time: " << totalTime / 60000 << " min" << std::endl;
+
+    cc->ClearStaticMapsAndVectors();
 }
 
 void SwitchFHEWtoCKKS(uint32_t depth, uint32_t slots, uint32_t numValues) {
@@ -312,6 +314,8 @@ void SwitchFHEWtoCKKS(uint32_t depth, uint32_t slots, uint32_t numValues) {
 
     double totalTime = TOC(tTotal);
     std::cout << "\nTotal time: " << totalTime / 60000 << " min" << std::endl;
+
+    cc->ClearStaticMapsAndVectors();
 }
 
 void ComparisonViaSchemeSwitching(uint32_t depth, uint32_t slots, uint32_t numValues) {
@@ -454,6 +458,8 @@ void ComparisonViaSchemeSwitching(uint32_t depth, uint32_t slots, uint32_t numVa
 
     double totalTime = TOC(tTotal);
     std::cout << "\nTotal time: " << totalTime / 60000 << " min" << std::endl;
+
+    cc->ClearStaticMapsAndVectors();
 }
 
 void ArgminViaSchemeSwitching(uint32_t depth, uint32_t slots, uint32_t numValues) {
@@ -602,6 +608,8 @@ void ArgminViaSchemeSwitching(uint32_t depth, uint32_t slots, uint32_t numValues
 
     double totalTime = TOC(tTotal);
     std::cout << "\nTotal time: " << totalTime / 60000 << " min" << std::endl;
+
+    cc->ClearStaticMapsAndVectors();
 }
 
 void ArgminViaSchemeSwitchingAlt(uint32_t depth, uint32_t slots, uint32_t numValues) {
@@ -752,6 +760,8 @@ void ArgminViaSchemeSwitchingAlt(uint32_t depth, uint32_t slots, uint32_t numVal
 
     double totalTime = TOC(tTotal);
     std::cout << "\nTotal time: " << totalTime / 60000 << " min" << std::endl;
+
+    cc->ClearStaticMapsAndVectors();
 }
 
 void Argmin(uint32_t depth, uint32_t slots, uint32_t numValues, uint32_t ringDim) {
@@ -902,6 +912,8 @@ void Argmin(uint32_t depth, uint32_t slots, uint32_t numValues, uint32_t ringDim
 
     double totalTime = TOC(tTotal);
     std::cout << "\nTotal time: " << totalTime / 60000 << " min" << std::endl;
+
+    cc->ClearStaticMapsAndVectors();
 }
 
 void ArgminAlt(uint32_t depth, uint32_t slots, uint32_t numValues, uint32_t ringDim) {
@@ -1058,6 +1070,8 @@ void ArgminAlt(uint32_t depth, uint32_t slots, uint32_t numValues, uint32_t ring
 
     double totalTime = TOC(tTotal);
     std::cout << "\nTotal time: " << totalTime / 60000 << " min" << std::endl;
+
+    cc->ClearStaticMapsAndVectors();
 }
 
 void Comparison(uint32_t depth, uint32_t slots, uint32_t numValues, uint32_t ringDim) {

--- a/src/pke/unittest/utckksrns/UnitTestSchemeSwitch.cpp
+++ b/src/pke/unittest/utckksrns/UnitTestSchemeSwitch.cpp
@@ -160,24 +160,24 @@ static std::vector<TEST_CASE_UTCKKSRNS_SCHEMESWITCH> testCases = {
 #endif
     // ==========================================
     // TestType,              Descr, Scheme,          RDim, MultDepth,   SModSize,     DSize, BatchSz, SecKeyDist,      MaxRelinSkDeg, FModSize,  SecLvl,       KSTech, ScalTech,        LDigits,      PtMod, StdDev, EvalAddCt, KSCt, MultTech, EncTech, PREMode, Dim1,     LogQ, NumValues, Slots
-    { SCHEME_SWITCH_FHEW_CKKS, "01", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH1, SMODSIZE,     DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,          FMODSIZE,  HEStd_NotSet, HYBRID, FIXEDAUTO,       NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT},   { 16, 16 }, 25, 8, 8 },
-    { SCHEME_SWITCH_FHEW_CKKS, "02", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH1, SMODSIZE,     DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,          FMODSIZE,  HEStd_NotSet, HYBRID, FIXEDMANUAL,     NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT},   { 16, 16 }, 25, 8, 8 },
-    { SCHEME_SWITCH_FHEW_CKKS, "03", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH1, SMODSIZE,     DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,          FMODSIZE,  HEStd_NotSet, HYBRID, FIXEDAUTO,       NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT},   { 16, 16 }, 25, 8, RDIM/2 },
-    { SCHEME_SWITCH_FHEW_CKKS, "04", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH1, SMODSIZE,     DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,          FMODSIZE,  HEStd_NotSet, HYBRID, FIXEDMANUAL,     NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT},   { 16, 16 }, 25, 8, RDIM/2 },
-    { SCHEME_SWITCH_FHEW_CKKS, "05", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH1, SMODSIZE,     DFLT,  DFLT,    SPARSE_TERNARY,  DFLT,          FMODSIZE,  HEStd_NotSet, HYBRID, FIXEDAUTO,       NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT},   { 16, 16 }, 25, 8, 8 },
-    { SCHEME_SWITCH_FHEW_CKKS, "06", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH1, SMODSIZE,     DFLT,  DFLT,    SPARSE_TERNARY,  DFLT,          FMODSIZE,  HEStd_NotSet, HYBRID, FIXEDMANUAL,     NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT},   { 16, 16 }, 25, 8, 8 },
-    { SCHEME_SWITCH_FHEW_CKKS, "07", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH1, SMODSIZE,     DFLT,  DFLT,    SPARSE_TERNARY,  DFLT,          FMODSIZE,  HEStd_NotSet, HYBRID, FIXEDAUTO,       NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT},   { 16, 16 }, 25, 8, RDIM/2 },
-    { SCHEME_SWITCH_FHEW_CKKS, "08", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH1, SMODSIZE,     DFLT,  DFLT,    SPARSE_TERNARY,  DFLT,          FMODSIZE,  HEStd_NotSet, HYBRID, FIXEDMANUAL,     NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT},   { 16, 16 }, 25, 8, RDIM/2 },
+    { SCHEME_SWITCH_FHEW_CKKS, "01", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH1, SMODSIZE,     DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,          FMODSIZE,  HEStd_NotSet, HYBRID, FIXEDAUTO,       NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT},   { 16, 16 }, 27, 8, 8 },
+    { SCHEME_SWITCH_FHEW_CKKS, "02", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH1, SMODSIZE,     DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,          FMODSIZE,  HEStd_NotSet, HYBRID, FIXEDMANUAL,     NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT},   { 16, 16 }, 27, 8, 8 },
+    { SCHEME_SWITCH_FHEW_CKKS, "03", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH1, SMODSIZE,     DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,          FMODSIZE,  HEStd_NotSet, HYBRID, FIXEDAUTO,       NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT},   { 16, 16 }, 27, 8, RDIM/2 },
+    { SCHEME_SWITCH_FHEW_CKKS, "04", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH1, SMODSIZE,     DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,          FMODSIZE,  HEStd_NotSet, HYBRID, FIXEDMANUAL,     NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT},   { 16, 16 }, 27, 8, RDIM/2 },
+    { SCHEME_SWITCH_FHEW_CKKS, "05", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH1, SMODSIZE,     DFLT,  DFLT,    SPARSE_TERNARY,  DFLT,          FMODSIZE,  HEStd_NotSet, HYBRID, FIXEDAUTO,       NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT},   { 16, 16 }, 27, 8, 8 },
+    { SCHEME_SWITCH_FHEW_CKKS, "06", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH1, SMODSIZE,     DFLT,  DFLT,    SPARSE_TERNARY,  DFLT,          FMODSIZE,  HEStd_NotSet, HYBRID, FIXEDMANUAL,     NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT},   { 16, 16 }, 27, 8, 8 },
+    { SCHEME_SWITCH_FHEW_CKKS, "07", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH1, SMODSIZE,     DFLT,  DFLT,    SPARSE_TERNARY,  DFLT,          FMODSIZE,  HEStd_NotSet, HYBRID, FIXEDAUTO,       NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT},   { 16, 16 }, 27, 8, RDIM/2 },
+    { SCHEME_SWITCH_FHEW_CKKS, "08", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH1, SMODSIZE,     DFLT,  DFLT,    SPARSE_TERNARY,  DFLT,          FMODSIZE,  HEStd_NotSet, HYBRID, FIXEDMANUAL,     NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT},   { 16, 16 }, 27, 8, RDIM/2 },
 
 #if NATIVEINT != 128
-    { SCHEME_SWITCH_FHEW_CKKS, "09", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH1, SMODSIZE,     DFLT,  DFLT,    UNIFORM_TERNARY,  DFLT,          FMODSIZE,  HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT},   { 16, 16 }, 25, 8, 8 },
-    { SCHEME_SWITCH_FHEW_CKKS, "10", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH1, SMODSIZE,     DFLT,  DFLT,    UNIFORM_TERNARY,  DFLT,          FMODSIZE,  HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT},   { 16, 16 }, 25, 8, 8 },
-    { SCHEME_SWITCH_FHEW_CKKS, "11", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH1, SMODSIZE,     DFLT,  DFLT,    UNIFORM_TERNARY,  DFLT,          FMODSIZE,  HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT},   { 16, 16 }, 25, 8, RDIM/2 },
-    { SCHEME_SWITCH_FHEW_CKKS, "12", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH1, SMODSIZE,     DFLT,  DFLT,    UNIFORM_TERNARY,  DFLT,          FMODSIZE,  HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT},   { 16, 16 }, 25, 8, RDIM/2 },
-    { SCHEME_SWITCH_FHEW_CKKS, "13", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH1, SMODSIZE,     DFLT,  DFLT,    SPARSE_TERNARY,   DFLT,          FMODSIZE,  HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT},   { 16, 16 }, 25, 8, 8 },
-    { SCHEME_SWITCH_FHEW_CKKS, "14", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH1, SMODSIZE,     DFLT,  DFLT,    SPARSE_TERNARY,   DFLT,          FMODSIZE,  HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT},   { 16, 16 }, 25, 8, 8 },
-    { SCHEME_SWITCH_FHEW_CKKS, "15", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH1, SMODSIZE,     DFLT,  DFLT,    SPARSE_TERNARY,   DFLT,          FMODSIZE,  HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT},   { 16, 16 }, 25, 8, RDIM/2 },
-    { SCHEME_SWITCH_FHEW_CKKS, "16", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH1, SMODSIZE,     DFLT,  DFLT,    SPARSE_TERNARY,   DFLT,          FMODSIZE,  HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT},   { 16, 16 }, 25, 8, RDIM/2 },
+    { SCHEME_SWITCH_FHEW_CKKS, "09", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH1, SMODSIZE,     DFLT,  DFLT,    UNIFORM_TERNARY,  DFLT,          FMODSIZE,  HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT},   { 16, 16 }, 27, 8, 8 },
+    { SCHEME_SWITCH_FHEW_CKKS, "10", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH1, SMODSIZE,     DFLT,  DFLT,    UNIFORM_TERNARY,  DFLT,          FMODSIZE,  HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT},   { 16, 16 }, 27, 8, 8 },
+    { SCHEME_SWITCH_FHEW_CKKS, "11", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH1, SMODSIZE,     DFLT,  DFLT,    UNIFORM_TERNARY,  DFLT,          FMODSIZE,  HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT},   { 16, 16 }, 27, 8, RDIM/2 },
+    { SCHEME_SWITCH_FHEW_CKKS, "12", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH1, SMODSIZE,     DFLT,  DFLT,    UNIFORM_TERNARY,  DFLT,          FMODSIZE,  HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT},   { 16, 16 }, 27, 8, RDIM/2 },
+    { SCHEME_SWITCH_FHEW_CKKS, "13", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH1, SMODSIZE,     DFLT,  DFLT,    SPARSE_TERNARY,   DFLT,          FMODSIZE,  HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT},   { 16, 16 }, 27, 8, 8 },
+    { SCHEME_SWITCH_FHEW_CKKS, "14", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH1, SMODSIZE,     DFLT,  DFLT,    SPARSE_TERNARY,   DFLT,          FMODSIZE,  HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT},   { 16, 16 }, 27, 8, 8 },
+    { SCHEME_SWITCH_FHEW_CKKS, "15", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH1, SMODSIZE,     DFLT,  DFLT,    SPARSE_TERNARY,   DFLT,          FMODSIZE,  HEStd_NotSet, HYBRID, FLEXIBLEAUTO,    NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT},   { 16, 16 }, 27, 8, RDIM/2 },
+    { SCHEME_SWITCH_FHEW_CKKS, "16", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH1, SMODSIZE,     DFLT,  DFLT,    SPARSE_TERNARY,   DFLT,          FMODSIZE,  HEStd_NotSet, HYBRID, FLEXIBLEAUTOEXT, NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT},   { 16, 16 }, 27, 8, RDIM/2 },
 
 #endif
     // ==========================================
@@ -254,9 +254,10 @@ class UTCKKSRNS_SCHEMESWITCH : public ::testing::TestWithParam<TEST_CASE_UTCKKSR
 
     // The precision after which we consider two values equal.
     // This is necessary because CKKS works for approximate numbers.
-    const double eps1 = 0.0001;  // When working with binary or small values
-    const double eps2 =
-        0.05;  // When working with conversion to FHEW of larger values, since it implies multiplying by a large value and modular approximation around zero
+    // When working with binary or small values
+    const double eps1 = 0.0001;
+    // When working with conversion to FHEW of larger values, since it implies multiplying by a large value and modular approximation around zero
+    const double eps2 = 0.05;
 
     // CalculateApproximationError() calculates the precision number (or approximation error).
     // The higher the precision, the less the error.
@@ -366,20 +367,21 @@ protected:
             ccLWE->BinFHEContext::GenerateBinFHEContext(TOY, false, testData.logQ, 0, GINX, false);
             LWEPrivateKey lwesk = ccLWE->KeyGen();
 
-            auto modulus_LWE = 1 << testData.logQ;
-            uint32_t pLWE    = modulus_LWE / (2 * ccLWE->GetBeta().ConvertToInt());  // larger precision
             std::vector<int32_t> x1(testData.slots);
             std::vector<int32_t> x1_values{0, 0, 1, 1, 0, 0, 1, 1};
             std::copy(x1_values.begin(), x1_values.end(), x1.begin());
-            std::vector<int32_t> x2(testData.slots);
-            std::vector<int32_t> x2_values{0, -1, 2, -3, 4, -8, 16, -32};
-            std::copy(x2_values.begin(), x2_values.end(), x2.begin());
             std::vector<LWECiphertext> ctxtsLWE1(testData.slots);
+            auto modulus_LWE = 1 << testData.logQ;
             for (uint32_t i = 0; i < testData.slots; i++) {
                 // encrypted under small plantext modulus p = 4 and ciphertext modulus
                 ctxtsLWE1[i] = ccLWE->Encrypt(lwesk, x1[i], LARGE_DIM, 4, modulus_LWE);
             }
+
+            std::vector<int32_t> x2(testData.slots);
+            std::vector<int32_t> x2_values{0, -1, 2, -3, 4, -8, 16, -32};
+            std::copy(x2_values.begin(), x2_values.end(), x2.begin());
             std::vector<LWECiphertext> ctxtsLWE2(testData.slots);
+            uint32_t pLWE = 1 << (testData.logQ - 12);
             for (uint32_t i = 0; i < testData.slots; i++) {
                 // encrypted under larger plaintext modulus and large ciphertext modulus
                 ctxtsLWE2[i] = ccLWE->Encrypt(lwesk, x2[i], LARGE_DIM, pLWE, modulus_LWE);

--- a/src/pke/unittest/utils/schemeswitching-data-serializer.h
+++ b/src/pke/unittest/utils/schemeswitching-data-serializer.h
@@ -36,7 +36,6 @@
 #include <memory>
 #include <string>
 
-
 namespace lbcrypto {
 
 class DataAndLocation {
@@ -50,7 +49,7 @@ protected:
     Ciphertext<DCRTPoly> RAWCiphertext{nullptr};
 
     // Save-Load locations
-    std::string dataDirectory                  = getDataDir();
+    std::string dataDirectory                  = "demoData";
     const std::string cryptoContextFile        = "cryptocontext.txt";
     const std::string pubKeyFile               = "key_pub.txt";
     const std::string multKeyFile              = "key_mult.txt";


### PR DESCRIPTION
* Corrected the value of plaintext modulus in unit tests and examples for the cases when large precision is sought during FHEW to CKKS switching
* Added more clarifications to the documentation for FHEW<->CKKS scheme switching and more comments to the examples