### PR TITLE
Fixed the inconsistency in the minimum value of scaling mod size

### DIFF
--- a/src/pke/include/schemerns/rns-modulus-limits.h
+++ b/src/pke/include/schemerns/rns-modulus-limits.h
@@ -1,7 +1,7 @@
 //==================================================================================
 // BSD 2-Clause License
 //
-// Copyright (c) 2014-2022, NJIT, Duality Technologies Inc. and other contributors
+// Copyright (c) 2014-2026, NJIT, Duality Technologies Inc. and other contributors
 //
 // All rights reserved.
 //
@@ -28,47 +28,22 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
+#ifndef __RNS_MODULUS_LIMITS_H__
+#define __RNS_MODULUS_LIMITS_H__
 
-#ifndef LBCRYPTO_CRYPTO_RNS_PARAMETERGENERATION_H
-#define LBCRYPTO_CRYPTO_RNS_PARAMETERGENERATION_H
+#include <cstdint>
+#include <string_view>
 
-#include "lattice/lat-hal.h"
-
-#include "schemebase/base-parametergeneration.h"
-#include "schemerns/rns-modulus-limits.h"
-
-#include <string>
-#include <memory>
-
-/**
- * @namespace lbcrypto
- * The namespace of lbcrypto
- */
 namespace lbcrypto {
+namespace DCRT_MODULUS {
 
-/**
- * @brief Abstract interface for parameter generation algorithm
- * @tparam Element a ring element.
- */
-class ParameterGenerationRNS : public ParameterGenerationBase<DCRTPoly> {
-public:
-    virtual ~ParameterGenerationRNS() = default;
+inline constexpr std::uint32_t DEFAULT_EXTRA_MOD_SIZE = 20;
+inline constexpr std::uint32_t MIN_SIZE               = 14;
+inline constexpr std::uint32_t MAX_SIZE               = 60;
 
-    /////////////////////////////////////
-    // SERIALIZATION
-    /////////////////////////////////////
-
-    template <class Archive>
-    void save(Archive& ar, std::uint32_t const version) const {}
-
-    template <class Archive>
-    void load(Archive& ar, std::uint32_t const version) {}
-
-    std::string SerializedObjectName() const {
-        return "ParameterGenerationRNS";
-    }
-};
-
+}  // namespace DCRT_MODULUS
 }  // namespace lbcrypto
 
-#endif
+
+#endif // __RNS_MODULUS_LIMITS_H__
+

--- a/src/pke/include/schemerns/rns-modulus-limits.h
+++ b/src/pke/include/schemerns/rns-modulus-limits.h
@@ -31,6 +31,8 @@
 #ifndef __RNS_MODULUS_LIMITS_H__
 #define __RNS_MODULUS_LIMITS_H__
 
+#include "math/hal/basicint.h"
+
 #include <cstdint>
 #include <string_view>
 
@@ -39,11 +41,9 @@ namespace DCRT_MODULUS {
 
 inline constexpr std::uint32_t DEFAULT_EXTRA_MOD_SIZE = 20;
 inline constexpr std::uint32_t MIN_SIZE               = 14;
-inline constexpr std::uint32_t MAX_SIZE               = 60;
+inline constexpr std::uint32_t MAX_SIZE               = MAX_MODULUS_SIZE;
 
 }  // namespace DCRT_MODULUS
 }  // namespace lbcrypto
 
-
-#endif // __RNS_MODULUS_LIMITS_H__
-
+#endif  // __RNS_MODULUS_LIMITS_H__

--- a/src/pke/lib/scheme/bfvrns/bfvrns-parametergeneration.cpp
+++ b/src/pke/lib/scheme/bfvrns/bfvrns-parametergeneration.cpp
@@ -52,10 +52,10 @@ bool ParameterGenerationBFVRNS::ParamsGenBFVRNSInternal(std::shared_ptr<CryptoPa
     if (!cryptoParams)
         OPENFHE_THROW("No crypto parameters are supplied to BFVrns ParamsGen");
 
-    if ((dcrtBits < DCRT_MODULUS::MIN_SIZE) || (dcrtBits > DCRT_MODULUS::MAX_SIZE))
-        OPENFHE_THROW(
-            "BFVrns.ParamsGen: Number of bits in CRT moduli should be "
-            "in the range from 30 to 60");
+    if ((dcrtBits < DCRT_MODULUS::MIN_SIZE) || (dcrtBits > DCRT_MODULUS::MAX_SIZE)) {
+        OPENFHE_THROW("Number of bits in CRT moduli should be in the range from " +
+                      std::to_string(DCRT_MODULUS::MIN_SIZE) + " to " + std::to_string(DCRT_MODULUS::MAX_SIZE));
+    }
 
     const auto cryptoParamsBFVRNS = std::dynamic_pointer_cast<CryptoParametersBFVRNS>(cryptoParams);
 

--- a/src/pke/lib/scheme/bgvrns/bgvrns-parametergeneration.cpp
+++ b/src/pke/lib/scheme/bgvrns/bgvrns-parametergeneration.cpp
@@ -196,7 +196,7 @@ std::pair<std::vector<NativeInteger>, uint32_t> ParameterGenerationBGVRNS::compu
     uint32_t firstModSize = std::ceil(std::log2(firstModLowerBound));
     if (firstModSize >= DCRT_MODULUS::MAX_SIZE) {
         OPENFHE_THROW(std::string("Reduce the number of additions or key switches per level or the digit size. ") +
-            "We do not support moduli greater than " + std::to_string(DCRT_MODULUS::MAX_SIZE-1) + " bits.");
+                      "We do not support moduli greater than " + std::to_string(DCRT_MODULUS::MAX_SIZE) + " bits.");
     }
 
     moduliQ[0] = FirstPrime<NativeInteger>(firstModSize, cyclOrder);
@@ -210,7 +210,7 @@ std::pair<std::vector<NativeInteger>, uint32_t> ParameterGenerationBGVRNS::compu
 
         if (extraModSize >= DCRT_MODULUS::MAX_SIZE) {
             OPENFHE_THROW(std::string("Reduce the number of additions or key switches per level or the digit size. ") +
-                "We do not support moduli greater than " + std::to_string(DCRT_MODULUS::MAX_SIZE-1) + " bits.");
+                          "We do not support moduli greater than " + std::to_string(DCRT_MODULUS::MAX_SIZE) + " bits.");
         }
 
         moduliQ[numPrimes] = FirstPrime<NativeInteger>(extraModSize, cyclOrder);
@@ -241,7 +241,7 @@ std::pair<std::vector<NativeInteger>, uint32_t> ParameterGenerationBGVRNS::compu
         uint32_t modSize = std::ceil(std::log2(modLowerBound));
         if (modSize >= DCRT_MODULUS::MAX_SIZE) {
             OPENFHE_THROW(std::string("Reduce the number of additions or key switches per level or the digit size. ") +
-                "We do not support moduli greater than " + std::to_string(DCRT_MODULUS::MAX_SIZE-1) + " bits.");
+                          "We do not support moduli greater than " + std::to_string(DCRT_MODULUS::MAX_SIZE) + " bits.");
         }
 
         // Compute moduli.

--- a/src/pke/lib/scheme/bgvrns/bgvrns-parametergeneration.cpp
+++ b/src/pke/lib/scheme/bgvrns/bgvrns-parametergeneration.cpp
@@ -195,9 +195,8 @@ std::pair<std::vector<NativeInteger>, uint32_t> ParameterGenerationBGVRNS::compu
         firstModLowerBound = 2.0 * plainModulus * noiseEstimates.noisePerLevel - plainModulus;
     uint32_t firstModSize = std::ceil(std::log2(firstModLowerBound));
     if (firstModSize >= DCRT_MODULUS::MAX_SIZE) {
-        OPENFHE_THROW(
-            "Change parameters! Try reducing the number of additions per level, "
-            "number of key switches per level, or the digit size. We cannot support moduli greater than 60 bits.");
+        OPENFHE_THROW(std::string("Reduce the number of additions or key switches per level or the digit size. ") +
+            "We do not support moduli greater than " + std::to_string(DCRT_MODULUS::MAX_SIZE-1) + " bits.");
     }
 
     moduliQ[0] = FirstPrime<NativeInteger>(firstModSize, cyclOrder);
@@ -210,9 +209,8 @@ std::pair<std::vector<NativeInteger>, uint32_t> ParameterGenerationBGVRNS::compu
         uint32_t extraModSize = std::ceil(std::log2(extraModLowerBound));
 
         if (extraModSize >= DCRT_MODULUS::MAX_SIZE) {
-            OPENFHE_THROW(
-                "Change parameters! Try reducing the number of additions per level, "
-                "number of key switches per level, or the digit size. We cannot support moduli greater than 60 bits.");
+            OPENFHE_THROW(std::string("Reduce the number of additions or key switches per level or the digit size. ") +
+                "We do not support moduli greater than " + std::to_string(DCRT_MODULUS::MAX_SIZE-1) + " bits.");
         }
 
         moduliQ[numPrimes] = FirstPrime<NativeInteger>(extraModSize, cyclOrder);
@@ -242,9 +240,8 @@ std::pair<std::vector<NativeInteger>, uint32_t> ParameterGenerationBGVRNS::compu
 
         uint32_t modSize = std::ceil(std::log2(modLowerBound));
         if (modSize >= DCRT_MODULUS::MAX_SIZE) {
-            OPENFHE_THROW(
-                "Change parameters! Try reducing the number of additions per level, "
-                "number of key switches per level, or the digit size. We cannot support moduli greater than 60 bits.");
+            OPENFHE_THROW(std::string("Reduce the number of additions or key switches per level or the digit size. ") +
+                "We do not support moduli greater than " + std::to_string(DCRT_MODULUS::MAX_SIZE-1) + " bits.");
         }
 
         // Compute moduli.

--- a/src/pke/lib/scheme/gen-cryptocontext-params-validation.cpp
+++ b/src/pke/lib/scheme/gen-cryptocontext-params-validation.cpp
@@ -29,6 +29,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
 #include "scheme/gen-cryptocontext-params-validation.h"
+#include "schemerns/rns-modulus-limits.h"
 #include "utils/exception.h"
 #include "utils/utilities.h"
 
@@ -60,18 +61,18 @@ void validateParametersForCryptocontext(const Params& parameters) {
         if (COMPOSITESCALINGAUTO == parameters.GetScalingTechnique() ||
             COMPOSITESCALINGMANUAL == parameters.GetScalingTechnique()) {
             if (COMPOSITESCALING_MAX_MODULUS_SIZE <= parameters.GetScalingModSize() ||
-                15 > parameters.GetScalingModSize()) {
-                OPENFHE_THROW("scalingModSize should be greater than 15 and less than " +
-                              std::to_string(COMPOSITESCALING_MAX_MODULUS_SIZE));
+                DCRT_MODULUS::MIN_SIZE > parameters.GetScalingModSize()) {
+                OPENFHE_THROW("scalingModSize should be greater than " + std::to_string(DCRT_MODULUS::MIN_SIZE-1) +
+                              " and less than " + std::to_string(COMPOSITESCALING_MAX_MODULUS_SIZE));
             }
             if (SPARSE_ENCAPSULATED == parameters.GetSecretKeyDist()) {
                 OPENFHE_THROW("SPARSE_ENCAPSULATED not yet supported with COMPOSITESCALING");
             }
         }
         else {
-            if (MAX_MODULUS_SIZE <= parameters.GetScalingModSize() || 15 > parameters.GetScalingModSize()) {
-                OPENFHE_THROW("scalingModSize should be greater than 15 and less than " +
-                              std::to_string(MAX_MODULUS_SIZE));
+            if (MAX_MODULUS_SIZE <= parameters.GetScalingModSize() || DCRT_MODULUS::MIN_SIZE > parameters.GetScalingModSize()) {
+                OPENFHE_THROW("scalingModSize should be greater than " + std::to_string(DCRT_MODULUS::MIN_SIZE-1) +
+                              " and less than " + std::to_string(MAX_MODULUS_SIZE));
             }
         }
         if (30 != parameters.GetStatisticalSecurity()) {

--- a/src/pke/lib/scheme/gen-cryptocontext-params-validation.cpp
+++ b/src/pke/lib/scheme/gen-cryptocontext-params-validation.cpp
@@ -62,7 +62,7 @@ void validateParametersForCryptocontext(const Params& parameters) {
             COMPOSITESCALINGMANUAL == parameters.GetScalingTechnique()) {
             if (COMPOSITESCALING_MAX_MODULUS_SIZE <= parameters.GetScalingModSize() ||
                 DCRT_MODULUS::MIN_SIZE > parameters.GetScalingModSize()) {
-                OPENFHE_THROW("scalingModSize should be greater than " + std::to_string(DCRT_MODULUS::MIN_SIZE-1) +
+                OPENFHE_THROW("scalingModSize should be at least " + std::to_string(DCRT_MODULUS::MIN_SIZE) +
                               " and less than " + std::to_string(COMPOSITESCALING_MAX_MODULUS_SIZE));
             }
             if (SPARSE_ENCAPSULATED == parameters.GetSecretKeyDist()) {
@@ -71,7 +71,7 @@ void validateParametersForCryptocontext(const Params& parameters) {
         }
         else {
             if (MAX_MODULUS_SIZE <= parameters.GetScalingModSize() || DCRT_MODULUS::MIN_SIZE > parameters.GetScalingModSize()) {
-                OPENFHE_THROW("scalingModSize should be greater than " + std::to_string(DCRT_MODULUS::MIN_SIZE-1) +
+                OPENFHE_THROW("scalingModSize should be at least " + std::to_string(DCRT_MODULUS::MIN_SIZE) +
                               " and less than " + std::to_string(MAX_MODULUS_SIZE));
             }
         }


### PR DESCRIPTION
1. Moved the DCRT_MODULUS enum from "ParameterGenerationRNS" to a new header.
2. Replaced hardcoded values in error messages with DCRT_MODULUS::MIN_SIZE and DCRT_MODULUS::MAX_SIZE