### PR TITLE
Adjust the number of threads used for unit tests

### DIFF
--- a/docs/static_docs/Best_Performance.md
+++ b/docs/static_docs/Best_Performance.md
@@ -33,7 +33,7 @@ Typically, the default configuration for schemes in the `pke` module is only to 
 
 # Multithreading Configuration using OpenMP
 
-OpenFHE uses loop parallelization via OpenMP to speed up some lower-level (mostly polynomial) operations. From a bird's eye view,built-in OpenFHE loop parallelization is applied at the following levels:
+OpenFHE uses loop parallelization via OpenMP to speed up some lower-level (mostly polynomial) operations. From a bird's eye view, built-in OpenFHE loop parallelization is applied at the following levels:
 * For many Double-CRT operations (used for BGV, BFV, and CKKS implemented using RNS in OpenFHE), loop parallelization over the number of RNS limbs is automatically applied. The biggest benefit is seen when the multiplicative depth is not small (in deeper computations). For BGV and CKKS, the number of RNS limbs is roughly the same as the multiplicative depth set by the user (it is 1 or 2 larger). In BFV, it gets more complicated, but the number of RNS limbs is still proportional to the multiplicative depth.
 * A higher-level loop parallelization is employed for CKKS bootstrapping and scheme switching between CKKS and FHEW/TFHE.
 * Loop parallelization is also used for all schemes during key generation (but this does not have effect on online operations).

--- a/docs/static_docs/Best_Performance.md
+++ b/docs/static_docs/Best_Performance.md
@@ -1,13 +1,13 @@
 # Building OpenFHE for Best Performance
 
 The default build configuration of OpenFHE focuses on portability and ease of installation.
-As a result, the runtime performace for the default configuration is often significantly worse than for the optimal configuration.
+As a result, runtime performace for the default configuration is often significantly worse than for the optimal configuration.
 
-There are three important CMake flags that affect the runtime performance:
+There are three important CMake flags that affect runtime performance:
 * `WITH_NATIVEOPT` allows the user to turn on/off machine-specific optimizations. By default, it is set to OFF for maximum portability of generated binaries.
 * `NATIVE_SIZE` specifies the word size used internally for "small" integers. By default, it is set to 64. However, when used moduli are 28 bits or below,
 it is more efficient to set it to 32.
-* `WITH_OPENMP` allows the user to turn on multithreading using OpenMP. By default, it is set to ON, and all threads are available for OpenMP multithreading. The OMP_NUM_THREADS environment variable can be used to set the number of threads available in parallel regions.
+* `WITH_OPENMP` allows the user to turn on/off multithreading using OpenMP. By default, it is set to ON, and all threads are available for OpenMP multithreading. The OMP_NUM_THREADS environment variable can be used to limit the number of threads available in parallel regions.
 
 The compiler used is also important. We recommend using more recent compiler versions to achieve the best runtime performance.
 
@@ -33,16 +33,15 @@ Typically, the default configuration for schemes in the `pke` module is only to 
 
 # Multithreading Configuration using OpenMP
 
-OpenFHE uses loop parallelization via OpenMP to speed up some lower-level (mostly polynomial) operations. This loop parallelization gives the biggest improvement in the `pke` module and only provides modest speed-up in the `binfhe` module.
-
-From a bird's eye view, the built-in OpenFHE loop parallelization is applied at the following levels:
+OpenFHE uses loop parallelization via OpenMP to speed up some lower-level (mostly polynomial) operations. From a bird's eye view,built-in OpenFHE loop parallelization is applied at the following levels:
 * For many Double-CRT operations (used for BGV, BFV, and CKKS implemented using RNS in OpenFHE), loop parallelization over the number of RNS limbs is automatically applied. The biggest benefit is seen when the multiplicative depth is not small (in deeper computations). For BGV and CKKS, the number of RNS limbs is roughly the same as the multiplicative depth set by the user (it is 1 or 2 larger). In BFV, it gets more complicated, but the number of RNS limbs is still proportional to the multiplicative depth.
 * A higher-level loop parallelization is employed for CKKS bootstrapping and scheme switching between CKKS and FHEW/TFHE.
-* Loop parallelization is also used for all schemes during key generation (but this does not have effect on the online operations).
+* Loop parallelization is also used for all schemes during key generation (but this does not have effect on online operations).
 
-When developing C++ applications based on OpenFHE, it is advised to use OpenMP parallelization at the application level, e.g., when independent operations on multiple ciphertexts are performed, application-level OpenMP loop parallelization can be turned on. The scaling of performance with the number of cores in this setup can approach the "ideal" linear scaling if the dimension of the loop is comparable to the number of cores. Note that turning on OpenMP parallelization at the application level typically turns off the lower-level OpenMP loop parallelization (i.e., we do not use nested loop parallelization in OpenMP), so application-level loop parallelization should be used only when you know that the application loop dimension is higher than what is expected for built-in OpenFHE OpenMP loop parallization.
+When developing C++ applications based on OpenFHE, it is advised to use OpenMP parallelization at the application level, e.g., when independent operations on multiple ciphertexts are performed, application-level OpenMP loop parallelization can be turned on.
+The scaling of performance with the number of cores in this setup can approach the "ideal" linear scaling if the dimension of the loop is comparable to the number of cores. Note that turning on OpenMP parallelization at the application level typically turns off the lower-level OpenMP loop parallelization (i.e., we do not use nested loop parallelization in OpenMP), so application-level loop parallelization should be used only when you know that the application loop dimension is higher than what is expected for built-in OpenFHE OpenMP loop parallization.
 
-Within OpenFHE, the use of hyperthreading can lead to decreased performance so the `OMP_NUM_THREADS` environment variable should not be set higher than the number of physical cores.
+Within OpenFHE, the use of hyperthreading can lead to decreased performance so the `OMP_NUM_THREADS` environment variable should not be set higher than the number of physical cores. Performance gains also depend heavily on the execution environment. While a dedicated server allows OpenFHE to utilize all physical cores in isolation, running on a personal laptop often introduces contention with background processes and OS tasks. In such contentious environments, using every available thread can lead to frequent context switching and cache thrashing, ultimately degrading performance. To mitigate this on a general-purpose machine, it is often beneficial to set OMP_NUM_THREADS to roughly half the number of available cores, leaving sufficient headroom for the rest of the system.
 
 If an alternative parallelization mechanism is used, e.g., pthreads, C++11 threads, or multiprocessing, OpenMP should be turned off by setting the `WITH_OPENMP` CMake flag to OFF.
 

--- a/src/binfhe/unittest/UnitTestFHEW.cpp
+++ b/src/binfhe/unittest/UnitTestFHEW.cpp
@@ -29,14 +29,10 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
 
-/*
-  This code runs unit tests for the FHEW methods of the OpenFHE lattice encryption library
- */
-
 #include "binfhecontext.h"
+#include "gtest/gtest.h"
 #include "utils/demangle.h"
 
-#include "gtest/gtest.h"
 #include <sstream>
 
 using namespace lbcrypto;
@@ -48,10 +44,9 @@ using namespace lbcrypto;
 #endif
 // UNIT_TEST_HANDLE_ALL_EXCEPTIONS must always fail
 #define UNIT_TEST_HANDLE_ALL_EXCEPTIONS_BINFHE                                                                 \
-    std::string name(UNIT_TEST_EXCEPTION_TYPE_NAME_BINFHE);                                                           \
+    std::string name(UNIT_TEST_EXCEPTION_TYPE_NAME_BINFHE);                                                    \
     std::cerr << "Unknown exception of type \"" << name << "\" thrown from " << __func__ << "()" << std::endl; \
     EXPECT_TRUE(0 == 1) << failmsg;
-
 
 //===========================================================================================================
 enum TEST_CASE_TYPE {
@@ -241,8 +236,12 @@ static std::vector<TEST_CASE_UTGENERAL_FHEW> testCasesUTGENERAL_FHEW = {
 //===========================================================================================================
 class UTGENERAL_FHEW : public ::testing::TestWithParam<TEST_CASE_UTGENERAL_FHEW> {
 protected:
-    void SetUp() {}
-    void TearDown() {}
+    void SetUp() {
+        OpenFHEParallelControls.UnitTestStart();
+    }
+    void TearDown() {
+        OpenFHEParallelControls.UnitTestStop();
+    }
 
     // ---------------  TESTING METHODS OF FANDHEW ---------------
     void UnitTest_FHEW_KeySwitch(const TEST_CASE_UTGENERAL_FHEW& testData, const std::string& failmsg = std::string()) {

--- a/src/binfhe/unittest/UnitTestFHEWDeep.cpp
+++ b/src/binfhe/unittest/UnitTestFHEWDeep.cpp
@@ -29,10 +29,6 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
 
-/*
-  This code runs unit tests for the FHEW methods of the OpenFHE lattice encryption library
- */
-
 #include "binfhecontext.h"
 #include "gtest/gtest.h"
 

--- a/src/binfhe/unittest/UnitTestFHEWPKE.cpp
+++ b/src/binfhe/unittest/UnitTestFHEWPKE.cpp
@@ -29,10 +29,6 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
 
-/*
-  This code runs unit tests for the FHEW methods of the OpenFHE lattice encryption library
- */
-
 #include "binfhecontext.h"
 #include "gtest/gtest.h"
 

--- a/src/binfhe/unittest/UnitTestFHEWPKESerial.cpp
+++ b/src/binfhe/unittest/UnitTestFHEWPKESerial.cpp
@@ -29,14 +29,8 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
 
-/*
-  This code runs unit tests for the FHEW methods of the OpenFHE lattice encryption library
- */
-
-#include "gtest/gtest.h"
-
-// these header files are needed for serialization
 #include "binfhecontext-ser.h"
+#include "gtest/gtest.h"
 
 using namespace lbcrypto;
 

--- a/src/binfhe/unittest/UnitTestFHEWSerial.cpp
+++ b/src/binfhe/unittest/UnitTestFHEWSerial.cpp
@@ -29,20 +29,14 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
 
-/*
-  This code runs unit tests for the FHEW methods of the OpenFHE lattice encryption library
- */
-
-#include "gtest/gtest.h"
-
-// these header files are needed for serialization
 #include "binfhecontext-ser.h"
+#include "gtest/gtest.h"
 
 using namespace lbcrypto;
 
 template <typename ST>
-void UnitTestFHEWSerial(const ST& sertype, BINFHE_PARAMSET secLevel, BINFHE_METHOD variant,
-                        BINFHE_OUTPUT ctType, const std::string& errMsg) {
+void UnitTestFHEWSerial(const ST& sertype, BINFHE_PARAMSET secLevel, BINFHE_METHOD variant, BINFHE_OUTPUT ctType,
+                        const std::string& errMsg) {
     const LWEPlaintext val(1);
     auto cc1 = BinFHEContext();
     cc1.GenerateBinFHEContext(secLevel, variant);
@@ -81,11 +75,11 @@ void UnitTestFHEWSerial(const ST& sertype, BINFHE_PARAMSET secLevel, BINFHE_METH
     }
 
     // Loading deserialized bootstrapping keys
-    cc2.BTKeyLoad({refreshKey,switchKey});
+    cc2.BTKeyLoad({refreshKey, switchKey});
 
     // Check the keys after adding them to cc2
-    EXPECT_EQ( *(cc2.GetRefreshKey()), *(cc1.GetRefreshKey())) << errMsg << "Bootstrapping key mismatch: refresh key";
-    EXPECT_EQ( *(cc2.GetSwitchKey()), *(cc1.GetSwitchKey())) << errMsg << "Bootstrapping key mismatch: switching key";
+    EXPECT_EQ(*(cc2.GetRefreshKey()), *(cc1.GetRefreshKey())) << errMsg << "Bootstrapping key mismatch: refresh key";
+    EXPECT_EQ(*(cc2.GetSwitchKey()), *(cc1.GetSwitchKey())) << errMsg << "Bootstrapping key mismatch: switching key";
 
     LWEPrivateKey sk2;
     {
@@ -105,14 +99,13 @@ void UnitTestFHEWSerial(const ST& sertype, BINFHE_PARAMSET secLevel, BINFHE_METH
         EXPECT_EQ(*ct1, *ct2) << errMsg << " Ciphertext mismatch";
     }
 
-    auto ctNew = cc2.Encrypt(sk2, val, ctType);
+    auto ctNew    = cc2.Encrypt(sk2, val, ctType);
     auto ctResult = cc2.EvalBinGate(AND, ct2, ctNew);
     LWEPlaintext result;
     cc2.Decrypt(sk2, ctResult, &result);
 
     EXPECT_EQ(val, result) << errMsg << "result = " << result << ", it is expected to be equal 1";
 }
-
 
 // ---------------  TESTING SERIALIZATION METHODS OF FHEW ---------------
 // JSON tests were turned off as they take a very long time and require a lot of memory.

--- a/src/binfhe/unittest/UnitTestFunc.cpp
+++ b/src/binfhe/unittest/UnitTestFunc.cpp
@@ -29,10 +29,6 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
 
-/*
-  This code runs unit tests for the FHEW methods of the OpenFHE lattice encryption library
- */
-
 #include "binfhecontext.h"
 #include "gtest/gtest.h"
 

--- a/src/core/include/utils/parallel.h
+++ b/src/core/include/utils/parallel.h
@@ -125,6 +125,19 @@ public:
 #endif
     }
 
+    void UnitTestStart() {
+#ifdef PARALLEL
+        int nthreads = omp_get_max_threads() >> 1;
+        omp_set_num_threads(nthreads > machineThreads ? machineThreads : nthreads);
+#endif
+    }
+
+    void UnitTestStop() {
+#ifdef PARALLEL
+        omp_set_num_threads(machineThreads);
+#endif
+    }
+
 private:
     int machineThreads{1};
 };

--- a/src/core/unittest/UnitTest128.cpp
+++ b/src/core/unittest/UnitTest128.cpp
@@ -29,21 +29,16 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
 
-/*
-  This file contains google test code that exercises the big int vector library of the OpenFHE lattice encryption library.
- */
-
 #include "include/gtest/gtest.h"
-#include <iostream>
-#include <fstream>
-
-#include "math/math-hal.h"
-#include "utils/inttypes.h"
-#include "math/nbtheory.h"
-
-#include "math/distrgen.h"
-#include "utils/utilities.h"
 #include "lattice/lat-hal.h"
+#include "math/distrgen.h"
+#include "math/math-hal.h"
+#include "math/nbtheory.h"
+#include "utils/inttypes.h"
+#include "utils/utilities.h"
+
+#include <fstream>
+#include <iostream>
 
 using namespace lbcrypto;
 

--- a/src/core/unittest/UnitTestBinInt.cpp
+++ b/src/core/unittest/UnitTestBinInt.cpp
@@ -29,24 +29,17 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
 
-/*
-  This code tests the binary integers in the math libraries of the OpenFHE lattice encryption library.
- */
-
 #include "config_core.h"
 #include "gtest/gtest.h"
 #include "lattice/lat-hal.h"
-#include "lattice/ilelement.h"
-#include "math/math-hal.h"
 #include "math/distrgen.h"
+#include "math/math-hal.h"
 #include "math/nbtheory.h"
 #include "testdefs.h"
 #include "utils/inttypes.h"
 #include "utils/utilities.h"
 
 #include <iostream>
-
-#define PROFILE
 
 using namespace lbcrypto;
 

--- a/src/core/unittest/UnitTestBinVect.cpp
+++ b/src/core/unittest/UnitTestBinVect.cpp
@@ -29,19 +29,14 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
 
-/*
-  This code exercises the math libraries of the OpenFHE lattice encryption library.
- */
-
-#include <iostream>
 #include "gtest/gtest.h"
-
 #include "lattice/lat-hal.h"
-#include "lattice/ilelement.h"
 #include "testdefs.h"
 #include "utils/debug.h"
 #include "utils/inttypes.h"
 #include "utils/utilities.h"
+
+#include <iostream>
 
 using namespace lbcrypto;
 

--- a/src/core/unittest/UnitTestBlockAllocate.cpp
+++ b/src/core/unittest/UnitTestBlockAllocate.cpp
@@ -29,34 +29,29 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
 
-/*
-  This code exercises the block allocator utility of the OpenFHE lattice encryption library.
- */
 #if 0
-// #define PROFILE    //define this is we want profiling output and statistics
-    #include <assert.h>
-    #include <stdio.h>
-
-    #include <iostream>
-    #include <new>
-
     #include "gtest/gtest.h"
-
     #include "math/math-hal.h"
     #include "utils/blockAllocator/blockAllocator.h"
     #include "utils/debug.h"
     #include "utils/inttypes.h"
     #include "utils/utilities.h"
 
+    #include <assert.h>
+    #include <iostream>
+    #include <new>
+    #include <stdio.h>
+
 using namespace lbcrypto;
 
 class UnitTestBinInt : public ::testing::Test {
 protected:
-    virtual void SetUp() {}
+    virtual void SetUp() {
+        OpenFHEParallelControls.UnitTestStart();
+}
 
     virtual void TearDown() {
-        // Code here will be called immediately after each test
-        // (right before the destructor).
+        OpenFHEParallelControls.UnitTestStop();
     }
 };
 

--- a/src/core/unittest/UnitTestCommonElements.cpp
+++ b/src/core/unittest/UnitTestCommonElements.cpp
@@ -29,10 +29,6 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
 
-/*
-  This code tests the transform feature of the OpenFHE lattice encryption library.
- */
-
 #include "gtest/gtest.h"
 #include "lattice/lat-hal.h"
 #include "math/distrgen.h"

--- a/src/core/unittest/UnitTestDCRTElements.cpp
+++ b/src/core/unittest/UnitTestDCRTElements.cpp
@@ -29,10 +29,6 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
 
-/*
-  This code tests the transform feature of the OpenFHE lattice encryption library.
- */
-
 #include "gtest/gtest.h"
 #include "lattice/lat-hal.h"
 #include "math/distrgen.h"

--- a/src/core/unittest/UnitTestDistrGen.cpp
+++ b/src/core/unittest/UnitTestDistrGen.cpp
@@ -29,23 +29,17 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
 
-/*
-  This code exercises the random number distribution generator libraries of the OpenFHE lattice encryption library.
- */
-
-#include <iostream>
-#include <thread>
-
 #include "gtest/gtest.h"
-
 #include "lattice/lat-hal.h"
 #include "math/distrgen.h"
 #include "math/nbtheory.h"
+#include "testdefs.h"
 #include "utils/debug.h"
 #include "utils/inttypes.h"
 #include "utils/utilities.h"
 
-#include "testdefs.h"
+#include <iostream>
+#include <thread>
 
 using namespace lbcrypto;
 

--- a/src/core/unittest/UnitTestException.cpp
+++ b/src/core/unittest/UnitTestException.cpp
@@ -29,16 +29,12 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
 
-/*
-  This code tests the transform feature of the OpenFHE lattice encryption library.
- */
-
 #include "gtest/gtest.h"
+#include "utils/exception.h"
+#include "utils/inttypes.h"
+
 #include <iostream>
 #include <vector>
-
-#include "utils/inttypes.h"
-#include "utils/exception.h"
 
 using namespace lbcrypto;
 

--- a/src/core/unittest/UnitTestField2n.cpp
+++ b/src/core/unittest/UnitTestField2n.cpp
@@ -29,10 +29,6 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
 
-/*
-  This code exercises the Field2n methods of the OpenFHE lattice encryption library.
- */
-
 #include "gtest/gtest.h"
 #include "lattice/field2n.h"
 #include "math/dftransform.h"

--- a/src/core/unittest/UnitTestLatticeParams.cpp
+++ b/src/core/unittest/UnitTestLatticeParams.cpp
@@ -34,24 +34,23 @@
   unit tests for the utility to to find security parameters using the HomomorphicEncryption.org HE standard
  */
 
-#include <iostream>
-#include <thread>
-
 #include "gtest/gtest.h"
-
 #include "lattice/lat-hal.h"
-#include "utils/inttypes.h"
 #include "lattice/stdlatticeparms.h"
+#include "utils/inttypes.h"
+
+#include <iostream>
 
 using namespace lbcrypto;
 
 class UTLatticeParams : public ::testing::Test {
 protected:
-    virtual void SetUp() {}
+    virtual void SetUp() {
+        OpenFHEParallelControls.UnitTestStart();
+    }
 
     virtual void TearDown() {
-        // Code here will be called immediately after each test
-        // (right before the destructor).
+        OpenFHEParallelControls.UnitTestStop();
     }
 };
 

--- a/src/core/unittest/UnitTestMatrix.cpp
+++ b/src/core/unittest/UnitTestMatrix.cpp
@@ -29,22 +29,17 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
 
-/*
-  This code exercises the math libraries of the OpenFHE lattice encryption library.
- */
-
-#include <iostream>
 #include "gtest/gtest.h"
-
 #include "lattice/lat-hal.h"
 #include "math/distrgen.h"
+#include "math/matrix.h"
+#include "math/matrixstrassen-impl.h"
 #include "math/nbtheory.h"
 #include "testdefs.h"
 #include "utils/inttypes.h"
 #include "utils/utilities.h"
 
-#include "math/matrix.h"
-#include "math/matrixstrassen-impl.h"
+#include <iostream>
 
 using namespace lbcrypto;
 

--- a/src/core/unittest/UnitTestMubintvec.cpp
+++ b/src/core/unittest/UnitTestMubintvec.cpp
@@ -29,24 +29,19 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
 
-/*
-  This file contains google test code that exercises the big int vector library of the OpenFHE lattice encryption library.
- */
-
 #include "config_core.h"
 #ifdef WITH_BE4
 
-    #include <fstream>
-    #include <iostream>
     #include "gtest/gtest.h"
-
     #include "lattice/lat-hal.h"
+    #include "math/distrgen.h"
     #include "math/math-hal.h"
     #include "math/nbtheory.h"
     #include "utils/inttypes.h"
-
-    #include "math/distrgen.h"
     #include "utils/utilities.h"
+
+    #include <fstream>
+    #include <iostream>
 
 using namespace lbcrypto;
 

--- a/src/core/unittest/UnitTestNTT.cpp
+++ b/src/core/unittest/UnitTestNTT.cpp
@@ -38,15 +38,15 @@
   3. Math layer operations such as functions in nbtheory
   */
 
-#include <iostream>
 #include "gtest/gtest.h"
-
 #include "lattice/lat-hal.h"
 #include "math/distrgen.h"
 #include "math/nbtheory.h"
 #include "testdefs.h"
 #include "utils/inttypes.h"
 #include "utils/utilities.h"
+
+#include <iostream>
 
 using namespace lbcrypto;
 

--- a/src/core/unittest/UnitTestNbTheory.cpp
+++ b/src/core/unittest/UnitTestNbTheory.cpp
@@ -29,21 +29,16 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
 
-/*
-  This code exercises the math libraries of the OpenFHE lattice encryption library
- */
-
-#include <iostream>
 #include "gtest/gtest.h"
-
 #include "lattice/lat-hal.h"
-#include "lattice/ilelement.h"
-#include "math/math-hal.h"
 #include "math/distrgen.h"
+#include "math/math-hal.h"
 #include "math/nbtheory.h"
 #include "testdefs.h"
 #include "utils/inttypes.h"
 #include "utils/utilities.h"
+
+#include <iostream>
 
 using namespace lbcrypto;
 

--- a/src/core/unittest/UnitTestPolyElements.cpp
+++ b/src/core/unittest/UnitTestPolyElements.cpp
@@ -29,10 +29,6 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
 
-/*
-  This code tests the transform feature of the OpenFHE lattice encryption library
- */
-
 #include "gtest/gtest.h"
 #include "lattice/lat-hal.h"
 #include "math/distrgen.h"

--- a/src/core/unittest/UnitTestSTLBlockAllocate.cpp
+++ b/src/core/unittest/UnitTestSTLBlockAllocate.cpp
@@ -29,25 +29,8 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
 
-/*
-  This code exercises the block allocator utility of the OpenFHE lattice encryption library
- */
-
-// #define PROFILE  //uncomment to print out elapsed time
-
-#include <assert.h>
-#include <stdio.h>
-
-#include <iostream>
-#include <new>
-
 #include "gtest/gtest.h"
-
 #include "math/math-hal.h"
-#include "utils/debug.h"
-#include "utils/inttypes.h"
-#include "utils/utilities.h"
-
 #include "utils/blockAllocator/xlist.h"
 #include "utils/blockAllocator/xmap.h"
 #include "utils/blockAllocator/xqueue.h"
@@ -55,6 +38,14 @@
 #include "utils/blockAllocator/xsstream.h"
 #include "utils/blockAllocator/xstring.h"
 #include "utils/blockAllocator/xvector.h"
+#include "utils/debug.h"
+#include "utils/inttypes.h"
+#include "utils/utilities.h"
+
+#include <assert.h>
+#include <iostream>
+#include <new>
+#include <stdio.h>
 
 using namespace lbcrypto;
 

--- a/src/core/unittest/UnitTestTransform.cpp
+++ b/src/core/unittest/UnitTestTransform.cpp
@@ -29,23 +29,18 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
 
-/*
-  This code tests the transform feature of the OpenFHE lattice encryption library
- */
-
-#include <iostream>
 #include "gtest/gtest.h"
-
 #include "lattice/lat-hal.h"
-#include "lattice/ilelement.h"
-#include "math/math-hal.h"
 #include "math/distrgen.h"
+#include "math/math-hal.h"
 #include "math/nbtheory.h"
 #include "random"
 #include "testdefs.h"
 #include "utils/debug.h"
 #include "utils/inttypes.h"
 #include "utils/utilities.h"
+
+#include <iostream>
 
 using namespace lbcrypto;
 

--- a/src/core/unittest/UnitTestTrapdoor.cpp
+++ b/src/core/unittest/UnitTestTrapdoor.cpp
@@ -29,25 +29,26 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
 
-#include <iostream>
 #include "gtest/gtest.h"
-
 #include "lattice/lat-hal.h"
+#include "lattice/trapdoor.h"
 #include "math/distrgen.h"
 #include "math/nbtheory.h"
 #include "utils/inttypes.h"
 #include "utils/utilities.h"
-#include "lattice/trapdoor.h"
+
+#include <iostream>
 
 using namespace lbcrypto;
 
 class UnitTestTrapdoor : public ::testing::Test {
 protected:
-    virtual void SetUp() {}
+    virtual void SetUp() {
+        OpenFHEParallelControls.UnitTestStart();
+    }
 
     virtual void TearDown() {
-        // Code here will be called immediately after each test
-        // (right before the destructor).
+        OpenFHEParallelControls.UnitTestStop();
     }
 };
 

--- a/src/core/unittest/UnitTestUtils.cpp
+++ b/src/core/unittest/UnitTestUtils.cpp
@@ -29,15 +29,11 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
 
-/*
-  This file tests utilities functions
- */
+#include "include/gtest/gtest.h"
+#include "utils/utilities.h"
 
 #include <fstream>
 #include <iostream>
-#include "include/gtest/gtest.h"
-
-#include "utils/utilities.h"
 
 using namespace lbcrypto;
 

--- a/src/core/unittest/UnitTestXallocate.cpp
+++ b/src/core/unittest/UnitTestXallocate.cpp
@@ -33,37 +33,31 @@
 // ATTENTION: THIS TEST IS TEMPORARILY DISABLED!
 //==================================================================================
 #if (0)
-/*
-  This code exercises the block allocator utility of the OpenFHE lattice encryption library.
- */
+    #include "gtest/gtest.h"
+    #include "math/math-hal.h"
+    #include "utils/blockAllocator/xallocator.h"
+    #include "utils/debug.h"
+    #include "utils/inttypes.h"
+    #include "utils/utilities.h"
 
-// #define PROFILE  // define if we want elapsed time output and pool statistics
-#include <assert.h>
-#include <stdio.h>
+    #include <assert.h>
+    #include <iostream>
+    #include <new>
+    #include <stdio.h>
 
-#include <iostream>
-#include <new>
-
-#include "gtest/gtest.h"
-
-#include "math/math-hal.h"
-#include "utils/blockAllocator/xallocator.h"
-#include "utils/debug.h"
-#include "utils/inttypes.h"
-#include "utils/utilities.h"
-
-// this test does not work correctly in the web assembly configuration
-#if !defined(__EMSCRIPTEN__)
+    // this test does not work correctly in the web assembly configuration
+    #if !defined(__EMSCRIPTEN__)
 
 using namespace lbcrypto;
 
 class UnitTestBinInt : public ::testing::Test {
 protected:
-    virtual void SetUp() {}
+    virtual void SetUp() {
+        OpenFHEParallelControls.UnitTestStart();
+    }
 
     virtual void TearDown() {
-        // Code here will be called immediately after each test
-        // (right before the destructor).
+        OpenFHEParallelControls.UnitTestStop();
     }
 };
 
@@ -93,21 +87,21 @@ static MyClassStatic myClassStatic;
 static void out_of_memory() {
     // new-handler function called by Allocator when pool is out of memory
     xalloc_stats();
-    #if 0
+        #if 0
   std::bad_alloc exception;
   throw(exception);
-    #else
+        #else
     assert(0);
-    #endif
+        #endif
 }
 
 static const int MAX_BLOCK_SIZE = 4000;
-    // static const int MAX_ALLOCATIONS = 10000;
-    #ifdef __ANDROID__
+        // static const int MAX_ALLOCATIONS = 10000;
+        #ifdef __ANDROID__
 static const int MAX_ALLOCATIONS = 512;  // reduce size of pool for limited memory
-    #else
+        #else
 static const int MAX_ALLOCATIONS = 2048;
-    #endif
+        #endif
 static void* memoryPtrs[MAX_ALLOCATIONS];
 static void* memoryPtrs2[MAX_ALLOCATIONS];
 
@@ -122,11 +116,11 @@ void Benchmark(const char* name, AllocFunc allocFunc, DeallocFunc deallocFunc) {
     TimeVar t1, t_total;
 
     float ElapsedMicroseconds = 0;
-    #if defined(__clang__)
+        #if defined(__clang__)
     [[maybe_unused]] float TotalElapsedMicroseconds = 0;
-    #else
+        #else
     float TotalElapsedMicroseconds = 0;
-    #endif
+        #endif
     // Allocate MAX_ALLOCATIONS blocks MAX_BLOCK_SIZE / 2 sized blocks
     TIC(t_total);
     TIC(t1);
@@ -199,14 +193,14 @@ TEST(UTBlockAllocate, xalloc_test) {
     Benchmark("xmalloc/xfree (Run 2)", xmalloc, xfree);
     Benchmark("xmalloc/xfree (Run 3)", xmalloc, xfree);
 
-    #ifdef PROFILE
+        #ifdef PROFILE
     xalloc_stats();
-    #endif
+        #endif
 
     // If AUTOMATIC_XALLOCATOR_INIT_DESTROY is defined, ~XallocDestroy() will call
     // xalloc_destroy() automatically. Never call xalloc_destroy() manually except
     // if using xallocator in a C-only application.
     // xalloc_destroy();
 }
-#endif
+    #endif
 #endif

--- a/src/pke/include/cryptocontextfactory.h
+++ b/src/pke/include/cryptocontextfactory.h
@@ -34,7 +34,6 @@
 
 #include "cryptocontext-fwd.h"
 #include "lattice/lat-hal.h"
-
 #include "scheme/scheme-id.h"
 
 #include <memory>
@@ -64,6 +63,8 @@ protected:
 
 public:
     static void ReleaseAllContexts() {
+        if (AllContexts.size() > 0)
+            AllContexts[0]->ClearStaticMapsAndVectors();
         AllContexts.clear();
     }
 

--- a/src/pke/unittest/UnitTestCoexistingCryptocontexts.cpp
+++ b/src/pke/unittest/UnitTestCoexistingCryptocontexts.cpp
@@ -33,25 +33,22 @@
  * creation of another cryptocontext. This test's code should be as close to a regular user project
  * as possible
  */
+
+#include "include/gtest/gtest.h"
 #include "openfhe.h"
 #include "UnitTestUtils.h"
-#include "include/gtest/gtest.h"
 
 using namespace lbcrypto;
 
 class UTGENERAL_CRYPTOCONTEXTS : public ::testing::Test {
 protected:
-    virtual void SetUp() {}
+    virtual void SetUp() {
+        OpenFHEParallelControls.UnitTestStart();
+    }
 
     virtual void TearDown() {
-        // Code here will be called immediately after each test
-        // (right before the destructor).
-        // TODO (dsuponit): do we need to remove keys before releasing all context?
-        // CryptoContextImpl<Poly>::ClearEvalMultKeys();
-        // CryptoContextImpl<Poly>::ClearEvalSumKeys();
-        // CryptoContextImpl<DCRTPoly>::ClearEvalMultKeys();
-        // CryptoContextImpl<DCRTPoly>::ClearEvalSumKeys();
         CryptoContextFactory<DCRTPoly>::ReleaseAllContexts();
+        OpenFHEParallelControls.UnitTestStop();
     }
 };
 

--- a/src/pke/unittest/UnitTestENCRYPT.cpp
+++ b/src/pke/unittest/UnitTestENCRYPT.cpp
@@ -29,12 +29,12 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
 
-#include "UnitTestUtils.h"
+#include "include/gtest/gtest.h"
+#include "utils/exception.h"
 #include "UnitTestCCParams.h"
 #include "UnitTestCryptoContext.h"
-#include "utils/exception.h"
+#include "UnitTestUtils.h"
 
-#include "include/gtest/gtest.h"
 #include <iostream>
 #include <sstream>
 #include <vector>
@@ -140,15 +140,13 @@ class UTGENERAL_ENCRYPT_DECRYPT : public ::testing::TestWithParam<TEST_CASE_UTGE
     using Element = DCRTPoly;
 
 protected:
-    void SetUp() {}
+    void SetUp() {
+        OpenFHEParallelControls.UnitTestStart();
+    }
 
     void TearDown() {
-        // TODO (dsuponit): do we need to remove keys before releasing all context?
-        // CryptoContextImpl<Poly>::ClearEvalMultKeys();
-        // CryptoContextImpl<Poly>::ClearEvalSumKeys();
-        // CryptoContextImpl<DCRTPoly>::ClearEvalMultKeys();
-        // CryptoContextImpl<DCRTPoly>::ClearEvalSumKeys();
         CryptoContextFactory<DCRTPoly>::ReleaseAllContexts();
+        OpenFHEParallelControls.UnitTestStop();
     }
 
     void EncryptionString(const TEST_CASE_UTGENERAL_ENCRYPT_DECRYPT& testData,

--- a/src/pke/unittest/UnitTestEncoding.cpp
+++ b/src/pke/unittest/UnitTestEncoding.cpp
@@ -33,8 +33,6 @@
   This code exercises the encoding libraries of the OpenFHE lattice encryption library.
 */
 
-#define PROFILE
-
 #include "encoding/encodings.h"
 #include "gtest/gtest.h"
 #include "lattice/lat-hal.h"
@@ -47,11 +45,12 @@ using namespace lbcrypto;
 
 class UTGENERAL_ENCODING : public ::testing::Test {
 protected:
-    virtual void SetUp() {}
+    virtual void SetUp() {
+        OpenFHEParallelControls.UnitTestStart();
+    }
 
     virtual void TearDown() {
-        // Code here will be called immediately after each test
-        // (right before the destructor).
+        OpenFHEParallelControls.UnitTestStop();
     }
 };
 

--- a/src/pke/unittest/UnitTestEvalMult.cpp
+++ b/src/pke/unittest/UnitTestEvalMult.cpp
@@ -28,13 +28,14 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
-#include "UnitTestUtils.h"
+
+#include "gtest/gtest.h"
 #include "UnitTestCCParams.h"
 #include "UnitTestCryptoContext.h"
+#include "UnitTestUtils.h"
 
 #include <iostream>
 #include <vector>
-#include "gtest/gtest.h"
 
 using namespace lbcrypto;
 
@@ -265,11 +266,13 @@ class UTGENERAL_EVALMULT : public ::testing::TestWithParam<TEST_CASE_UTGENERAL_E
     const double eps = EPSILON;
 
 protected:
-    void SetUp() {}
+    void SetUp() {
+        OpenFHEParallelControls.UnitTestStart();
+    }
 
     void TearDown() {
-        PackedEncoding::Destroy();
         CryptoContextFactory<DCRTPoly>::ReleaseAllContexts();
+        OpenFHEParallelControls.UnitTestStop();
     }
 
     void UnitTest_EvalMultManyErrorHandling(const TEST_CASE_UTGENERAL_EVALMULT& testData,
@@ -325,12 +328,12 @@ protected:
             // EvalMult Operation
             ////////////////////////////////////////////////////////////
             // Perform consecutive multiplications and do a keyswtiching at the end.
-            auto ciphertextMul12 = (INVALID_CIPHERTEXT_ERROR1 == testData.error) ?
-                                       cryptoContext->EvalMultNoRelin(nullptr, ciphertext2) :
-                                       cryptoContext->EvalMultNoRelin(ciphertext1, ciphertext2);
-            auto ciphertextMul123 = (INVALID_CIPHERTEXT_ERROR2 == testData.error) ?
-                                        cryptoContext->EvalMultNoRelin(ciphertextMul12, nullptr) :
-                                        cryptoContext->EvalMultNoRelin(ciphertextMul12, ciphertext3);
+            auto ciphertextMul12                  = (INVALID_CIPHERTEXT_ERROR1 == testData.error) ?
+                                                        cryptoContext->EvalMultNoRelin(nullptr, ciphertext2) :
+                                                        cryptoContext->EvalMultNoRelin(ciphertext1, ciphertext2);
+            auto ciphertextMul123                 = (INVALID_CIPHERTEXT_ERROR2 == testData.error) ?
+                                                        cryptoContext->EvalMultNoRelin(ciphertextMul12, nullptr) :
+                                                        cryptoContext->EvalMultNoRelin(ciphertextMul12, ciphertext3);
             Ciphertext<Element> ciphertextMul1234 = nullptr;
             if (INVALID_CIPHERTEXT_ERROR3 == testData.error)
                 ciphertextMul1234 = cryptoContext->EvalMultAndRelinearize(nullptr, ciphertext4);

--- a/src/pke/unittest/UnitTestEvalMultMany.cpp
+++ b/src/pke/unittest/UnitTestEvalMultMany.cpp
@@ -29,26 +29,27 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
 
-#include "scheme/bfvrns/gen-cryptocontext-bfvrns.h"
+#include "cryptocontext.h"
+#include "encoding/encodings.h"
 #include "gen-cryptocontext.h"
+#include "gtest/gtest.h"
+#include "scheme/bfvrns/gen-cryptocontext-bfvrns.h"
+#include "utils/debug.h"
 
 #include <fstream>
 #include <iostream>
-#include "gtest/gtest.h"
-
-#include "cryptocontext.h"
-
-#include "encoding/encodings.h"
-
-#include "utils/debug.h"
 
 using namespace lbcrypto;
 
 class UTGENERAL_EVAL_MULT_MANY : public ::testing::Test {
 protected:
-    virtual void SetUp() {}
+    virtual void SetUp() {
+        OpenFHEParallelControls.UnitTestStart();
+    }
 
-    virtual void TearDown() {}
+    virtual void TearDown() {
+        OpenFHEParallelControls.UnitTestStop();
+    }
 
 public:
 };

--- a/src/pke/unittest/UnitTestMultihopPRE.cpp
+++ b/src/pke/unittest/UnitTestMultihopPRE.cpp
@@ -33,11 +33,10 @@
   unit tests for Proxy Re-Encryption. Demo software for multiparty proxy reencryption operations for various schemes
  */
 
-#include "scheme/bgvrns/gen-cryptocontext-bgvrns.h"
-#include "gen-cryptocontext.h"
 #include "cryptocontext.h"
-
+#include "gen-cryptocontext.h"
 #include "include/gtest/gtest.h"
+#include "scheme/bgvrns/gen-cryptocontext-bgvrns.h"
 
 #include <chrono>
 #include <fstream>

--- a/src/pke/unittest/UnitTestMultiparty.cpp
+++ b/src/pke/unittest/UnitTestMultiparty.cpp
@@ -30,10 +30,10 @@
 //==================================================================================
 
 #include "include/gtest/gtest.h"
-#include "UnitTestUtils.h"
+#include "utils/exception.h"
 #include "UnitTestCCParams.h"
 #include "UnitTestCryptoContext.h"
-#include "utils/exception.h"
+#include "UnitTestUtils.h"
 
 #include <iostream>
 #include <sstream>
@@ -373,14 +373,12 @@ class UTGENERAL_MULTIPARTY : public ::testing::TestWithParam<TEST_CASE_UTGENERAL
     using Element = DCRTPoly;
 
 protected:
-    void SetUp() {}
+    void SetUp() {
+        OpenFHEParallelControls.UnitTestStart();
+    }
     void TearDown() {
-        // destroy all staic key maps
-        CryptoContextImpl<DCRTPoly>::ClearEvalMultKeys();
-        CryptoContextImpl<DCRTPoly>::ClearEvalSumKeys();
-        CryptoContextImpl<DCRTPoly>::ClearEvalAutomorphismKeys();
-
         CryptoContextFactory<Element>::ReleaseAllContexts();
+        OpenFHEParallelControls.UnitTestStop();
     }
 
     // in order to avoid redundancy, UnitTest_MultiParty() uses 2 conditions:

--- a/src/pke/unittest/UnitTestPRE.cpp
+++ b/src/pke/unittest/UnitTestPRE.cpp
@@ -29,15 +29,12 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
 
-/*
-  unit tests for the PRE capabilities
- */
-#include "UnitTestUtils.h"
+#include "gtest/gtest.h"
+#include "utils/exception.h"
 #include "UnitTestCCParams.h"
 #include "UnitTestCryptoContext.h"
-#include "utils/exception.h"
+#include "UnitTestUtils.h"
 
-#include "gtest/gtest.h"
 #include <iostream>
 #include <vector>
 
@@ -124,10 +121,13 @@ class UTGENERAL_REENCRYPT : public ::testing::TestWithParam<TEST_CASE_UTGENERAL_
     using Element = DCRTPoly;
 
 protected:
-    void SetUp() {}
+    void SetUp() {
+        OpenFHEParallelControls.UnitTestStart();
+    }
 
     void TearDown() {
         CryptoContextFactory<DCRTPoly>::ReleaseAllContexts();
+        OpenFHEParallelControls.UnitTestStop();
     }
 
     void ReEncryption(const TEST_CASE_UTGENERAL_REENCRYPT& testData, const std::string& failmsg = std::string()) {

--- a/src/pke/unittest/UnitTestSHE.cpp
+++ b/src/pke/unittest/UnitTestSHE.cpp
@@ -33,14 +33,14 @@
   unit tests for the SHE capabilities
  */
 
-#include "UnitTestUtils.h"
+#include "gtest/gtest.h"
 #include "UnitTestCCParams.h"
 #include "UnitTestCryptoContext.h"
 #include "UnitTestMetadataTest.h"
+#include "UnitTestUtils.h"
 
 #include <iostream>
 #include <vector>
-#include "gtest/gtest.h"
 
 using namespace lbcrypto;
 
@@ -495,10 +495,13 @@ class UTGENERAL_SHE : public ::testing::TestWithParam<TEST_CASE_UTGENERAL_SHE> {
     const double eps = EPSILON;
 
 protected:
-    void SetUp() {}
+    void SetUp() {
+        OpenFHEParallelControls.UnitTestStart();
+    }
 
     void TearDown() {
         CryptoContextFactory<DCRTPoly>::ReleaseAllContexts();
+        OpenFHEParallelControls.UnitTestStop();
     }
 
     void UnitTest_Add_Packed(const TEST_CASE_UTGENERAL_SHE& testData, const std::string& failmsg = std::string()) {

--- a/src/pke/unittest/utbfvrns/UnitTestBFVrns.cpp
+++ b/src/pke/unittest/utbfvrns/UnitTestBFVrns.cpp
@@ -28,14 +28,15 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
-#include "UnitTestUtils.h"
+
+#include "gtest/gtest.h"
 #include "UnitTestCCParams.h"
 #include "UnitTestCryptoContext.h"
+#include "UnitTestUtils.h"
 
 #include <iostream>
-#include <vector>
-#include "gtest/gtest.h"
 #include <iterator>
+#include <vector>
 
 using namespace lbcrypto;
 
@@ -122,10 +123,13 @@ class UTBFVRNS : public ::testing::TestWithParam<TEST_CASE_UTBFVRNS> {
     const double eps = EPSILON;
 
 protected:
-    void SetUp() {}
+    void SetUp() {
+        OpenFHEParallelControls.UnitTestStart();
+    }
 
     void TearDown() {
         CryptoContextFactory<DCRTPoly>::ReleaseAllContexts();
+        OpenFHEParallelControls.UnitTestStop();
     }
 
     void UnitTest_EvalFastRotation(const TEST_CASE_UTBFVRNS& testData, const std::string& failmsg = std::string()) {

--- a/src/pke/unittest/utbfvrns/UnitTestBFVrnsAutomorphism.cpp
+++ b/src/pke/unittest/utbfvrns/UnitTestBFVrnsAutomorphism.cpp
@@ -29,30 +29,30 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
 
-#include "scheme/bfvrns/gen-cryptocontext-bfvrns.h"
+#include "cryptocontext.h"
+#include "encoding/encodings.h"
 #include "gen-cryptocontext.h"
+#include "gtest/gtest.h"
+#include "scheme/bfvrns/gen-cryptocontext-bfvrns.h"
+#include "UnitTestUtils.h"
+#include "utils/debug.h"
 
 #include <algorithm>
 #include <iostream>
 #include <vector>
-#include "UnitTestUtils.h"
-#include "gtest/gtest.h"
-
-#include "cryptocontext.h"
-
-#include "encoding/encodings.h"
-
-#include "utils/debug.h"
 
 using namespace lbcrypto;
 
 namespace {
 class UTBFVRNS_AUTOMORPHISM : public ::testing::Test {
 protected:
-    void SetUp() {}
+    void SetUp() {
+        OpenFHEParallelControls.UnitTestStart();
+    }
 
     void TearDown() {
         CryptoContextFactory<DCRTPoly>::ReleaseAllContexts();
+        OpenFHEParallelControls.UnitTestStop();
     }
 
 public:

--- a/src/pke/unittest/utbfvrns/UnitTestBFVrnsCRTOperations.cpp
+++ b/src/pke/unittest/utbfvrns/UnitTestBFVrnsCRTOperations.cpp
@@ -31,8 +31,8 @@
 
 #include "cryptocontext.h"
 #include "encoding/encodings.h"
-#include "gtest/gtest.h"
 #include "gen-cryptocontext.h"
+#include "gtest/gtest.h"
 #include "scheme/bfvrns/gen-cryptocontext-bfvrns.h"
 #include "UnitTestCCParams.h"
 #include "UnitTestCryptoContext.h"
@@ -46,10 +46,13 @@ using namespace lbcrypto;
 
 class UTBFVRNS_CRT : public ::testing::Test {
 protected:
-    void SetUp() {}
+    void SetUp() {
+        OpenFHEParallelControls.UnitTestStart();
+    }
 
     void TearDown() {
         CryptoContextFactory<DCRTPoly>::ReleaseAllContexts();
+        OpenFHEParallelControls.UnitTestStop();
     }
 
 public:

--- a/src/pke/unittest/utbfvrns/UnitTestBFVrnsDecrypt.cpp
+++ b/src/pke/unittest/utbfvrns/UnitTestBFVrnsDecrypt.cpp
@@ -43,10 +43,13 @@ using namespace lbcrypto;
 
 class UTBFVRNS_DECRYPT : public ::testing::TestWithParam<std::tuple<usint, usint>> {
 protected:
-    void SetUp() {}
+    void SetUp() {
+        OpenFHEParallelControls.UnitTestStart();
+    }
 
     void TearDown() {
         CryptoContextFactory<DCRTPoly>::ReleaseAllContexts();
+        OpenFHEParallelControls.UnitTestStop();
     }
 
 public:

--- a/src/pke/unittest/utbfvrns/UnitTestBFVrnsInnerProduct.cpp
+++ b/src/pke/unittest/utbfvrns/UnitTestBFVrnsInnerProduct.cpp
@@ -29,24 +29,26 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
 
+#include "cryptocontext.h"
 #include "scheme/bfvrns/gen-cryptocontext-bfvrns.h"
 #include "gen-cryptocontext.h"
-#include "cryptocontext.h"
+#include "gtest/gtest.h"
+#include "utils/debug.h"
 
 #include <vector>
-#include "gtest/gtest.h"
-
-#include "utils/debug.h"
 
 using namespace lbcrypto;
 
 namespace {
 class UTBFVRNS_INNERPRODUCT : public ::testing::Test {
 protected:
-    void SetUp() {}
+    void SetUp() {
+        OpenFHEParallelControls.UnitTestStart();
+    }
 
     void TearDown() {
         CryptoContextFactory<DCRTPoly>::ReleaseAllContexts();
+        OpenFHEParallelControls.UnitTestStop();
     }
 
 public:

--- a/src/pke/unittest/utbfvrns/UnitTestBFVrnsSerialize.cpp
+++ b/src/pke/unittest/utbfvrns/UnitTestBFVrnsSerialize.cpp
@@ -29,23 +29,23 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
 
-#include "UnitTestSer.h"
+#include "gen-cryptocontext.h"
 #include "gtest/gtest.h"
-
 #include "scheme/bfvrns/bfvrns-ser.h"
 #include "scheme/bfvrns/gen-cryptocontext-bfvrns.h"
-#include "gen-cryptocontext.h"
+#include "UnitTestSer.h"
 
 using namespace lbcrypto;
 
 class UTBFVRNS_SER : public ::testing::Test {
 protected:
-    void SetUp() {}
+    void SetUp() {
+        OpenFHEParallelControls.UnitTestStart();
+    }
 
     void TearDown() {
-        CryptoContextImpl<DCRTPoly>::ClearEvalMultKeys();
-        CryptoContextImpl<DCRTPoly>::ClearEvalSumKeys();
         CryptoContextFactory<DCRTPoly>::ReleaseAllContexts();
+        OpenFHEParallelControls.UnitTestStop();
     }
 };
 

--- a/src/pke/unittest/utbgvrns/UnitTestBGVrns.cpp
+++ b/src/pke/unittest/utbgvrns/UnitTestBGVrns.cpp
@@ -29,16 +29,16 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
 
-#include "UnitTestUtils.h"
+#include "gtest/gtest.h"
 #include "UnitTestCCParams.h"
 #include "UnitTestCryptoContext.h"
 #include "UnitTestMetadataTest.h"
+#include "UnitTestUtils.h"
 
 #include <iostream>
-#include <vector>
 #include <memory>
 #include <string>
-#include "gtest/gtest.h"
+#include <vector>
 
 using namespace lbcrypto;
 
@@ -268,10 +268,13 @@ class UTBGVRNS : public ::testing::TestWithParam<TEST_CASE_UTBGVRNS> {
     const std::vector<int64_t> vectorOfInts1s{1, 1, 1, 1, 1, 1, 1, 1};  // all 1's
 
 protected:
-    void SetUp() {}
+    void SetUp() {
+        OpenFHEParallelControls.UnitTestStart();
+    }
 
     void TearDown() {
         CryptoContextFactory<DCRTPoly>::ReleaseAllContexts();
+        OpenFHEParallelControls.UnitTestStop();
     }
 
     void UnitTest_Add_Packed(const TEST_CASE_UTBGVRNS& testData, const std::string& failmsg = std::string()) {

--- a/src/pke/unittest/utbgvrns/UnitTestBGVrnsAdvancedSHE.cpp
+++ b/src/pke/unittest/utbgvrns/UnitTestBGVrnsAdvancedSHE.cpp
@@ -31,13 +31,13 @@
 
 #if !defined(_MSC_VER)
 
-    #include "UnitTestUtils.h"
+    #include "gtest/gtest.h"
     #include "UnitTestCCParams.h"
     #include "UnitTestCryptoContext.h"
+    #include "UnitTestUtils.h"
 
     #include <iostream>
     #include <vector>
-    #include "gtest/gtest.h"
 
 using namespace lbcrypto;
 
@@ -120,10 +120,13 @@ class UTBGVRNS_SHEADVANCED : public ::testing::TestWithParam<TEST_CASE_UTBGVRNS_
     using Element = DCRTPoly;
 
 protected:
-    void SetUp() {}
+    void SetUp() {
+        OpenFHEParallelControls.UnitTestStart();
+    }
 
     void TearDown() {
         CryptoContextFactory<DCRTPoly>::ReleaseAllContexts();
+        OpenFHEParallelControls.UnitTestStop();
     }
 
     void UnitTest_EvalMultSingle(const TEST_CASE_UTBGVRNS_SHEADVANCED& testData,

--- a/src/pke/unittest/utbgvrns/UnitTestBGVrnsAutomorphism.cpp
+++ b/src/pke/unittest/utbgvrns/UnitTestBGVrnsAutomorphism.cpp
@@ -28,16 +28,17 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
+
 #include "BaseTestCase.h"
-#include "UnitTestReadCSVData.h"
-#include "UnitTestUtils.h"
+#include "gtest/gtest.h"
 #include "UnitTestCCParams.h"
 #include "UnitTestCryptoContext.h"
+#include "UnitTestReadCSVData.h"
+#include "UnitTestUtils.h"
 
 #include <iostream>
-#include <vector>
 #include <unordered_map>
-#include "gtest/gtest.h"
+#include <vector>
 
 #if !defined(__EMSCRIPTEN__)
 using namespace lbcrypto;
@@ -188,11 +189,13 @@ class UTBGVRNS_AUTOMORPHISM : public ::testing::TestWithParam<TEST_CASE_UTBGVRNS
     const int64_t vector8Sum             = std::accumulate(vector8.begin(), vector8.end(), int64_t(0));  // 36
 
 protected:
-    void SetUp() {}
+    void SetUp() {
+        OpenFHEParallelControls.UnitTestStart();
+    }
 
     void TearDown() {
-        PackedEncoding::Destroy();
         CryptoContextFactory<DCRTPoly>::ReleaseAllContexts();
+        OpenFHEParallelControls.UnitTestStop();
     }
 
     void UnitTest_AutomorphismPackedArray(const TEST_CASE_UTBGVRNS_AUTOMORPHISM& testData,
@@ -414,4 +417,4 @@ TEST_P(UTBGVRNS_AUTOMORPHISM, Automorphism) {
 
 INSTANTIATE_TEST_SUITE_P(UnitTests, UTBGVRNS_AUTOMORPHISM, ::testing::ValuesIn(testCasesUTBGVRNS_AUTOMORPHISM),
                          testName);
-#endif // __EMSCRIPTEN__
+#endif  // __EMSCRIPTEN__

--- a/src/pke/unittest/utbgvrns/UnitTestBGVrnsSerialize.cpp
+++ b/src/pke/unittest/utbgvrns/UnitTestBGVrnsSerialize.cpp
@@ -31,17 +31,16 @@
 
 #include "ciphertext-ser.h"
 #include "cryptocontext-ser.h"
+#include "globals.h"
+#include "include/gtest/gtest.h"
 #include "key/key-ser.h"
 #include "scheme/bgvrns/bgvrns-ser.h"
-
-#include "UnitTestUtils.h"
-#include "UnitTestSer.h"
 #include "UnitTestCCParams.h"
 #include "UnitTestCryptoContext.h"
+#include "UnitTestSer.h"
+#include "UnitTestUtils.h"
 #include "utils/exception.h"
-#include "globals.h"  // for SERIALIZE_PRECOMPUTE
 
-#include "include/gtest/gtest.h"
 #include <iostream>
 #include <sstream>
 #include <vector>
@@ -159,10 +158,13 @@ class UTBGVRNS_SER : public ::testing::TestWithParam<TEST_CASE_UTBGVRNS_SER> {
     const double eps = EPSILON;
 
 protected:
-    void SetUp() {}
+    void SetUp() {
+        OpenFHEParallelControls.UnitTestStart();
+    }
 
     void TearDown() {
         CryptoContextFactory<DCRTPoly>::ReleaseAllContexts();
+        OpenFHEParallelControls.UnitTestStop();
     }
 
     void UnitTestContext(const TEST_CASE_UTBGVRNS_SER& testData, const std::string& failmsg = std::string()) {

--- a/src/pke/unittest/utckksrns/UnitTestBootstrap.cpp
+++ b/src/pke/unittest/utckksrns/UnitTestBootstrap.cpp
@@ -402,10 +402,13 @@ class UTCKKSRNS_BOOT : public ::testing::TestWithParam<TEST_CASE_UTCKKSRNS_BOOT>
     }
 
 protected:
-    void SetUp() {}
+    void SetUp() {
+        OpenFHEParallelControls.UnitTestStart();
+    }
 
     void TearDown() {
         CryptoContextFactory<DCRTPoly>::ReleaseAllContexts();
+        OpenFHEParallelControls.UnitTestStop();
     }
 
     void UnitTest_Bootstrap(const TEST_CASE_UTCKKSRNS_BOOT& testData, const bool StCFlag,

--- a/src/pke/unittest/utckksrns/UnitTestCKKSrns.cpp
+++ b/src/pke/unittest/utckksrns/UnitTestCKKSrns.cpp
@@ -29,10 +29,6 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
 
-/*
-  Unit tests for the CKKS scheme
- */
-
 #include "gtest/gtest.h"
 #include "UnitTestCCParams.h"
 #include "UnitTestCryptoContext.h"
@@ -640,10 +636,13 @@ class UTCKKSRNS : public ::testing::TestWithParam<TEST_CASE_UTCKKSRNS> {
     }
 
 protected:
-    void SetUp() {}
+    void SetUp() {
+        OpenFHEParallelControls.UnitTestStart();
+    }
 
     void TearDown() {
         CryptoContextFactory<DCRTPoly>::ReleaseAllContexts();
+        OpenFHEParallelControls.UnitTestStop();
     }
 
     template <typename T>

--- a/src/pke/unittest/utckksrns/UnitTestCKKSrnsAutomorphism.cpp
+++ b/src/pke/unittest/utckksrns/UnitTestCKKSrnsAutomorphism.cpp
@@ -29,16 +29,13 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
 
-/*
-  UnitTestAutomorphism for all transform testing
- */
-#include "UnitTestUtils.h"
 #include "UnitTestCCParams.h"
 #include "UnitTestCryptoContext.h"
+#include "UnitTestUtils.h"
+#include "gtest/gtest.h"
 
 #include <iostream>
 #include <vector>
-#include "gtest/gtest.h"
 
 using namespace lbcrypto;
 
@@ -212,11 +209,13 @@ class UTCKKSRNS_AUTOMORPHISM : public ::testing::TestWithParam<TEST_CASE_UTCKKSR
     const int64_t vector8Sum = std::accumulate(vector8.begin(), vector8.end(), int64_t(0));      // 36
 
 protected:
-    void SetUp() {}
+    void SetUp() {
+        OpenFHEParallelControls.UnitTestStart();
+    }
 
     void TearDown() {
-        PackedEncoding::Destroy();
         CryptoContextFactory<DCRTPoly>::ReleaseAllContexts();
+        OpenFHEParallelControls.UnitTestStop();
     }
 
     void UnitTest_EvalAtIndexPackedArray(const TEST_CASE_UTCKKSRNS_AUTOMORPHISM& testData,

--- a/src/pke/unittest/utckksrns/UnitTestCKKSrnsCompositeScaling.cpp
+++ b/src/pke/unittest/utckksrns/UnitTestCKKSrnsCompositeScaling.cpp
@@ -29,22 +29,18 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
 
-/*
-  Unit tests for the CKKS scheme
- */
-
-#include "UnitTestUtils.h"
+#include "gtest/gtest.h"
 #include "UnitTestCCParams.h"
 #include "UnitTestCryptoContext.h"
 #include "UnitTestMetadataTest.h"
+#include "UnitTestUtils.h"
 
-#include <iostream>
-#include <vector>
-#include "gtest/gtest.h"
-#include <iterator>
 #include <algorithm>
+#include <iostream>
+#include <iterator>
 #include <memory>
 #include <string>
+#include <vector>
 
 using namespace lbcrypto;
 
@@ -439,10 +435,13 @@ class UTCKKSRNSCS : public ::testing::TestWithParam<TEST_CASE_UTCKKSRNS_CS> {
     }
 
 protected:
-    void SetUp() {}
+    void SetUp() {
+        OpenFHEParallelControls.UnitTestStart();
+    }
 
     void TearDown() {
         CryptoContextFactory<DCRTPoly>::ReleaseAllContexts();
+        OpenFHEParallelControls.UnitTestStop();
     }
 
     template <typename T>

--- a/src/pke/unittest/utckksrns/UnitTestCKKSrnsCompositeScalingBootstrap.cpp
+++ b/src/pke/unittest/utckksrns/UnitTestCKKSrnsCompositeScalingBootstrap.cpp
@@ -29,22 +29,18 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
 
-/*
-  Unit tests for the CKKS scheme
- */
-
-#include "UnitTestUtils.h"
+#include "cryptocontext-ser.h"
+#include "gtest/gtest.h"
+#include "scheme/ckksrns/ckksrns-ser.h"
+#include "scheme/ckksrns/ckksrns-utils.h"
 #include "UnitTestCCParams.h"
 #include "UnitTestCryptoContext.h"
-#include "scheme/ckksrns/ckksrns-utils.h"
-#include "cryptocontext-ser.h"
-#include "scheme/ckksrns/ckksrns-ser.h"
+#include "UnitTestUtils.h"
 
 #include <iostream>
-#include <vector>
-#include "gtest/gtest.h"
 #include <iterator>
 #include <string>
+#include <vector>
 
 using namespace lbcrypto;
 
@@ -232,10 +228,13 @@ class UTCKKSRNSCS_BOOT : public ::testing::TestWithParam<TEST_CASE_UTCKKSRNSCS_B
     }
 
 protected:
-    void SetUp() {}
+    void SetUp() {
+        OpenFHEParallelControls.UnitTestStart();
+    }
 
     void TearDown() {
         CryptoContextFactory<DCRTPoly>::ReleaseAllContexts();
+        OpenFHEParallelControls.UnitTestStop();
     }
 
     void UnitTest_Bootstrap(const TEST_CASE_UTCKKSRNSCS_BOOT& testData, const bool StCFlag,

--- a/src/pke/unittest/utckksrns/UnitTestCKKSrnsInnerProduct.cpp
+++ b/src/pke/unittest/utckksrns/UnitTestCKKSrnsInnerProduct.cpp
@@ -29,24 +29,26 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
 
-#include "scheme/ckksrns/gen-cryptocontext-ckksrns.h"
-#include "gen-cryptocontext.h"
 #include "cryptocontext.h"
+#include "gen-cryptocontext.h"
+#include "gtest/gtest.h"
+#include "scheme/ckksrns/gen-cryptocontext-ckksrns.h"
+#include "utils/debug.h"
 
 #include <vector>
-#include "gtest/gtest.h"
-
-#include "utils/debug.h"
 
 using namespace lbcrypto;
 
 namespace {
 class UTCKKSRNS_INNERPRODUCT : public ::testing::Test {
 protected:
-    void SetUp() {}
+    void SetUp() {
+        OpenFHEParallelControls.UnitTestStart();
+    }
 
     void TearDown() {
         CryptoContextFactory<DCRTPoly>::ReleaseAllContexts();
+        OpenFHEParallelControls.UnitTestStop();
     }
 
 public:

--- a/src/pke/unittest/utckksrns/UnitTestCKKSrnsSerialize.cpp
+++ b/src/pke/unittest/utckksrns/UnitTestCKKSrnsSerialize.cpp
@@ -31,7 +31,7 @@
 
 #include "ciphertext-ser.h"
 #include "cryptocontext-ser.h"
-#include "globals.h"  // for SERIALIZE_PRECOMPUTE
+#include "globals.h"
 #include "gtest/gtest.h"
 #include "scheme/ckksrns/ckksrns-ser.h"
 #include "UnitTestCCParams.h"
@@ -40,8 +40,8 @@
 #include "UnitTestUtils.h"
 
 #include <iostream>
-#include <vector>
 #include <string>
+#include <vector>
 
 using namespace lbcrypto;
 
@@ -176,10 +176,13 @@ class UTCKKSRNS_SER : public ::testing::TestWithParam<TEST_CASE_UTCKKSRNS_SER> {
     const double eps = EPSILON;
 
 protected:
-    void SetUp() {}
+    void SetUp() {
+        OpenFHEParallelControls.UnitTestStart();
+    }
 
     void TearDown() {
         CryptoContextFactory<DCRTPoly>::ReleaseAllContexts();
+        OpenFHEParallelControls.UnitTestStop();
     }
 
     void UnitTestContext(const TEST_CASE_UTCKKSRNS_SER& testData, const std::string& failmsg = std::string()) {

--- a/src/pke/unittest/utckksrns/UnitTestFBT.cpp
+++ b/src/pke/unittest/utckksrns/UnitTestFBT.cpp
@@ -288,10 +288,13 @@ static std::vector<TEST_CASE_FBT> testCases = {
 
 class UTCKKSRNS_FBT : public ::testing::TestWithParam<TEST_CASE_FBT> {
 protected:
-    void SetUp() {};
+    void SetUp() {
+        OpenFHEParallelControls.UnitTestStart();
+    };
 
     void TearDown() {
         CryptoContextFactory<DCRTPoly>::ReleaseAllContexts();
+        OpenFHEParallelControls.UnitTestStop();
     }
 
     void UnitTest_ArbLUT(TEST_CASE_FBT t, const std::string& failmsg = std::string()) {

--- a/src/pke/unittest/utckksrns/UnitTestInteractiveBootstrap.cpp
+++ b/src/pke/unittest/utckksrns/UnitTestInteractiveBootstrap.cpp
@@ -167,11 +167,13 @@ class UTCKKSRNS_INTERACTIVE_BOOT : public ::testing::TestWithParam<TEST_CASE_UTC
     };
 
 protected:
-    void SetUp() {}
+    void SetUp() {
+        OpenFHEParallelControls.UnitTestStart();
+    }
 
     void TearDown() {
-        PackedEncoding::Destroy();
         CryptoContextFactory<Element>::ReleaseAllContexts();
+        OpenFHEParallelControls.UnitTestStop();
     }
 
     void UnitTest_MultiPartyBoot(const TEST_CASE_UTCKKSRNS_INTERACTIVE_BOOT& testData,

--- a/src/pke/unittest/utckksrns/UnitTestNoiseFlooding.cpp
+++ b/src/pke/unittest/utckksrns/UnitTestNoiseFlooding.cpp
@@ -29,18 +29,14 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
 
-/*
-  Unit tests for the CKKS scheme
- */
-
-#include "UnitTestUtils.h"
+#include "gtest/gtest.h"
 #include "UnitTestCCParams.h"
 #include "UnitTestCryptoContext.h"
+#include "UnitTestUtils.h"
 
 #include <iostream>
-#include <vector>
-#include "gtest/gtest.h"
 #include <iterator>
+#include <vector>
 
 using namespace lbcrypto;
 
@@ -203,10 +199,13 @@ class UTCKKSRNS_NOISE_FLOODING : public ::testing::TestWithParam<TEST_CASE_UTCKK
     }
 
 protected:
-    void SetUp() {}
+    void SetUp() {
+        OpenFHEParallelControls.UnitTestStart();
+    }
 
     void TearDown() {
         CryptoContextFactory<DCRTPoly>::ReleaseAllContexts();
+        OpenFHEParallelControls.UnitTestStop();
     }
 
     void UnitTest_NoiseEstimation(const TEST_CASE_UTCKKSRNS_NOISE_FLOODING& testData,

--- a/src/pke/unittest/utckksrns/UnitTestPoly.cpp
+++ b/src/pke/unittest/utckksrns/UnitTestPoly.cpp
@@ -29,18 +29,14 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
 
-/*
-  Unit tests for the CKKS scheme
- */
-
-#include "UnitTestUtils.h"
+#include "gtest/gtest.h"
 #include "UnitTestCCParams.h"
 #include "UnitTestCryptoContext.h"
+#include "UnitTestUtils.h"
 
 #include <iostream>
-#include <vector>
-#include "gtest/gtest.h"
 #include <iterator>
+#include <vector>
 
 using namespace lbcrypto;
 
@@ -276,10 +272,13 @@ class UTCKKSRNS_EVAL_POLY : public ::testing::TestWithParam<TEST_CASE_UTCKKSRNS_
     const double eps = 0.001;
 
 protected:
-    void SetUp() {}
+    void SetUp() {
+        OpenFHEParallelControls.UnitTestStart();
+    }
 
     void TearDown() {
         CryptoContextFactory<DCRTPoly>::ReleaseAllContexts();
+        OpenFHEParallelControls.UnitTestStop();
     }
 
     void UnitTest_EvalPoly(const TEST_CASE_UTCKKSRNS_EVAL_POLY& testData, const std::string& failmsg = std::string()) {

--- a/src/pke/unittest/utckksrns/UnitTestSchemeSwitch.cpp
+++ b/src/pke/unittest/utckksrns/UnitTestSchemeSwitch.cpp
@@ -294,10 +294,13 @@ class UTCKKSRNS_SCHEMESWITCH : public ::testing::TestWithParam<TEST_CASE_UTCKKSR
     }
 
 protected:
-    void SetUp() {}
+    void SetUp() {
+        OpenFHEParallelControls.UnitTestStart();
+    }
 
     void TearDown() {
         CryptoContextFactory<Element>::ReleaseAllContexts();
+        OpenFHEParallelControls.UnitTestStop();
     }
 
     void UnitTest_SchemeSwitch_CKKS_FHEW(const TEST_CASE_UTCKKSRNS_SCHEMESWITCH& testData,

--- a/src/pke/unittest/utils/BaseTestCase.h
+++ b/src/pke/unittest/utils/BaseTestCase.h
@@ -32,11 +32,10 @@
 #define __BASETESTCASE_H__
 
 #include "config_core.h"
-#include "scheme/ckksrns/gen-cryptocontext-ckksrns.h"
 #include "scheme/bfvrns/gen-cryptocontext-bfvrns.h"
 #include "scheme/bgvrns/gen-cryptocontext-bgvrns.h"
+#include "scheme/ckksrns/gen-cryptocontext-ckksrns.h"
 #include "scheme/gen-cryptocontext-params.h"
-
 #include "utils/exception.h"
 
 #include <memory>

--- a/src/pke/unittest/utils/UnitTestCCParams.cpp
+++ b/src/pke/unittest/utils/UnitTestCCParams.cpp
@@ -30,37 +30,24 @@
 //==================================================================================
 
 #include "UnitTestCCParams.h"
-#include <sstream>
+
 #include <ostream>
+#include <sstream>
 
 std::string UnitTestCCParams::toString() const {
     std::stringstream ss;
-    ss << "schemeId [" << schemeId << "], "
-       << "ringDimension [" << ringDimension << "], "
-       << "multiplicativeDepth [" << multiplicativeDepth << "], "
-       << "scalingModSize [" << scalingModSize << "], "
-       << "digitSize [" << digitSize << "], "
-       << "batchSize [" << batchSize << "], "
-       << "secretKeyDist [" << secretKeyDist << "], "
-       << "maxRelinSkDeg [" << maxRelinSkDeg << "], "
-       << "firstModSize [" << firstModSize << "], "
-       << "securityLevel [" << securityLevel << "], "
-       << "ksTech [" << ksTech << "], "
-       << "scalTech [" << scalTech << "], "
-       << "numLargeDigits [" << numLargeDigits << "], "
-       << "plaintextModulus [" << plaintextModulus << "], "
-       << "standardDeviation [" << standardDeviation << "], "
-       << "evalAddCount [" << evalAddCount << "], "
-       << "keySwitchCount [" << keySwitchCount << "], "
-       << "multiplicationTechnique [" << multiplicationTechnique << "], "
-       << "encryptionTechnique [" << encryptionTechnique << "], "
-       << "PREMode [" << PREMode << "], "
-       << "multipartyMode [" << multipartyMode << "], "
-       << "decryptionNoiseMode [" << decryptionNoiseMode << "], "
-       << "executionMode [" << executionMode << "], "
-       << "noiseEstimate [" << noiseEstimate << "], "
-       << "registerWordSize [" << registerWordSize << "], "
-       << "compositeDegree [" << compositeDegree << "] ";
+    ss << "schemeId [" << schemeId << "], " << "ringDimension [" << ringDimension << "], " << "multiplicativeDepth ["
+       << multiplicativeDepth << "], " << "scalingModSize [" << scalingModSize << "], " << "digitSize [" << digitSize
+       << "], " << "batchSize [" << batchSize << "], " << "secretKeyDist [" << secretKeyDist << "], "
+       << "maxRelinSkDeg [" << maxRelinSkDeg << "], " << "firstModSize [" << firstModSize << "], " << "securityLevel ["
+       << securityLevel << "], " << "ksTech [" << ksTech << "], " << "scalTech [" << scalTech << "], "
+       << "numLargeDigits [" << numLargeDigits << "], " << "plaintextModulus [" << plaintextModulus << "], "
+       << "standardDeviation [" << standardDeviation << "], " << "evalAddCount [" << evalAddCount << "], "
+       << "keySwitchCount [" << keySwitchCount << "], " << "multiplicationTechnique [" << multiplicationTechnique
+       << "], " << "encryptionTechnique [" << encryptionTechnique << "], " << "PREMode [" << PREMode << "], "
+       << "multipartyMode [" << multipartyMode << "], " << "decryptionNoiseMode [" << decryptionNoiseMode << "], "
+       << "executionMode [" << executionMode << "], " << "noiseEstimate [" << noiseEstimate << "], "
+       << "registerWordSize [" << registerWordSize << "], " << "compositeDegree [" << compositeDegree << "] ";
     return ss.str();
 }
 //===========================================================================================================

--- a/src/pke/unittest/utils/UnitTestCCParams.h
+++ b/src/pke/unittest/utils/UnitTestCCParams.h
@@ -32,10 +32,11 @@
 #ifndef __UNITTESTCCPARAMS_H__
 #define __UNITTESTCCPARAMS_H__
 
+#include "scheme/scheme-id.h"
+
+#include <cmath>
 #include <iosfwd>
 #include <string>
-#include <cmath>
-#include "scheme/scheme-id.h"  // SCHEME
 
 enum { DFLT = -999 };  // enum for test cases if you want to use the default value for the parameter
 

--- a/src/pke/unittest/utils/UnitTestCryptoContext.cpp
+++ b/src/pke/unittest/utils/UnitTestCryptoContext.cpp
@@ -29,11 +29,11 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
 
-#include "UnitTestCryptoContext.h"
-#include "scheme/ckksrns/gen-cryptocontext-ckksrns.h"
+#include "gen-cryptocontext.h"
 #include "scheme/bfvrns/gen-cryptocontext-bfvrns.h"
 #include "scheme/bgvrns/gen-cryptocontext-bgvrns.h"
-#include "gen-cryptocontext.h"
+#include "scheme/ckksrns/gen-cryptocontext-ckksrns.h"
+#include "UnitTestCryptoContext.h"
 
 using namespace lbcrypto;
 
@@ -142,7 +142,6 @@ static void setCryptoContextParametersFromUnitTestCCParams(const UnitTestCCParam
         if (!isDefaultValue(params.compositeDegree)) {
             parameters.SetCompositeDegree(params.compositeDegree);
         }
-
     }
     if constexpr (std::is_same_v<U, CCParams<CryptoContextCKKSRNS>> == true) {
         if (!isDefaultValue(params.ckksDataType)) {

--- a/src/pke/unittest/utils/UnitTestCryptoContext.h
+++ b/src/pke/unittest/utils/UnitTestCryptoContext.h
@@ -33,9 +33,9 @@
 #define __UNITTESTCRYPTOCONTEXT_H__
 
 #include "BaseTestCase.h"
-#include "UnitTestCCParams.h"
 #include "cryptocontext.h"
 #include "schemebase/base-scheme.h"
+#include "UnitTestCCParams.h"
 
 using Element = lbcrypto::DCRTPoly;
 

--- a/src/pke/unittest/utils/UnitTestException.h
+++ b/src/pke/unittest/utils/UnitTestException.h
@@ -34,6 +34,7 @@
 
 #include "gtest/gtest.h"
 #include "utils/demangle.h"
+
 #include <iostream>
 #include <string>
 

--- a/src/pke/unittest/utils/UnitTestMetadataTest.h
+++ b/src/pke/unittest/utils/UnitTestMetadataTest.h
@@ -31,12 +31,12 @@
 #ifndef __UNITTESTMETADATATEST_H__
 #define __UNITTESTMETADATATEST_H__
 
-#include "metadata.h"
 #include "ciphertext.h"
+#include "metadata.h"
 
 #include <memory>
-#include <string>
 #include <ostream>
+#include <string>
 
 namespace lbcrypto {
 

--- a/src/pke/unittest/utils/UnitTestReadCSVData.cpp
+++ b/src/pke/unittest/utils/UnitTestReadCSVData.cpp
@@ -28,10 +28,10 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
-#include "UnitTestReadCSVData.h"
-#include "UnitTestException.h"
 
 #include "scheme/gen-cryptocontext-params.h"
+#include "UnitTestReadCSVData.h"
+#include "UnitTestException.h"
 #include "utils/exception.h"
 
 #include <fstream>

--- a/src/pke/unittest/utils/UnitTestSer.h
+++ b/src/pke/unittest/utils/UnitTestSer.h
@@ -36,12 +36,13 @@
 #ifndef __UNITTEST_SER_H__
 #define __UNITTEST_SER_H__
 
-#include "UnitTestException.h"
 #include "cryptocontext-ser.h"
+#include "globals.h"
 #include "gtest/gtest.h"
-#include <string>
+#include "UnitTestException.h"
+
 #include <iostream>
-#include "globals.h"  // for SERIALIZE_PRECOMPUTE
+#include <string>
 
 using namespace lbcrypto;
 

--- a/src/pke/unittest/utils/UnitTestUtils.h
+++ b/src/pke/unittest/utils/UnitTestUtils.h
@@ -38,12 +38,13 @@
 
 #include "gtest/gtest.h"
 #include "UnitTestException.h"
-#include <vector>
-#include <string>
+
 #include <algorithm>
-#include <csignal>
 #include <complex>
+#include <csignal>
 #include <iostream>
+#include <string>
+#include <vector>
 
 // some functions are inlined in this files to avoid link errors
 //===========================================================================================================

--- a/src/pke/unittest/utils/schemeswitching-data-serializer.cpp
+++ b/src/pke/unittest/utils/schemeswitching-data-serializer.cpp
@@ -28,13 +28,15 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==================================================================================
-#include "schemeswitching-data-serializer.h"
 
 #include "ciphertext-ser.h"
 #include "cryptocontext-ser.h"
 #include "key/key-ser.h"
 #include "scheme/ckksrns/ckksrns-ser.h"
+#include "schemeswitching-data-serializer.h"
+
 #include <filesystem>
+#include <vector>
 
 // includes for getProgramPath()
 #if defined(_WIN32) && (defined(__MINGW32__) || defined(__MINGW64__))
@@ -47,7 +49,6 @@ namespace lbcrypto {
 
 // Helper function to get the absolute path to the running unittests executable
 std::filesystem::path getProgramPath() {
-
 #if defined(_WIN32) && (defined(__MINGW32__) || defined(__MINGW64__))
     // MinGW: Unicode-safe wide API. Use a big static buffer (32K).
     wchar_t buf[32768];
@@ -59,7 +60,7 @@ std::filesystem::path getProgramPath() {
     return std::filesystem::path(buf, buf + len);
 #elif defined(__APPLE__)
     uint32_t size = 0;
-    _NSGetExecutablePath(nullptr, &size);           // ask required size
+    _NSGetExecutablePath(nullptr, &size);  // ask required size
     std::string tmp(size, '\0');
     if (_NSGetExecutablePath(tmp.data(), &size) != 0)
         OPENFHE_THROW("Can not get the executable path for macOS.");
@@ -78,7 +79,7 @@ std::filesystem::path getProgramPath() {
 }
 
 std::string DataAndLocation::getDataDir() {
-    const std::filesystem::path exe = getProgramPath();
+    const std::filesystem::path exe    = getProgramPath();
     const std::filesystem::path exeDir = exe.empty() ? std::filesystem::current_path() : exe.parent_path();
 
     // One level up (e.g., .../build/unittest -> .../build)


### PR DESCRIPTION
- sets omp thread count to half the number of available cores for unit tests
- adds text about limiting the number of omp threads in contentious execution environments to Best_Performance.md
- CryptoContextFactory::ReleaseAllContexts() now calls CryptoContext::ClearStaticMapsAndVectors() before releasing contexts
- limited code cleanup