### PR TITLE
Replace log(x)/log(2) with log2(x)

### DIFF
--- a/docs/sphinx_rsts/modules/core/math/sampling.rst
+++ b/docs/sphinx_rsts/modules/core/math/sampling.rst
@@ -200,7 +200,7 @@ Generic Sampler
    }
 
    /*Create the sampler object*/
-   int base = std::log(CENTER_COUNT)/std::log(2);
+   int base = std::log2(CENTER_COUNT);
    DiscreteGaussianGeneratorGeneric dggGeneric(peikert_samplers,stdBase,base,SMOOTHING_PARAMETER);
 
    /*Generate Integer */

--- a/src/core/examples/sampling.cpp
+++ b/src/core/examples/sampling.cpp
@@ -95,7 +95,7 @@ int main() {
     std::cout << "Sampling " << std::to_string(count) << " integers (Karney): " << (finish - start) / CENTER_COUNT
               << " ms\n";
 
-    int base = std::log(CENTER_COUNT) / std::log(2);
+    int base = std::log2(CENTER_COUNT);
     // Initialization for the generic sampler, takes the parameters array of base
     // samplers, standard deviation of the base sampler base=(which is log2(number
     // of cosets or centers)) and smoothing parameter Make sure that stdBase>= 4 *

--- a/src/core/include/math/SAMPLING_README.md
+++ b/src/core/include/math/SAMPLING_README.md
@@ -109,7 +109,7 @@ for(int i=0;i<CENTER_COUNT;i++){
 }
 
 /*Create the sampler object*/
-int base = std::log(CENTER_COUNT)/std::log(2);
+int base = std::log2(CENTER_COUNT);
 DiscreteGaussianGeneratorGeneric dggGeneric(peikert_samplers,stdBase,base,SMOOTHING_PARAMETER);
 
 /*Generate Integer */

--- a/src/core/unittest/UnitTestTrapdoor.cpp
+++ b/src/core/unittest/UnitTestTrapdoor.cpp
@@ -73,7 +73,7 @@ TEST(UTTrapdoor, sizes) {
 
     double val = modulus.ConvertToDouble();  // TODO get the next few lines
                                              // working in a single instance.
-    double logTwo = std::log(val - 1.0) / std::log(2) + 1.0;
+    double logTwo = std::log2(val - 1.0) + 1.0;
     usint k       = (usint)std::floor(logTwo);  // = this->m_cryptoParameters.GetModulus();
 
     auto fastParams = std::make_shared<ILParams>(m, modulus, rootOfUnity);
@@ -98,7 +98,7 @@ TEST(UTTrapdoor, TrapDoorPairTest) {
 
     double val = modulus.ConvertToDouble();  // TODO get the next few lines
                                              // working in a single instance.
-    double logTwo = std::log(val - 1.0) / std::log(2) + 1.0;
+    double logTwo = std::log2(val - 1.0) + 1.0;
     usint k       = (usint)std::floor(logTwo);  // = this->m_cryptoParameters.GetModulus();
 
     auto params     = std::make_shared<ILParams>(m, modulus, rootOfUnity);
@@ -172,7 +172,7 @@ TEST(UTTrapdoor, GadgetTest) {
 
     double val = modulus.ConvertToDouble();  // TODO get the next few lines
                                              // working in a single instance.
-    double logTwo = std::log(val - 1.0) / std::log(2) + 1.0;
+    double logTwo = std::log2(val - 1.0) + 1.0;
     usint k       = (usint)std::floor(logTwo);  // = this->m_cryptoParameters.GetModulus();
 
     auto params     = std::make_shared<ILParams>(m, modulus, rootOfUnity);
@@ -192,7 +192,7 @@ TEST(UTTrapdoor, TrapDoorMultTest) {
 
     double val = modulus.ConvertToDouble();  // TODO get the next few lines
                                              // working in a single instance.
-    double logTwo = std::log(val - 1.0) / std::log(2) + 1.0;
+    double logTwo = std::log2(val - 1.0) + 1.0;
     usint k       = (usint)std::floor(logTwo);  // = this->m_cryptoParameters.GetModulus();
 
     auto params     = std::make_shared<ILParams>(m, modulus, rootOfUnity);
@@ -282,7 +282,7 @@ TEST(UTTrapdoor, TrapDoorGaussGqSampTest) {
     double val = modulus.ConvertToDouble();  // TODO get the next few lines
                                              // working in a single instance.
     // YSP check logTwo computation
-    double logTwo = std::log(val - 1.0) / std::log(2) + 1.0;
+    double logTwo = std::log2(val - 1.0) + 1.0;
     usint k       = (usint)std::floor(logTwo);
 
     Matrix<int64_t> zHatBBI([]() { return 0; }, k, m / 2);
@@ -387,7 +387,7 @@ TEST(UTTrapdoor, TrapDoorGaussGqSampTestBase1024) {
     usint nBits = std::floor(std::log2(modulus.ConvertToDouble() - 1.0) + 1.0);
     usint k     = std::ceil(nBits / std::log2(base));
 
-    // double logTwo = log(val - 1.0) / log(2) + 1.0;
+    // double logTwo = log2(val - 1.0) + 1.0;
     // usint k = (usint)floor(logTwo);
 
     Matrix<int64_t> zHatBBI([]() { return 0; }, k, m / 2);
@@ -451,7 +451,7 @@ TEST(UTTrapdoor, TrapDoorGaussSampTest) {
 
     double val = modulus.ConvertToDouble();  // TODO get the next few lines
                                              // working in a single instance.
-    double logTwo = std::log(val - 1.0) / std::log(2) + 1.0;
+    double logTwo = std::log2(val - 1.0) + 1.0;
     usint k       = (usint)std::floor(logTwo);  // = this->m_cryptoParameters.GetModulus();
 
     OPENFHE_DEBUG("k = " << k);
@@ -638,7 +638,7 @@ TEST(UTTrapdoor, TrapDoorPerturbationSamplingTest) {
 
     double val = modulus.ConvertToDouble();  // TODO get the next few lines
                                              // working in a single instance.
-    double logTwo = std::log(val - 1.0) / std::log(2) + 1.0;
+    double logTwo = std::log2(val - 1.0) + 1.0;
     usint k       = (usint)std::floor(logTwo);  // = this->m_cryptoParameters.GetModulus();
 
     // smoothing parameter

--- a/src/pke/examples/polynomial-evaluation-high-precision-composite-scaling.cpp
+++ b/src/pke/examples/polynomial-evaluation-high-precision-composite-scaling.cpp
@@ -47,9 +47,9 @@ void printPrimeModuliChain(const DCRTPoly& poly) {
     double total_bit_len = 0.0;
     for (int i = 0; i < num_primes; i++) {
         auto qi = poly.GetParams()->GetParams()[i]->GetModulus();
-        std::cout << "q_" << i << ": " << qi << ",  log q_" << i << ": " << std::log(qi.ConvertToDouble()) / std::log(2)
+        std::cout << "q_" << i << ": " << qi << ",  log q_" << i << ": " << std::log2(qi.ConvertToDouble())
                   << std::endl;
-        total_bit_len += std::log(qi.ConvertToDouble()) / std::log(2);
+        total_bit_len += std::log2(qi.ConvertToDouble());
     }
     std::cout << "Total bit length: " << total_bit_len << std::endl;
 }

--- a/src/pke/lib/scheme/bfvrns/bfvrns-leveledshe.cpp
+++ b/src/pke/lib/scheme/bfvrns/bfvrns-leveledshe.cpp
@@ -144,7 +144,7 @@ uint32_t FindLevelsToDrop(uint32_t multiplicativeDepth, std::shared_ptr<CryptoPa
 #endif
         else {
             double numDigitsPerTower = (relinWindow == 0) ? 1 : ((dcrtBits / relinWindow) + 1);
-            return delta(n) * numDigitsPerTower * (std::floor(logqPrev / (std::log(2) * dcrtBits)) + 1) * w * Berr / 2.0;
+            return delta(n) * numDigitsPerTower * (std::floor(logqPrev / dcrtBits) + 1) * w * Berr / 2.0;
         }
     };
 
@@ -161,23 +161,23 @@ uint32_t FindLevelsToDrop(uint32_t multiplicativeDepth, std::shared_ptr<CryptoPa
     // main correctness constraint
     auto logqBFV = [&](uint32_t n, double logqPrev) -> double {
         if (multiplicativeDepth > 0) {
-            return std::log(4 * p) + (multiplicativeDepth - 1) * std::log(C1(n)) +
-                   std::log(C1(n) * Vnorm(n) + multiplicativeDepth * C2(n, logqPrev));
+            return std::log2(4 * p) + (multiplicativeDepth - 1) * std::log2(C1(n)) +
+                   std::log2(C1(n) * Vnorm(n) + multiplicativeDepth * C2(n, logqPrev));
         }
-        return std::log(p * (4 * (Vnorm(n))));
+        return std::log2(p * (4 * (Vnorm(n))));
     };
 
     // initial values
-    double logqPrev = 6. * std::log(10);
+    double logqPrev = 6. * std::log2(10);
     double logq     = logqBFV(n, logqPrev);
 
-    while (std::fabs(logq - logqPrev) > std::log(1.001)) {
+    while (std::fabs(logq - logqPrev) > std::log2(1.001)) {
         logqPrev = logq;
         logq     = logqBFV(n, logqPrev);
     }
 
     // get an estimate of the error q / (4t)
-    double loge = logq / std::log(2) - 2 - std::log2(p);
+    double loge = logq - 2 - std::log2(p);
 
     double logExtra = keySwitch ? std::log2(noiseKS(n, logq, w)) : std::log2(deltaMS(n));
 


### PR DESCRIPTION
- Replace log(x)/log(2) with log2(x) in code, docs, and tests (style cleanup)
- Fix bfvrns-leveledshe.cpp to use std::log2 — the noise estimation was mixing std::log() and std::log2()