### PR TITLE
Fix BGV ring dimension underestimation with NOISE_FLOODING_MULTIPARTY + HYBRID on 128-bit builds

### DIFF
--- a/src/pke/examples/threshold-fhe.cpp
+++ b/src/pke/examples/threshold-fhe.cpp
@@ -62,6 +62,9 @@ int main(int argc, char* argv[]) {
 void RunBGVrnsAdditive() {
     CCParams<CryptoContextBGVRNS> parameters;
     parameters.SetPlaintextModulus(65537);
+    parameters.SetMultiplicativeDepth(0);
+    parameters.SetKeySwitchTechnique(BV);
+    parameters.SetDigitSize(10);
 
     // NOISE_FLOODING_MULTIPARTY adds extra noise to the ciphertext before decrypting
     // and is most secure mode of threshold FHE for BFV and BGV.

--- a/src/pke/include/schemerns/rns-cryptoparameters.h
+++ b/src/pke/include/schemerns/rns-cryptoparameters.h
@@ -195,13 +195,15 @@ public:
    * @param numPrimes number of moduli witout extraModulus
    * @param auxBits size of auxiliar moduli used for hybrid key switching
    * @param scalTech scaling technique
+   * @param isNoiseFloodingMultiparty whether threshold FHE uses noise flooding multiparty mode (BGV only)
    * @param addOne should an extra bit be added (for CKKS and BGV)
    *
    * @return log2 of the modulus and number of RNS limbs.
    */
     static std::pair<double, uint32_t> EstimateLogP(uint32_t numPartQ, double firstModulusSize, double dcrtBits,
                                                     double extraModulusSize, uint32_t numPrimes, uint32_t auxBits,
-                                                    ScalingTechnique scalTech, bool addOne = false);
+                                                    ScalingTechnique scalTech, bool isNoiseFloodingMultiparty = false,
+                                                    bool addOne = false);
 
     /*
    * Estimates the extra modulus bitsize needed for threshold FHE noise flooding (only for BGV and BFV)

--- a/src/pke/include/schemerns/rns-cryptoparameters.h
+++ b/src/pke/include/schemerns/rns-cryptoparameters.h
@@ -195,15 +195,15 @@ public:
    * @param numPrimes number of moduli witout extraModulus
    * @param auxBits size of auxiliar moduli used for hybrid key switching
    * @param scalTech scaling technique
-   * @param isNoiseFloodingMultiparty whether threshold FHE uses noise flooding multiparty mode (BGV only)
    * @param addOne should an extra bit be added (for CKKS and BGV)
+   * @param isNoiseFloodingMultiparty whether threshold FHE uses noise flooding multiparty mode (BGV and BFV)
    *
    * @return log2 of the modulus and number of RNS limbs.
    */
     static std::pair<double, uint32_t> EstimateLogP(uint32_t numPartQ, double firstModulusSize, double dcrtBits,
                                                     double extraModulusSize, uint32_t numPrimes, uint32_t auxBits,
-                                                    ScalingTechnique scalTech, bool isNoiseFloodingMultiparty = false,
-                                                    bool addOne = false);
+                                                    ScalingTechnique scalTech, bool addOne = false,
+                                                    bool isNoiseFloodingMultiparty = false);
 
     /*
    * Estimates the extra modulus bitsize needed for threshold FHE noise flooding (only for BGV and BFV)

--- a/src/pke/lib/scheme/bgvrns/bgvrns-parametergeneration.cpp
+++ b/src/pke/lib/scheme/bgvrns/bgvrns-parametergeneration.cpp
@@ -490,11 +490,21 @@ bool ParameterGenerationBGVRNS::ParamsGenBGVRNSInternal(std::shared_ptr<CryptoPa
             if (multipartyMode == NOISE_FLOODING_MULTIPARTY)
                 newQBound += cryptoParamsBGVRNS->EstimateMultipartyFloodingLogQ();
             if (ksTech == HYBRID) {
+                // When NOISE_FLOODING_MULTIPARTY is used, PrecomputeCRTTables adds NUM_MODULI_MULTIPARTY
+                // flooding primes (of MULTIPARTY_MOD_SIZE bits each) to Q after this loop. Include them
+                // in the P estimation so the ring dimension is not underestimated, particularly in
+                // 128-bit builds where P primes are 121 bits and the larger QP can exceed the security limit.
+                uint32_t numPrimesEst = (scalTech == FLEXIBLEAUTOEXT) ? moduliQ.size() - 1 : moduliQ.size();
+                double dcrtBitsEst    = (moduliQ.size() > 1) ? std::log2(moduliQ[1].ConvertToDouble()) : 0;
+                if (multipartyMode == NOISE_FLOODING_MULTIPARTY) {
+                    numPrimesEst += NoiseFlooding::NUM_MODULI_MULTIPARTY;
+                    dcrtBitsEst = std::max(dcrtBitsEst, static_cast<double>(NoiseFlooding::MULTIPARTY_MOD_SIZE));
+                }
                 auto hybridKSInfo = CryptoParametersRNS::EstimateLogP(
                     numPartQ, std::log2(moduliQ[0].ConvertToDouble()),
-                    (moduliQ.size() > 1) ? std::log2(moduliQ[1].ConvertToDouble()) : 0,
+                    dcrtBitsEst,
                     (scalTech == FLEXIBLEAUTOEXT) ? std::log2(moduliQ[moduliQ.size() - 1].ConvertToDouble()) : 0,
-                    (scalTech == FLEXIBLEAUTOEXT) ? moduliQ.size() - 1 : moduliQ.size(), auxBits, scalTech, false);
+                    numPrimesEst, auxBits, scalTech, false);
                 newQBound += std::get<0>(hybridKSInfo);
             }
         } while (qBound < newQBound);

--- a/src/pke/lib/scheme/bgvrns/bgvrns-parametergeneration.cpp
+++ b/src/pke/lib/scheme/bgvrns/bgvrns-parametergeneration.cpp
@@ -461,8 +461,13 @@ bool ParameterGenerationBGVRNS::ParamsGenBGVRNSInternal(std::shared_ptr<CryptoPa
         if ((qBound != auxBits) && (scalTech != FIXEDMANUAL))
             qBound++;
 
-        auto hybridKSInfo = CryptoParametersRNS::EstimateLogP(numPartQ, firstModSize, dcrtBits, extraModSize, numPrimes,
-                                                              auxBits, scalTech, true);
+        uint32_t numPrimesEst          = numPrimes;
+        bool isNoiseFloodingMultiparty = (multipartyMode == NOISE_FLOODING_MULTIPARTY);
+        if (isNoiseFloodingMultiparty)
+            numPrimesEst += NoiseFlooding::NUM_MODULI_MULTIPARTY;
+        auto hybridKSInfo =
+            CryptoParametersRNS::EstimateLogP(numPartQ, firstModSize, dcrtBits, extraModSize, numPrimesEst, auxBits,
+                                              scalTech, isNoiseFloodingMultiparty, true);
         qBound += std::get<0>(hybridKSInfo);
         auxTowers = std::get<1>(hybridKSInfo);
     }
@@ -490,21 +495,16 @@ bool ParameterGenerationBGVRNS::ParamsGenBGVRNSInternal(std::shared_ptr<CryptoPa
             if (multipartyMode == NOISE_FLOODING_MULTIPARTY)
                 newQBound += cryptoParamsBGVRNS->EstimateMultipartyFloodingLogQ();
             if (ksTech == HYBRID) {
-                // When NOISE_FLOODING_MULTIPARTY is used, PrecomputeCRTTables adds NUM_MODULI_MULTIPARTY
-                // flooding primes (of MULTIPARTY_MOD_SIZE bits each) to Q after this loop. Include them
-                // in the P estimation so the ring dimension is not underestimated, particularly in
-                // 128-bit builds where P primes are 121 bits and the larger QP can exceed the security limit.
-                uint32_t numPrimesEst = (scalTech == FLEXIBLEAUTOEXT) ? moduliQ.size() - 1 : moduliQ.size();
                 double dcrtBitsEst    = (moduliQ.size() > 1) ? std::log2(moduliQ[1].ConvertToDouble()) : 0;
-                if (multipartyMode == NOISE_FLOODING_MULTIPARTY) {
+                uint32_t numPrimesEst = (scalTech == FLEXIBLEAUTOEXT) ? moduliQ.size() - 1 : moduliQ.size();
+                bool isNoiseFloodingMultiparty = (multipartyMode == NOISE_FLOODING_MULTIPARTY);
+                if (isNoiseFloodingMultiparty)
                     numPrimesEst += NoiseFlooding::NUM_MODULI_MULTIPARTY;
-                    dcrtBitsEst = std::max(dcrtBitsEst, static_cast<double>(NoiseFlooding::MULTIPARTY_MOD_SIZE));
-                }
                 auto hybridKSInfo = CryptoParametersRNS::EstimateLogP(
                     numPartQ, std::log2(moduliQ[0].ConvertToDouble()),
                     dcrtBitsEst,
                     (scalTech == FLEXIBLEAUTOEXT) ? std::log2(moduliQ[moduliQ.size() - 1].ConvertToDouble()) : 0,
-                    numPrimesEst, auxBits, scalTech, false);
+                    numPrimesEst, auxBits, scalTech, isNoiseFloodingMultiparty, false);
                 newQBound += std::get<0>(hybridKSInfo);
             }
         } while (qBound < newQBound);

--- a/src/pke/lib/scheme/bgvrns/bgvrns-parametergeneration.cpp
+++ b/src/pke/lib/scheme/bgvrns/bgvrns-parametergeneration.cpp
@@ -467,7 +467,7 @@ bool ParameterGenerationBGVRNS::ParamsGenBGVRNSInternal(std::shared_ptr<CryptoPa
             numPrimesEst += NoiseFlooding::NUM_MODULI_MULTIPARTY;
         auto hybridKSInfo =
             CryptoParametersRNS::EstimateLogP(numPartQ, firstModSize, dcrtBits, extraModSize, numPrimesEst, auxBits,
-                                              scalTech, isNoiseFloodingMultiparty, true);
+                                              scalTech, true, isNoiseFloodingMultiparty);
         qBound += std::get<0>(hybridKSInfo);
         auxTowers = std::get<1>(hybridKSInfo);
     }
@@ -504,7 +504,7 @@ bool ParameterGenerationBGVRNS::ParamsGenBGVRNSInternal(std::shared_ptr<CryptoPa
                     numPartQ, std::log2(moduliQ[0].ConvertToDouble()),
                     dcrtBitsEst,
                     (scalTech == FLEXIBLEAUTOEXT) ? std::log2(moduliQ[moduliQ.size() - 1].ConvertToDouble()) : 0,
-                    numPrimesEst, auxBits, scalTech, isNoiseFloodingMultiparty, false);
+                    numPrimesEst, auxBits, scalTech, false, isNoiseFloodingMultiparty);
                 newQBound += std::get<0>(hybridKSInfo);
             }
         } while (qBound < newQBound);

--- a/src/pke/lib/scheme/bgvrns/bgvrns-parametergeneration.cpp
+++ b/src/pke/lib/scheme/bgvrns/bgvrns-parametergeneration.cpp
@@ -458,8 +458,11 @@ bool ParameterGenerationBGVRNS::ParamsGenBGVRNSInternal(std::shared_ptr<CryptoPa
         // we add an extra bit to account for the special logic of selecting the RNS moduli in BGV
         // ignore the case when there is only one max size modulus
         // no extra bit needs to be added for FIXEDMANUAL
-        if ((qBound != auxBits) && (scalTech != FIXEDMANUAL))
+        bool addOne = false;
+        if ((qBound != auxBits) && (scalTech != FIXEDMANUAL)) {
             qBound++;
+            addOne = true;
+        }
 
         uint32_t numPrimesEst          = numPrimes;
         bool isNoiseFloodingMultiparty = (multipartyMode == NOISE_FLOODING_MULTIPARTY);
@@ -467,7 +470,7 @@ bool ParameterGenerationBGVRNS::ParamsGenBGVRNSInternal(std::shared_ptr<CryptoPa
             numPrimesEst += NoiseFlooding::NUM_MODULI_MULTIPARTY;
         auto hybridKSInfo =
             CryptoParametersRNS::EstimateLogP(numPartQ, firstModSize, dcrtBits, extraModSize, numPrimesEst, auxBits,
-                                              scalTech, true, isNoiseFloodingMultiparty);
+                                              scalTech, addOne, isNoiseFloodingMultiparty);
         qBound += std::get<0>(hybridKSInfo);
         auxTowers = std::get<1>(hybridKSInfo);
     }

--- a/src/pke/lib/scheme/ckksrns/ckksrns-parametergeneration.cpp
+++ b/src/pke/lib/scheme/ckksrns/ckksrns-parametergeneration.cpp
@@ -133,8 +133,7 @@ bool ParameterGenerationCKKSRNS::ParamsGenCKKSRNSInternal(std::shared_ptr<Crypto
         // Estimate ciphertext modulus Q*P bound (in case of HYBRID P*Q)
         if (ksTech == HYBRID)
             qBound += std::get<0>(CryptoParametersRNS::EstimateLogP(numPartQ, firstModSize, scalingModSize,
-                                                                    extraModSize, numPrimes, auxBits, scalTech,
-                                                                    false, true));
+                                                                    extraModSize, numPrimes, auxBits, scalTech, true));
 
         uint32_t he_std_n = StdLatticeParm::FindRingDim(distType, stdLevel, qBound);
 

--- a/src/pke/lib/scheme/ckksrns/ckksrns-parametergeneration.cpp
+++ b/src/pke/lib/scheme/ckksrns/ckksrns-parametergeneration.cpp
@@ -133,7 +133,8 @@ bool ParameterGenerationCKKSRNS::ParamsGenCKKSRNSInternal(std::shared_ptr<Crypto
         // Estimate ciphertext modulus Q*P bound (in case of HYBRID P*Q)
         if (ksTech == HYBRID)
             qBound += std::get<0>(CryptoParametersRNS::EstimateLogP(numPartQ, firstModSize, scalingModSize,
-                                                                    extraModSize, numPrimes, auxBits, scalTech, true));
+                                                                    extraModSize, numPrimes, auxBits, scalTech,
+                                                                    false, true));
 
         uint32_t he_std_n = StdLatticeParm::FindRingDim(distType, stdLevel, qBound);
 

--- a/src/pke/lib/schemerns/rns-cryptoparameters.cpp
+++ b/src/pke/lib/schemerns/rns-cryptoparameters.cpp
@@ -40,6 +40,10 @@
 #include <string>
 
 namespace lbcrypto {
+namespace {
+    // global used to validate the estimated sizeP value
+    uint32_t sizeP_estimate_global{};
+}
 
 void CryptoParametersRNS::PrecomputeCRTTables(KeySwitchTechnique ksTech, ScalingTechnique scalTech,
                                               EncryptionTechnique encTech, MultiplicationTechnique multTech,
@@ -133,6 +137,16 @@ void CryptoParametersRNS::PrecomputeCRTTables(KeySwitchTechnique ksTech, Scaling
         }
         // Select number of primes in auxiliary CRT basis
         uint32_t sizeP = static_cast<uint32_t>(std::ceil(static_cast<double>(maxBits) / auxBits));
+        // validate the estimated sizeP value
+        if(sizeP_estimate_global > 0) {
+            if(sizeP_estimate_global != sizeP) {
+                auto str = "EstimateLogP() failure: expected sizeP [" + std::to_string(sizeP_estimate_global) +
+                        "], but got sizeP [" + std::to_string(sizeP) + "]";
+                OPENFHE_THROW(str);
+            }
+            // reset sizeP_estimate_global before the next use
+            sizeP_estimate_global = 0;
+        }
 
         uint64_t primeStep = FindAuxPrimeStep();
 
@@ -394,7 +408,7 @@ std::pair<double, uint32_t> CryptoParametersRNS::EstimateLogP(uint32_t numPartQ,
                                                               double dcrtBits, double extraModulusSize,
                                                               uint32_t numPrimes, uint32_t auxBits,
                                                               ScalingTechnique scalTech,
-                                                              bool isNoiseFloodingMultiparty, bool addOne) {
+                                                              bool addOne, bool isNoiseFloodingMultiparty) {
     // numPartQ can not be zero as there is a division by numPartQ
     if (numPartQ == 0)
         OPENFHE_THROW("numPartQ is zero");
@@ -421,7 +435,7 @@ std::pair<double, uint32_t> CryptoParametersRNS::EstimateLogP(uint32_t numPartQ,
     if (extraModulusSize > 0)
         qi[sizeQ - 1] = extraModulusSize;
     if (isNoiseFloodingMultiparty) {
-        for (size_t i = 0; i < std::min<size_t>(NoiseFlooding::NUM_MODULI_MULTIPARTY, sizeQ); ++i) {
+        for (size_t i = 1; i < (NoiseFlooding::NUM_MODULI_MULTIPARTY+1); ++i) {
             qi[i] = NoiseFlooding::MULTIPARTY_MOD_SIZE;
         }
     }
@@ -445,7 +459,8 @@ std::pair<double, uint32_t> CryptoParametersRNS::EstimateLogP(uint32_t numPartQ,
         maxBits++;
 
     // Select number of primes in auxiliary CRT basis
-    auto sizeP = static_cast<uint32_t>(std::ceil(static_cast<double>(maxBits) / auxBits));
+    uint32_t sizeP = static_cast<uint32_t>(std::ceil(static_cast<double>(maxBits) / auxBits));
+    sizeP_estimate_global = sizeP;
 
     return std::make_pair(sizeP * auxBits, sizeP);
 }

--- a/src/pke/lib/schemerns/rns-cryptoparameters.cpp
+++ b/src/pke/lib/schemerns/rns-cryptoparameters.cpp
@@ -393,7 +393,8 @@ uint64_t CryptoParametersRNS::FindAuxPrimeStep() const {
 std::pair<double, uint32_t> CryptoParametersRNS::EstimateLogP(uint32_t numPartQ, double firstModulusSize,
                                                               double dcrtBits, double extraModulusSize,
                                                               uint32_t numPrimes, uint32_t auxBits,
-                                                              ScalingTechnique scalTech, bool addOne) {
+                                                              ScalingTechnique scalTech,
+                                                              bool isNoiseFloodingMultiparty, bool addOne) {
     // numPartQ can not be zero as there is a division by numPartQ
     if (numPartQ == 0)
         OPENFHE_THROW("numPartQ is zero");
@@ -419,6 +420,11 @@ std::pair<double, uint32_t> CryptoParametersRNS::EstimateLogP(uint32_t numPartQ,
     qi[0] = firstModulusSize;
     if (extraModulusSize > 0)
         qi[sizeQ - 1] = extraModulusSize;
+    if (isNoiseFloodingMultiparty) {
+        for (size_t i = 0; i < std::min<size_t>(NoiseFlooding::NUM_MODULI_MULTIPARTY, sizeQ); ++i) {
+            qi[i] = NoiseFlooding::MULTIPARTY_MOD_SIZE;
+        }
+    }
 
     // Compute partitions of Q into numPartQ digits
     uint32_t maxBits = 0;


### PR DESCRIPTION
**BUG**
We estimate P from estimated Q before the flooding primes are added. After that, the actual value of P is calculated from the actual Q in PrecomputeCRTTables(). In some 128-bit cases this made the real QP bigger than expected and failed generating a cryptocontext.

**FIXES**
* Makes the P estimate include the flooding primes (this bug affected BGV and BFV)
* Adds a check to compare estimated vs actual sizeP in PrecomputeCRTTables() and triggers an exception if there is a mismatch
* Fixes another bug (affecting FIXEDMANUAL for BGV), which was detected by the new checking mechanism. An extra bit was added to an estimate of Q for FIXEDMANUAL, which caused a mismatch in the size limbs in P.


