### PR TITLE
Performance: cache paramsQl for HYBRID KeySwitchDown

### DIFF
--- a/src/pke/include/schemerns/rns-cryptoparameters.h
+++ b/src/pke/include/schemerns/rns-cryptoparameters.h
@@ -391,6 +391,18 @@ public:
     }
 
     /**
+   * Gets cached params for the first sizeQl towers of Q, used in KeySwitchDown.
+   * Only populated when key switching technique is HYBRID.
+   * @param sizeQl number of Q towers (1 to GetElementParams()->GetParams().size()).
+   * @return shared_ptr to ILDCRTParams for the first sizeQl moduli, or nullptr if not cached.
+   */
+    const std::shared_ptr<ILDCRTParams<BigInteger>> GetParamsQlHybrid(uint32_t sizeQl) const {
+        if (m_paramsQlHybrid.empty() || sizeQl == 0 || sizeQl > m_paramsQlHybrid.size())
+            return nullptr;
+        return m_paramsQlHybrid[sizeQl - 1];
+    }
+
+    /**
    * Method that returns the number of towers within every digit.
    * This is the alpha parameter from the paper (see documentation
    * for KeySwitchHHybrid).
@@ -1445,6 +1457,10 @@ protected:
     // Params for Extended CRT basis {QP} = {q_1...q_l,p_1,...,p_k}
     // used in GHS key switching
     std::shared_ptr<ILDCRTParams<BigInteger>> m_paramsQP;
+
+    // Cached params for Q_l (first sizeQl towers of Q) used in KeySwitchDown.
+    // m_paramsQlHybrid[l] = params for first (l+1) Q towers; index by sizeQl-1 when looking up.
+    std::vector<std::shared_ptr<ILDCRTParams<BigInteger>>> m_paramsQlHybrid;
 
     // Stores the partition size {PartQ} = {Q_1,...,Q_l}
     // where each Q_i is the product of q_j

--- a/src/pke/include/schemerns/rns-cryptoparameters.h
+++ b/src/pke/include/schemerns/rns-cryptoparameters.h
@@ -391,16 +391,14 @@ public:
     }
 
     /**
-   * Gets cached params for the first sizeQl towers of Q, used in KeySwitchDown.
-   * Only populated when key switching technique is HYBRID.
-   * @param sizeQl number of Q towers (1 to GetElementParams()->GetParams().size()).
-   * @return shared_ptr to ILDCRTParams for the first sizeQl moduli, or nullptr if not cached.
+   * Gets params for the first sizeQl towers of Q, used in HYBRID KeySwitchDown.
+   * Returns a cached entry when available; otherwise builds params from the Q towers in paramsQlP.
+   * @param paramsQlP params for the extended Q_lP basis used as the fallback source.
+   * @param sizeQl number of Q towers to include (1 to GetElementParams()->GetParams().size()).
+   * @return shared_ptr to ILDCRTParams for the first sizeQl Q moduli.
    */
-    const std::shared_ptr<ILDCRTParams<BigInteger>> GetParamsQlHybrid(uint32_t sizeQl) const {
-        if (m_paramsQlHybrid.empty() || sizeQl == 0 || sizeQl > m_paramsQlHybrid.size())
-            return nullptr;
-        return m_paramsQlHybrid[sizeQl - 1];
-    }
+    const std::shared_ptr<ILDCRTParams<BigInteger>> GetParamsQlHybrid(
+        const std::shared_ptr<DCRTPoly::Params>& paramsQlP, uint32_t sizeQl) const;
 
     /**
    * Method that returns the number of towers within every digit.

--- a/src/pke/include/schemerns/rns-cryptoparameters.h
+++ b/src/pke/include/schemerns/rns-cryptoparameters.h
@@ -396,10 +396,7 @@ public:
    * @return shared_ptr to ILDCRTParams for the first sizeQl Q moduli.
    */
     const std::shared_ptr<ILDCRTParams<BigInteger>> GetParamsQlHybrid(uint32_t sizeQl) const {
-        if (sizeQl != 0 && sizeQl <= m_paramsQlHybrid.size())
-            return m_paramsQlHybrid[sizeQl - 1];
-
-        OPENFHE_THROW("Index out of bounds.");
+        return m_paramsQlHybrid.at(sizeQl - 1);
     }
 
     /**

--- a/src/pke/include/schemerns/rns-cryptoparameters.h
+++ b/src/pke/include/schemerns/rns-cryptoparameters.h
@@ -391,14 +391,16 @@ public:
     }
 
     /**
-   * Gets params for the first sizeQl towers of Q, used in HYBRID KeySwitchDown.
-   * Returns a cached entry when available; otherwise builds params from the Q towers in paramsQlP.
-   * @param paramsQlP params for the extended Q_lP basis used as the fallback source.
+   * Gets params for the first sizeQl towers of Q, used in HYBRID KeySwitchDown and returns a cached entry.
    * @param sizeQl number of Q towers to include (1 to GetElementParams()->GetParams().size()).
    * @return shared_ptr to ILDCRTParams for the first sizeQl Q moduli.
    */
-    const std::shared_ptr<ILDCRTParams<BigInteger>> GetParamsQlHybrid(
-        const std::shared_ptr<DCRTPoly::Params>& paramsQlP, uint32_t sizeQl) const;
+    const std::shared_ptr<ILDCRTParams<BigInteger>> GetParamsQlHybrid(uint32_t sizeQl) const {
+        if (sizeQl != 0 && sizeQl <= m_paramsQlHybrid.size())
+            return m_paramsQlHybrid[sizeQl - 1];
+
+        OPENFHE_THROW("Index out of bounds.");
+    }
 
     /**
    * Method that returns the number of towers within every digit.

--- a/src/pke/lib/keyswitch/keyswitch-hybrid.cpp
+++ b/src/pke/lib/keyswitch/keyswitch-hybrid.cpp
@@ -45,19 +45,18 @@ namespace lbcrypto {
 
 namespace {
 
-// Builds params for the first sizeQl towers of Q from extended params QlP (fallback when cache absent).
-std::shared_ptr<KeySwitchHYBRID::ParmType> MakeParamsQlFromQlP(
-    const std::shared_ptr<KeySwitchHYBRID::ParmType>& paramsQlP, uint32_t sizeQl) {
-    std::vector<NativeInteger> moduliQ(sizeQl);
-    std::vector<NativeInteger> rootsQ(sizeQl);
-    for (uint32_t i = 0; i < sizeQl; ++i) {
-        moduliQ[i] = paramsQlP->GetParams()[i]->GetModulus();
-        rootsQ[i]  = paramsQlP->GetParams()[i]->GetRootOfUnity();
+    std::shared_ptr<DCRTPoly::Params> MakeParamsQlFromQlP(
+        const std::shared_ptr<DCRTPoly::Params>& paramsQlP, uint32_t sizeQl) {
+        std::vector<NativeInteger> moduliQ(sizeQl);
+        std::vector<NativeInteger> rootsQ(sizeQl);
+        for (uint32_t i = 0; i < sizeQl; ++i) {
+            moduliQ[i] = paramsQlP->GetParams()[i]->GetModulus();
+            rootsQ[i]  = paramsQlP->GetParams()[i]->GetRootOfUnity();
+        }
+        return std::make_shared<DCRTPoly::Params>(paramsQlP->GetCyclotomicOrder(), moduliQ, rootsQ);
     }
-    return std::make_shared<KeySwitchHYBRID::ParmType>(paramsQlP->GetCyclotomicOrder(), moduliQ, rootsQ);
-}
-
-}  // namespace
+    
+    }  // namespace
 
 EvalKey<DCRTPoly> KeySwitchHYBRID::KeySwitchGenInternal(const PrivateKey<DCRTPoly> oldKey,
                                                         const PrivateKey<DCRTPoly> newKey) const {

--- a/src/pke/lib/keyswitch/keyswitch-hybrid.cpp
+++ b/src/pke/lib/keyswitch/keyswitch-hybrid.cpp
@@ -245,24 +245,24 @@ Ciphertext<DCRTPoly> KeySwitchHYBRID::KeySwitchDown(ConstCiphertext<DCRTPoly> ci
     const auto paramsQlP = cv[0].GetParams();
 
     const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersCKKSRNS>(ciphertext->GetCryptoParameters());
-    const auto paramsP     = cryptoParams->GetParamsP();
+    const auto paramsP      = cryptoParams->GetParamsP();
 
     const uint32_t sizeQl = paramsQlP->GetParams().size() - paramsP->GetParams().size();
-    std::shared_ptr<ParmType> paramsQl = cryptoParams->GetParamsQlHybrid(sizeQl);
+    const auto paramsQl   = cryptoParams->GetParamsQlHybrid(sizeQl);
 
     const PlaintextModulus t = (cryptoParams->GetNoiseScale() == 1) ? 0 : cryptoParams->GetPlaintextModulus();
 
-    std::vector<DCRTPoly> elements(2);
-    elements[0] = cv[0].ApproxModDown(paramsQl, cryptoParams->GetParamsP(), cryptoParams->GetPInvModq(),
-                                      cryptoParams->GetPInvModqPrecon(), cryptoParams->GetPHatInvModp(),
-                                      cryptoParams->GetPHatInvModpPrecon(), cryptoParams->GetPHatModq(),
-                                      cryptoParams->GetModqBarrettMu(), cryptoParams->GettInvModp(),
-                                      cryptoParams->GettInvModpPrecon(), t, cryptoParams->GettModqPrecon());
-    elements[1] = cv[1].ApproxModDown(paramsQl, cryptoParams->GetParamsP(), cryptoParams->GetPInvModq(),
-                                      cryptoParams->GetPInvModqPrecon(), cryptoParams->GetPHatInvModp(),
-                                      cryptoParams->GetPHatInvModpPrecon(), cryptoParams->GetPHatModq(),
-                                      cryptoParams->GetModqBarrettMu(), cryptoParams->GettInvModp(),
-                                      cryptoParams->GettInvModpPrecon(), t, cryptoParams->GettModqPrecon());
+    std::vector<DCRTPoly> elements;
+    elements.emplace_back(cv[0].ApproxModDown(paramsQl, cryptoParams->GetParamsP(), cryptoParams->GetPInvModq(),
+                                              cryptoParams->GetPInvModqPrecon(), cryptoParams->GetPHatInvModp(),
+                                              cryptoParams->GetPHatInvModpPrecon(), cryptoParams->GetPHatModq(),
+                                              cryptoParams->GetModqBarrettMu(), cryptoParams->GettInvModp(),
+                                              cryptoParams->GettInvModpPrecon(), t, cryptoParams->GettModqPrecon()));
+    elements.emplace_back(cv[1].ApproxModDown(paramsQl, cryptoParams->GetParamsP(), cryptoParams->GetPInvModq(),
+                                              cryptoParams->GetPInvModqPrecon(), cryptoParams->GetPHatInvModp(),
+                                              cryptoParams->GetPHatInvModpPrecon(), cryptoParams->GetPHatModq(),
+                                              cryptoParams->GetModqBarrettMu(), cryptoParams->GettInvModp(),
+                                              cryptoParams->GettInvModpPrecon(), t, cryptoParams->GettModqPrecon()));
 
     auto result = ciphertext->CloneEmpty();
     result->SetElements(std::move(elements));
@@ -277,7 +277,7 @@ DCRTPoly KeySwitchHYBRID::KeySwitchDownFirstElement(ConstCiphertext<DCRTPoly> ci
     const auto paramsP      = cryptoParams->GetParamsP();
 
     const uint32_t sizeQl = paramsQlP->GetParams().size() - paramsP->GetParams().size();
-    std::shared_ptr<ParmType> paramsQl = cryptoParams->GetParamsQlHybrid(sizeQl);
+    const auto paramsQl   = cryptoParams->GetParamsQlHybrid(sizeQl);
 
     const PlaintextModulus t = (cryptoParams->GetNoiseScale() == 1) ? 0 : cryptoParams->GetPlaintextModulus();
 

--- a/src/pke/lib/keyswitch/keyswitch-hybrid.cpp
+++ b/src/pke/lib/keyswitch/keyswitch-hybrid.cpp
@@ -43,21 +43,6 @@
 
 namespace lbcrypto {
 
-namespace {
-
-    std::shared_ptr<DCRTPoly::Params> MakeParamsQlFromQlP(
-        const std::shared_ptr<DCRTPoly::Params>& paramsQlP, uint32_t sizeQl) {
-        std::vector<NativeInteger> moduliQ(sizeQl);
-        std::vector<NativeInteger> rootsQ(sizeQl);
-        for (uint32_t i = 0; i < sizeQl; ++i) {
-            moduliQ[i] = paramsQlP->GetParams()[i]->GetModulus();
-            rootsQ[i]  = paramsQlP->GetParams()[i]->GetRootOfUnity();
-        }
-        return std::make_shared<DCRTPoly::Params>(paramsQlP->GetCyclotomicOrder(), moduliQ, rootsQ);
-    }
-    
-    }  // namespace
-
 EvalKey<DCRTPoly> KeySwitchHYBRID::KeySwitchGenInternal(const PrivateKey<DCRTPoly> oldKey,
                                                         const PrivateKey<DCRTPoly> newKey) const {
     return KeySwitchHYBRID::KeySwitchGenInternal(oldKey, newKey, nullptr);
@@ -263,9 +248,7 @@ Ciphertext<DCRTPoly> KeySwitchHYBRID::KeySwitchDown(ConstCiphertext<DCRTPoly> ci
     const auto paramsP     = cryptoParams->GetParamsP();
 
     const uint32_t sizeQl = paramsQlP->GetParams().size() - paramsP->GetParams().size();
-    std::shared_ptr<ParmType> paramsQl = cryptoParams->GetParamsQlHybrid(sizeQl);
-    if (!paramsQl)
-        paramsQl = MakeParamsQlFromQlP(paramsQlP, sizeQl);
+    std::shared_ptr<ParmType> paramsQl = cryptoParams->GetParamsQlHybrid(paramsQlP, sizeQl);
 
     const PlaintextModulus t = (cryptoParams->GetNoiseScale() == 1) ? 0 : cryptoParams->GetPlaintextModulus();
 
@@ -294,9 +277,7 @@ DCRTPoly KeySwitchHYBRID::KeySwitchDownFirstElement(ConstCiphertext<DCRTPoly> ci
     const auto paramsP      = cryptoParams->GetParamsP();
 
     const uint32_t sizeQl = paramsQlP->GetParams().size() - paramsP->GetParams().size();
-    std::shared_ptr<ParmType> paramsQl = cryptoParams->GetParamsQlHybrid(sizeQl);
-    if (!paramsQl)
-        paramsQl = MakeParamsQlFromQlP(paramsQlP, sizeQl);
+    std::shared_ptr<ParmType> paramsQl = cryptoParams->GetParamsQlHybrid(paramsQlP, sizeQl);
 
     const PlaintextModulus t = (cryptoParams->GetNoiseScale() == 1) ? 0 : cryptoParams->GetPlaintextModulus();
 

--- a/src/pke/lib/keyswitch/keyswitch-hybrid.cpp
+++ b/src/pke/lib/keyswitch/keyswitch-hybrid.cpp
@@ -248,7 +248,7 @@ Ciphertext<DCRTPoly> KeySwitchHYBRID::KeySwitchDown(ConstCiphertext<DCRTPoly> ci
     const auto paramsP     = cryptoParams->GetParamsP();
 
     const uint32_t sizeQl = paramsQlP->GetParams().size() - paramsP->GetParams().size();
-    std::shared_ptr<ParmType> paramsQl = cryptoParams->GetParamsQlHybrid(paramsQlP, sizeQl);
+    std::shared_ptr<ParmType> paramsQl = cryptoParams->GetParamsQlHybrid(sizeQl);
 
     const PlaintextModulus t = (cryptoParams->GetNoiseScale() == 1) ? 0 : cryptoParams->GetPlaintextModulus();
 
@@ -277,7 +277,7 @@ DCRTPoly KeySwitchHYBRID::KeySwitchDownFirstElement(ConstCiphertext<DCRTPoly> ci
     const auto paramsP      = cryptoParams->GetParamsP();
 
     const uint32_t sizeQl = paramsQlP->GetParams().size() - paramsP->GetParams().size();
-    std::shared_ptr<ParmType> paramsQl = cryptoParams->GetParamsQlHybrid(paramsQlP, sizeQl);
+    std::shared_ptr<ParmType> paramsQl = cryptoParams->GetParamsQlHybrid(sizeQl);
 
     const PlaintextModulus t = (cryptoParams->GetNoiseScale() == 1) ? 0 : cryptoParams->GetPlaintextModulus();
 

--- a/src/pke/lib/keyswitch/keyswitch-hybrid.cpp
+++ b/src/pke/lib/keyswitch/keyswitch-hybrid.cpp
@@ -43,6 +43,22 @@
 
 namespace lbcrypto {
 
+namespace {
+
+// Builds params for the first sizeQl towers of Q from extended params QlP (fallback when cache absent).
+std::shared_ptr<KeySwitchHYBRID::ParmType> MakeParamsQlFromQlP(
+    const std::shared_ptr<KeySwitchHYBRID::ParmType>& paramsQlP, uint32_t sizeQl) {
+    std::vector<NativeInteger> moduliQ(sizeQl);
+    std::vector<NativeInteger> rootsQ(sizeQl);
+    for (uint32_t i = 0; i < sizeQl; ++i) {
+        moduliQ[i] = paramsQlP->GetParams()[i]->GetModulus();
+        rootsQ[i]  = paramsQlP->GetParams()[i]->GetRootOfUnity();
+    }
+    return std::make_shared<KeySwitchHYBRID::ParmType>(paramsQlP->GetCyclotomicOrder(), moduliQ, rootsQ);
+}
+
+}  // namespace
+
 EvalKey<DCRTPoly> KeySwitchHYBRID::KeySwitchGenInternal(const PrivateKey<DCRTPoly> oldKey,
                                                         const PrivateKey<DCRTPoly> newKey) const {
     return KeySwitchHYBRID::KeySwitchGenInternal(oldKey, newKey, nullptr);
@@ -245,17 +261,12 @@ Ciphertext<DCRTPoly> KeySwitchHYBRID::KeySwitchDown(ConstCiphertext<DCRTPoly> ci
     const auto paramsQlP = cv[0].GetParams();
 
     const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersCKKSRNS>(ciphertext->GetCryptoParameters());
-    const auto paramsP      = cryptoParams->GetParamsP();
+    const auto paramsP     = cryptoParams->GetParamsP();
 
-    // TODO : (Andrey) precompute paramsQl in cryptoparameters
     const uint32_t sizeQl = paramsQlP->GetParams().size() - paramsP->GetParams().size();
-    std::vector<NativeInteger> moduliQ(sizeQl);
-    std::vector<NativeInteger> rootsQ(sizeQl);
-    for (uint32_t i = 0; i < sizeQl; ++i) {
-        moduliQ[i] = paramsQlP->GetParams()[i]->GetModulus();
-        rootsQ[i]  = paramsQlP->GetParams()[i]->GetRootOfUnity();
-    }
-    const auto paramsQl = std::make_shared<ParmType>(paramsQlP->GetCyclotomicOrder(), moduliQ, rootsQ);
+    std::shared_ptr<ParmType> paramsQl = cryptoParams->GetParamsQlHybrid(sizeQl);
+    if (!paramsQl)
+        paramsQl = MakeParamsQlFromQlP(paramsQlP, sizeQl);
 
     const PlaintextModulus t = (cryptoParams->GetNoiseScale() == 1) ? 0 : cryptoParams->GetPlaintextModulus();
 
@@ -283,15 +294,10 @@ DCRTPoly KeySwitchHYBRID::KeySwitchDownFirstElement(ConstCiphertext<DCRTPoly> ci
     const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersCKKSRNS>(ciphertext->GetCryptoParameters());
     const auto paramsP      = cryptoParams->GetParamsP();
 
-    // TODO : (Andrey) precompute paramsQl in cryptoparameters
     const uint32_t sizeQl = paramsQlP->GetParams().size() - paramsP->GetParams().size();
-    std::vector<NativeInteger> moduliQ(sizeQl);
-    std::vector<NativeInteger> rootsQ(sizeQl);
-    for (uint32_t i = 0; i < sizeQl; ++i) {
-        moduliQ[i] = paramsQlP->GetParams()[i]->GetModulus();
-        rootsQ[i]  = paramsQlP->GetParams()[i]->GetRootOfUnity();
-    }
-    const auto paramsQl = std::make_shared<ParmType>(paramsQlP->GetCyclotomicOrder(), moduliQ, rootsQ);
+    std::shared_ptr<ParmType> paramsQl = cryptoParams->GetParamsQlHybrid(sizeQl);
+    if (!paramsQl)
+        paramsQl = MakeParamsQlFromQlP(paramsQlP, sizeQl);
 
     const PlaintextModulus t = (cryptoParams->GetNoiseScale() == 1) ? 0 : cryptoParams->GetPlaintextModulus();
 

--- a/src/pke/lib/schemerns/rns-cryptoparameters.cpp
+++ b/src/pke/lib/schemerns/rns-cryptoparameters.cpp
@@ -193,6 +193,19 @@ void CryptoParametersRNS::PrecomputeCRTTables(KeySwitchTechnique ksTech, Scaling
 
         m_paramsQP = std::make_shared<ILDCRTParams<BigInteger>>(2 * n, moduliQP, rootsQP);
 
+        // Precompute params for first 1..sizeQ towers of Q for KeySwitchDown (avoids per-call allocation).
+        m_paramsQlHybrid.resize(sizeQ);
+        for (size_t l = 0; l < sizeQ; ++l) {
+            std::vector<NativeInteger> moduliQl(l + 1);
+            std::vector<NativeInteger> rootsQl(l + 1);
+            for (size_t i = 0; i <= l; ++i) {
+                moduliQl[i] = moduliQ[i];
+                rootsQl[i]  = rootsQ[i];
+            }
+            m_paramsQlHybrid[l] =
+                std::make_shared<ILDCRTParams<BigInteger>>(2 * n, std::move(moduliQl), std::move(rootsQl));
+        }
+
         // Pre-compute CRT::FFT values for P
         ChineseRemainderTransformFTT<NativeVector>().PreCompute(rootsP, 2 * n, moduliP);
 

--- a/src/pke/lib/schemerns/rns-cryptoparameters.cpp
+++ b/src/pke/lib/schemerns/rns-cryptoparameters.cpp
@@ -478,4 +478,21 @@ std::pair<double, uint32_t> CryptoParametersRNS::EstimateLogP(uint32_t numPartQ,
     return std::make_pair(sizeP * auxBits, sizeP);
 }
 
+
+const std::shared_ptr<ILDCRTParams<BigInteger>> CryptoParametersRNS::GetParamsQlHybrid(
+    const std::shared_ptr<DCRTPoly::Params>& paramsQlP, uint32_t sizeQl) const {
+    if (m_paramsQlHybrid.empty() || sizeQl == 0 || sizeQl > m_paramsQlHybrid.size()) {
+            std::vector<NativeInteger> moduliQ(sizeQl);
+            std::vector<NativeInteger> rootsQ(sizeQl);
+            for (uint32_t i = 0; i < sizeQl; ++i) {
+                moduliQ[i] = paramsQlP->GetParams()[i]->GetModulus();
+                rootsQ[i]  = paramsQlP->GetParams()[i]->GetRootOfUnity();
+            }
+            return std::make_shared<ILDCRTParams<BigInteger>>(paramsQlP->GetCyclotomicOrder(), moduliQ, rootsQ);
+    }
+
+    return m_paramsQlHybrid[sizeQl - 1];
+}
+
+
 }  // namespace lbcrypto

--- a/src/pke/lib/schemerns/rns-cryptoparameters.cpp
+++ b/src/pke/lib/schemerns/rns-cryptoparameters.cpp
@@ -41,9 +41,9 @@
 
 namespace lbcrypto {
 namespace {
-    // global used to validate the estimated sizeP value
-    uint32_t sizeP_estimate_global{};
-}
+// global used to validate the estimated sizeP value
+uint32_t sizeP_estimate_global{};
+}  // namespace
 
 void CryptoParametersRNS::PrecomputeCRTTables(KeySwitchTechnique ksTech, ScalingTechnique scalTech,
                                               EncryptionTechnique encTech, MultiplicationTechnique multTech,
@@ -138,10 +138,10 @@ void CryptoParametersRNS::PrecomputeCRTTables(KeySwitchTechnique ksTech, Scaling
         // Select number of primes in auxiliary CRT basis
         uint32_t sizeP = static_cast<uint32_t>(std::ceil(static_cast<double>(maxBits) / auxBits));
         // validate the estimated sizeP value
-        if(sizeP_estimate_global > 0) {
-            if(sizeP_estimate_global != sizeP) {
+        if (sizeP_estimate_global > 0) {
+            if (sizeP_estimate_global != sizeP) {
                 auto str = "EstimateLogP() failure: expected sizeP [" + std::to_string(sizeP_estimate_global) +
-                        "], but got sizeP [" + std::to_string(sizeP) + "]";
+                           "], but got sizeP [" + std::to_string(sizeP) + "]";
                 OPENFHE_THROW(str);
             }
             // reset sizeP_estimate_global before the next use
@@ -195,15 +195,13 @@ void CryptoParametersRNS::PrecomputeCRTTables(KeySwitchTechnique ksTech, Scaling
 
         // Precompute params for first 1..sizeQ towers of Q for KeySwitchDown (avoids per-call allocation).
         m_paramsQlHybrid.resize(sizeQ);
-        for (size_t l = 0; l < sizeQ; ++l) {
-            std::vector<NativeInteger> moduliQl(l + 1);
-            std::vector<NativeInteger> rootsQl(l + 1);
-            for (size_t i = 0; i <= l; ++i) {
-                moduliQl[i] = moduliQ[i];
-                rootsQl[i]  = rootsQ[i];
-            }
-            m_paramsQlHybrid[l] =
-                std::make_shared<ILDCRTParams<BigInteger>>(2 * n, std::move(moduliQl), std::move(rootsQl));
+        std::vector<NativeInteger> moduliQl, rootsQl;
+        moduliQl.reserve(sizeQ);
+        rootsQl.reserve(sizeQ);
+        for (size_t i = 0; i < sizeQ; ++i) {
+            moduliQl.push_back(moduliQ[i]);
+            rootsQl.push_back(rootsQ[i]);
+            m_paramsQlHybrid[i] = std::make_shared<ILDCRTParams<BigInteger>>(2 * n, moduliQl, rootsQl);
         }
 
         // Pre-compute CRT::FFT values for P
@@ -420,8 +418,8 @@ uint64_t CryptoParametersRNS::FindAuxPrimeStep() const {
 std::pair<double, uint32_t> CryptoParametersRNS::EstimateLogP(uint32_t numPartQ, double firstModulusSize,
                                                               double dcrtBits, double extraModulusSize,
                                                               uint32_t numPrimes, uint32_t auxBits,
-                                                              ScalingTechnique scalTech,
-                                                              bool addOne, bool isNoiseFloodingMultiparty) {
+                                                              ScalingTechnique scalTech, bool addOne,
+                                                              bool isNoiseFloodingMultiparty) {
     // numPartQ can not be zero as there is a division by numPartQ
     if (numPartQ == 0)
         OPENFHE_THROW("numPartQ is zero");
@@ -448,7 +446,7 @@ std::pair<double, uint32_t> CryptoParametersRNS::EstimateLogP(uint32_t numPartQ,
     if (extraModulusSize > 0)
         qi[sizeQ - 1] = extraModulusSize;
     if (isNoiseFloodingMultiparty) {
-        for (size_t i = 1; i < (NoiseFlooding::NUM_MODULI_MULTIPARTY+1); ++i) {
+        for (size_t i = 1; i < (NoiseFlooding::NUM_MODULI_MULTIPARTY + 1); ++i) {
             qi[i] = NoiseFlooding::MULTIPARTY_MOD_SIZE;
         }
     }
@@ -472,11 +470,10 @@ std::pair<double, uint32_t> CryptoParametersRNS::EstimateLogP(uint32_t numPartQ,
         maxBits++;
 
     // Select number of primes in auxiliary CRT basis
-    uint32_t sizeP = static_cast<uint32_t>(std::ceil(static_cast<double>(maxBits) / auxBits));
+    uint32_t sizeP        = static_cast<uint32_t>(std::ceil(static_cast<double>(maxBits) / auxBits));
     sizeP_estimate_global = sizeP;
 
     return std::make_pair(sizeP * auxBits, sizeP);
 }
-
 
 }  // namespace lbcrypto

--- a/src/pke/lib/schemerns/rns-cryptoparameters.cpp
+++ b/src/pke/lib/schemerns/rns-cryptoparameters.cpp
@@ -479,20 +479,4 @@ std::pair<double, uint32_t> CryptoParametersRNS::EstimateLogP(uint32_t numPartQ,
 }
 
 
-const std::shared_ptr<ILDCRTParams<BigInteger>> CryptoParametersRNS::GetParamsQlHybrid(
-    const std::shared_ptr<DCRTPoly::Params>& paramsQlP, uint32_t sizeQl) const {
-    if (m_paramsQlHybrid.empty() || sizeQl == 0 || sizeQl > m_paramsQlHybrid.size()) {
-            std::vector<NativeInteger> moduliQ(sizeQl);
-            std::vector<NativeInteger> rootsQ(sizeQl);
-            for (uint32_t i = 0; i < sizeQl; ++i) {
-                moduliQ[i] = paramsQlP->GetParams()[i]->GetModulus();
-                rootsQ[i]  = paramsQlP->GetParams()[i]->GetRootOfUnity();
-            }
-            return std::make_shared<ILDCRTParams<BigInteger>>(paramsQlP->GetCyclotomicOrder(), moduliQ, rootsQ);
-    }
-
-    return m_paramsQlHybrid[sizeQl - 1];
-}
-
-
 }  // namespace lbcrypto


### PR DESCRIPTION
This PR implements the TODO in `keyswitch-hybrid.cpp` by avoiding repeated `paramsQl` construction in the HYBRID keyswitch path.

## Changes

- Precompute `m_paramsQlHybrid` in `CryptoParametersRNS::PrecomputeCRTTables()` for the first `1..sizeQ` towers of Q when HYBRID key switching is used.
- Add `GetParamsQlHybrid(sizeQl)` in `rns-cryptoparameters.h`.
- Use the cached params in `KeySwitchDown()` and `KeySwitchDownFirstElement()` instead of rebuilding `ILDCRTParams` on each call.

## Notes

- No cryptographic semantics are changed.
- The cache is built during parameter initialization and read afterward.
- No API breaking changes.