### PR TITLE
Optimizations for KeySwitchCore/EvalFastRotation

### DIFF
--- a/benchmark/src/lib-benchmark.cpp
+++ b/benchmark/src/lib-benchmark.cpp
@@ -186,12 +186,6 @@ using namespace lbcrypto;
     state.SetComplexityN(state.range(0));
 }
 
-// BENCHMARK(NativeNTT)->Unit(benchmark::kMicrosecond)->RangeMultiplier(2)->Range(1<<10, 1<<16)->Complexity(benchmark::oAuto);
-BENCHMARK(NativeNTT)->Unit(benchmark::kMicrosecond)->Apply(RingArgs);          // ->Complexity(benchmark::oAuto);
-BENCHMARK(NativeINTT)->Unit(benchmark::kMicrosecond)->Apply(RingArgs);         // ->Complexity(benchmark::oAuto);
-BENCHMARK(NativeNTTInPlace)->Unit(benchmark::kMicrosecond)->Apply(RingArgs);   // ->Complexity(benchmark::oAuto);
-BENCHMARK(NativeINTTInPlace)->Unit(benchmark::kMicrosecond)->Apply(RingArgs);  // ->Complexity(benchmark::oAuto);
-
 /*
  * BFVrns benchmarks
  */
@@ -206,8 +200,6 @@ BENCHMARK(NativeINTTInPlace)->Unit(benchmark::kMicrosecond)->Apply(RingArgs);  /
     }
 }
 
-BENCHMARK(BFVrns_KeyGen)->Unit(benchmark::kMicrosecond);
-
 [[maybe_unused]] void BFVrns_MultKeyGen(benchmark::State& state) {
     CryptoContext<DCRTPoly> cc = GenerateBFVrnsContext();
 
@@ -218,8 +210,6 @@ BENCHMARK(BFVrns_KeyGen)->Unit(benchmark::kMicrosecond);
         cc->EvalMultKeyGen(keyPair.secretKey);
     }
 }
-
-BENCHMARK(BFVrns_MultKeyGen)->Unit(benchmark::kMicrosecond);
 
 // TODO: revisit this?
 [[maybe_unused]] void BFVrns_EvalAtIndexKeyGen(benchmark::State& state) {
@@ -238,8 +228,6 @@ BENCHMARK(BFVrns_MultKeyGen)->Unit(benchmark::kMicrosecond);
     }
 }
 
-BENCHMARK(BFVrns_EvalAtIndexKeyGen)->Unit(benchmark::kMicrosecond);
-
 [[maybe_unused]] void BFVrns_Encryption(benchmark::State& state) {
     CryptoContext<DCRTPoly> cryptoContext = GenerateBFVrnsContext();
 
@@ -252,8 +240,6 @@ BENCHMARK(BFVrns_EvalAtIndexKeyGen)->Unit(benchmark::kMicrosecond);
         auto ciphertext1 = cryptoContext->Encrypt(keyPair.publicKey, plaintext1);
     }
 }
-
-BENCHMARK(BFVrns_Encryption)->Unit(benchmark::kMicrosecond);
 
 [[maybe_unused]] void BFVrns_Decryption(benchmark::State& state) {
     CryptoContext<DCRTPoly> cryptoContext = GenerateBFVrnsContext();
@@ -270,8 +256,6 @@ BENCHMARK(BFVrns_Encryption)->Unit(benchmark::kMicrosecond);
         cryptoContext->Decrypt(keyPair.secretKey, ciphertext1, &plaintextDec1);
     }
 }
-
-BENCHMARK(BFVrns_Decryption)->Unit(benchmark::kMicrosecond);
 
 [[maybe_unused]] void BFVrns_Add(benchmark::State& state) {
     CryptoContext<DCRTPoly> cc = GenerateBFVrnsContext();
@@ -292,8 +276,6 @@ BENCHMARK(BFVrns_Decryption)->Unit(benchmark::kMicrosecond);
     }
 }
 
-BENCHMARK(BFVrns_Add)->Unit(benchmark::kMicrosecond);
-
 [[maybe_unused]] void BFVrns_AddInPlace(benchmark::State& state) {
     CryptoContext<DCRTPoly> cc = GenerateBFVrnsContext();
 
@@ -312,8 +294,6 @@ BENCHMARK(BFVrns_Add)->Unit(benchmark::kMicrosecond);
         cc->EvalAddInPlace(ciphertext1, ciphertext2);
     }
 }
-
-BENCHMARK(BFVrns_AddInPlace)->Unit(benchmark::kMicrosecond);
 
 [[maybe_unused]] void BFVrns_MultNoRelin(benchmark::State& state) {
     CryptoContext<DCRTPoly> cryptoContext = GenerateBFVrnsContext(state.range(0));
@@ -336,8 +316,6 @@ BENCHMARK(BFVrns_AddInPlace)->Unit(benchmark::kMicrosecond);
     state.SetComplexityN(state.range(0));
 }
 
-BENCHMARK(BFVrns_MultNoRelin)->Unit(benchmark::kMicrosecond)->Apply(DepthArgs);  // ->Complexity(benchmark::oAuto);
-
 [[maybe_unused]] void BFVrns_MultRelin(benchmark::State& state) {
     CryptoContext<DCRTPoly> cryptoContext = GenerateBFVrnsContext(state.range(0));
 
@@ -359,8 +337,6 @@ BENCHMARK(BFVrns_MultNoRelin)->Unit(benchmark::kMicrosecond)->Apply(DepthArgs); 
 
     state.SetComplexityN(state.range(0));
 }
-
-BENCHMARK(BFVrns_MultRelin)->Unit(benchmark::kMicrosecond)->Apply(DepthArgs);  // ->Complexity(benchmark::oAuto);
 
 [[maybe_unused]] void BFVrns_EvalAtIndex(benchmark::State& state) {
     CryptoContext<DCRTPoly> cc = GenerateBFVrnsContext();
@@ -391,8 +367,6 @@ BENCHMARK(BFVrns_MultRelin)->Unit(benchmark::kMicrosecond)->Apply(DepthArgs);  /
     }
 }
 
-BENCHMARK(BFVrns_EvalAtIndex)->Unit(benchmark::kMicrosecond);
-
 [[maybe_unused]] void BFVrns_EvalFastRotation(benchmark::State& state) {
     auto cc = GenerateBFVrnsContext(state.range(0));
 
@@ -411,8 +385,6 @@ BENCHMARK(BFVrns_EvalAtIndex)->Unit(benchmark::kMicrosecond);
     }
 }
 
-BENCHMARK(BFVrns_EvalFastRotation)->Unit(benchmark::kMicrosecond)->Apply(DepthArgs);
-
 /*
  * CKKS benchmarks
  * */
@@ -427,8 +399,6 @@ BENCHMARK(BFVrns_EvalFastRotation)->Unit(benchmark::kMicrosecond)->Apply(DepthAr
     }
 }
 
-BENCHMARK(CKKSrns_KeyGen)->Unit(benchmark::kMicrosecond);
-
 [[maybe_unused]] void CKKSrns_MultKeyGen(benchmark::State& state) {
     CryptoContext<DCRTPoly> cc = GenerateCKKSContext();
 
@@ -439,8 +409,6 @@ BENCHMARK(CKKSrns_KeyGen)->Unit(benchmark::kMicrosecond);
         cc->EvalMultKeyGen(keyPair.secretKey);
     }
 }
-
-BENCHMARK(CKKSrns_MultKeyGen)->Unit(benchmark::kMicrosecond);
 
 [[maybe_unused]] void CKKSrns_EvalAtIndexKeyGen(benchmark::State& state) {
     CryptoContext<DCRTPoly> cc = GenerateCKKSContext();
@@ -457,8 +425,6 @@ BENCHMARK(CKKSrns_MultKeyGen)->Unit(benchmark::kMicrosecond);
         cc->EvalAtIndexKeyGen(keyPair.secretKey, indexList);
     }
 }
-
-BENCHMARK(CKKSrns_EvalAtIndexKeyGen)->Unit(benchmark::kMicrosecond);
 
 [[maybe_unused]] void CKKSrns_Encryption(benchmark::State& state) {
     CryptoContext<DCRTPoly> cc = GenerateCKKSContext();
@@ -477,8 +443,6 @@ BENCHMARK(CKKSrns_EvalAtIndexKeyGen)->Unit(benchmark::kMicrosecond);
         auto ciphertext = cc->Encrypt(keyPair.publicKey, plaintext);
     }
 }
-
-BENCHMARK(CKKSrns_Encryption)->Unit(benchmark::kMicrosecond);
 
 [[maybe_unused]] void CKKSrns_Decryption(benchmark::State& state) {
     CryptoContext<DCRTPoly> cc = GenerateCKKSContext();
@@ -501,8 +465,6 @@ BENCHMARK(CKKSrns_Encryption)->Unit(benchmark::kMicrosecond);
         cc->Decrypt(keyPair.secretKey, ciphertext1, &plaintextDec1);
     }
 }
-
-BENCHMARK(CKKSrns_Decryption)->Unit(benchmark::kMicrosecond);
 
 [[maybe_unused]] void CKKSrns_Add(benchmark::State& state) {
     CryptoContext<DCRTPoly> cc = GenerateCKKSContext();
@@ -527,8 +489,6 @@ BENCHMARK(CKKSrns_Decryption)->Unit(benchmark::kMicrosecond);
     }
 }
 
-BENCHMARK(CKKSrns_Add)->Unit(benchmark::kMicrosecond);
-
 [[maybe_unused]] void CKKSrns_AddInPlace(benchmark::State& state) {
     CryptoContext<DCRTPoly> cc = GenerateCKKSContext();
 
@@ -551,8 +511,6 @@ BENCHMARK(CKKSrns_Add)->Unit(benchmark::kMicrosecond);
         cc->EvalAddInPlace(ciphertext1, ciphertext2);
     }
 }
-
-BENCHMARK(CKKSrns_AddInPlace)->Unit(benchmark::kMicrosecond);
 
 [[maybe_unused]] void CKKSrns_MultNoRelin(benchmark::State& state) {
     CryptoContext<DCRTPoly> cc = GenerateCKKSContext(state.range(0));
@@ -578,8 +536,6 @@ BENCHMARK(CKKSrns_AddInPlace)->Unit(benchmark::kMicrosecond);
 
     state.SetComplexityN(state.range(0));
 }
-
-BENCHMARK(CKKSrns_MultNoRelin)->Unit(benchmark::kMicrosecond)->Apply(DepthArgs);  // ->Complexity(benchmark::oAuto);
 
 [[maybe_unused]] void CKKSrns_MultRelin(benchmark::State& state) {
     CryptoContext<DCRTPoly> cc = GenerateCKKSContext(state.range(0));
@@ -607,8 +563,6 @@ BENCHMARK(CKKSrns_MultNoRelin)->Unit(benchmark::kMicrosecond)->Apply(DepthArgs);
     state.SetComplexityN(state.range(0));
 }
 
-BENCHMARK(CKKSrns_MultRelin)->Unit(benchmark::kMicrosecond)->Apply(DepthArgs);  // ->Complexity(benchmark::oAuto);
-
 [[maybe_unused]] void CKKSrns_Relin(benchmark::State& state) {
     CryptoContext<DCRTPoly> cc = GenerateCKKSContext();
 
@@ -634,8 +588,6 @@ BENCHMARK(CKKSrns_MultRelin)->Unit(benchmark::kMicrosecond)->Apply(DepthArgs);  
         auto ciphertext3 = cc->Relinearize(ciphertextMul);
     }
 }
-
-BENCHMARK(CKKSrns_Relin)->Unit(benchmark::kMicrosecond);
 
 [[maybe_unused]] void CKKSrns_RelinInPlace(benchmark::State& state) {
     CryptoContext<DCRTPoly> cc = GenerateCKKSContext();
@@ -667,8 +619,6 @@ BENCHMARK(CKKSrns_Relin)->Unit(benchmark::kMicrosecond);
     }
 }
 
-BENCHMARK(CKKSrns_RelinInPlace)->Unit(benchmark::kMicrosecond);
-
 [[maybe_unused]] void CKKSrns_Rescale(benchmark::State& state) {
     CryptoContext<DCRTPoly> cc = GenerateCKKSContext();
 
@@ -695,8 +645,6 @@ BENCHMARK(CKKSrns_RelinInPlace)->Unit(benchmark::kMicrosecond);
     }
 }
 
-BENCHMARK(CKKSrns_Rescale)->Unit(benchmark::kMicrosecond);
-
 [[maybe_unused]] void CKKSrns_RescaleInPlace(benchmark::State& state) {
     CryptoContext<DCRTPoly> cc = GenerateCKKSContext();
 
@@ -721,8 +669,6 @@ BENCHMARK(CKKSrns_Rescale)->Unit(benchmark::kMicrosecond);
         state.ResumeTiming();
     }
 }
-
-BENCHMARK(CKKSrns_RescaleInPlace)->Unit(benchmark::kMicrosecond);
 
 [[maybe_unused]] void CKKSrns_EvalAtIndex(benchmark::State& state) {
     CryptoContext<DCRTPoly> cc = GenerateCKKSContext();
@@ -757,8 +703,6 @@ BENCHMARK(CKKSrns_RescaleInPlace)->Unit(benchmark::kMicrosecond);
     }
 }
 
-BENCHMARK(CKKSrns_EvalAtIndex)->Unit(benchmark::kMicrosecond);
-
 [[maybe_unused]] void CKKSrns_EvalFastRotation(benchmark::State& state) {
     auto cc = GenerateCKKSContext(state.range(0));
 
@@ -777,8 +721,6 @@ BENCHMARK(CKKSrns_EvalAtIndex)->Unit(benchmark::kMicrosecond);
     }
 }
 
-BENCHMARK(CKKSrns_EvalFastRotation)->Unit(benchmark::kMicrosecond)->Apply(DepthArgs);
-
 /*
  * BGVrns benchmarks
  * */
@@ -793,8 +735,6 @@ BENCHMARK(CKKSrns_EvalFastRotation)->Unit(benchmark::kMicrosecond)->Apply(DepthA
     }
 }
 
-BENCHMARK(BGVrns_KeyGen)->Unit(benchmark::kMicrosecond);
-
 [[maybe_unused]] void BGVrns_MultKeyGen(benchmark::State& state) {
     CryptoContext<DCRTPoly> cc = GenerateBGVrnsContext();
 
@@ -805,8 +745,6 @@ BENCHMARK(BGVrns_KeyGen)->Unit(benchmark::kMicrosecond);
         cc->EvalMultKeyGen(keyPair.secretKey);
     }
 }
-
-BENCHMARK(BGVrns_MultKeyGen)->Unit(benchmark::kMicrosecond);
 
 [[maybe_unused]] void BGVrns_EvalAtIndexKeyGen(benchmark::State& state) {
     CryptoContext<DCRTPoly> cc = GenerateBGVrnsContext();
@@ -824,8 +762,6 @@ BENCHMARK(BGVrns_MultKeyGen)->Unit(benchmark::kMicrosecond);
     }
 }
 
-BENCHMARK(BGVrns_EvalAtIndexKeyGen)->Unit(benchmark::kMicrosecond);
-
 [[maybe_unused]] void BGVrns_Encryption(benchmark::State& state) {
     CryptoContext<DCRTPoly> cryptoContext = GenerateBGVrnsContext();
 
@@ -838,8 +774,6 @@ BENCHMARK(BGVrns_EvalAtIndexKeyGen)->Unit(benchmark::kMicrosecond);
         auto ciphertext = cryptoContext->Encrypt(keyPair.publicKey, plaintext);
     }
 }
-
-BENCHMARK(BGVrns_Encryption)->Unit(benchmark::kMicrosecond);
 
 [[maybe_unused]] void BGVrns_Decryption(benchmark::State& state) {
     CryptoContext<DCRTPoly> cc = GenerateBGVrnsContext();
@@ -858,8 +792,6 @@ BENCHMARK(BGVrns_Encryption)->Unit(benchmark::kMicrosecond);
         cc->Decrypt(keyPair.secretKey, ciphertext, &plaintextDec);
     }
 }
-
-BENCHMARK(BGVrns_Decryption)->Unit(benchmark::kMicrosecond);
 
 [[maybe_unused]] void BGVrns_Add(benchmark::State& state) {
     CryptoContext<DCRTPoly> cc = GenerateBGVrnsContext();
@@ -880,8 +812,6 @@ BENCHMARK(BGVrns_Decryption)->Unit(benchmark::kMicrosecond);
     }
 }
 
-BENCHMARK(BGVrns_Add)->Unit(benchmark::kMicrosecond);
-
 [[maybe_unused]] void BGVrns_AddInPlace(benchmark::State& state) {
     CryptoContext<DCRTPoly> cc = GenerateBGVrnsContext();
 
@@ -900,8 +830,6 @@ BENCHMARK(BGVrns_Add)->Unit(benchmark::kMicrosecond);
         cc->EvalAddInPlace(ciphertext1, ciphertext2);
     }
 }
-
-BENCHMARK(BGVrns_AddInPlace)->Unit(benchmark::kMicrosecond);
 
 [[maybe_unused]] void BGVrns_MultNoRelin(benchmark::State& state) {
     CryptoContext<DCRTPoly> cc = GenerateBGVrnsContext(state.range(0));
@@ -923,8 +851,6 @@ BENCHMARK(BGVrns_AddInPlace)->Unit(benchmark::kMicrosecond);
 
     state.SetComplexityN(state.range(0));
 }
-
-BENCHMARK(BGVrns_MultNoRelin)->Unit(benchmark::kMicrosecond)->Apply(DepthArgs);  // ->Complexity(benchmark::oAuto);
 
 [[maybe_unused]] void BGVrns_MultRelin(benchmark::State& state) {
     CryptoContext<DCRTPoly> cc = GenerateBGVrnsContext(state.range(0));
@@ -948,8 +874,6 @@ BENCHMARK(BGVrns_MultNoRelin)->Unit(benchmark::kMicrosecond)->Apply(DepthArgs); 
     state.SetComplexityN(state.range(0));
 }
 
-BENCHMARK(BGVrns_MultRelin)->Unit(benchmark::kMicrosecond)->Apply(DepthArgs);  // ->Complexity(benchmark::oAuto);
-
 [[maybe_unused]] void BGVrns_Relin(benchmark::State& state) {
     CryptoContext<DCRTPoly> cc = GenerateBGVrnsContext();
 
@@ -971,8 +895,6 @@ BENCHMARK(BGVrns_MultRelin)->Unit(benchmark::kMicrosecond)->Apply(DepthArgs);  /
         auto ciphertext3 = cc->Relinearize(ciphertextMul);
     }
 }
-
-BENCHMARK(BGVrns_Relin)->Unit(benchmark::kMicrosecond);
 
 [[maybe_unused]] void BGVrns_RelinInPlace(benchmark::State& state) {
     CryptoContext<DCRTPoly> cc = GenerateBGVrnsContext();
@@ -1000,8 +922,6 @@ BENCHMARK(BGVrns_Relin)->Unit(benchmark::kMicrosecond);
     }
 }
 
-BENCHMARK(BGVrns_RelinInPlace)->Unit(benchmark::kMicrosecond);
-
 [[maybe_unused]] void BGVrns_ModSwitch(benchmark::State& state) {
     CryptoContext<DCRTPoly> cc = GenerateBGVrnsContext();
 
@@ -1024,8 +944,6 @@ BENCHMARK(BGVrns_RelinInPlace)->Unit(benchmark::kMicrosecond);
     }
 }
 
-BENCHMARK(BGVrns_ModSwitch)->Unit(benchmark::kMicrosecond);
-
 [[maybe_unused]] void BGVrns_ModSwitchInPlace(benchmark::State& state) {
     CryptoContext<DCRTPoly> cc = GenerateBGVrnsContext();
 
@@ -1046,8 +964,6 @@ BENCHMARK(BGVrns_ModSwitch)->Unit(benchmark::kMicrosecond);
         state.ResumeTiming();
     }
 }
-
-BENCHMARK(BGVrns_ModSwitchInPlace)->Unit(benchmark::kMicrosecond);
 
 [[maybe_unused]] void BGVrns_EvalAtIndex(benchmark::State& state) {
     CryptoContext<DCRTPoly> cc = GenerateBGVrnsContext();
@@ -1078,8 +994,6 @@ BENCHMARK(BGVrns_ModSwitchInPlace)->Unit(benchmark::kMicrosecond);
     }
 }
 
-BENCHMARK(BGVrns_EvalAtIndex)->Unit(benchmark::kMicrosecond);
-
 [[maybe_unused]] void BGVrns_EvalFastRotation(benchmark::State& state) {
     auto cc = GenerateBGVrnsContext(state.range(0));
 
@@ -1098,6 +1012,54 @@ BENCHMARK(BGVrns_EvalAtIndex)->Unit(benchmark::kMicrosecond);
     }
 }
 
+// BENCHMARK(NativeNTT)->Unit(benchmark::kMicrosecond)->RangeMultiplier(2)->Range(1<<10, 1<<16)->Complexity(benchmark::oAuto);
+BENCHMARK(NativeNTT)->Unit(benchmark::kMicrosecond)->Apply(RingArgs);          // ->Complexity(benchmark::oAuto);
+BENCHMARK(NativeINTT)->Unit(benchmark::kMicrosecond)->Apply(RingArgs);         // ->Complexity(benchmark::oAuto);
+BENCHMARK(NativeNTTInPlace)->Unit(benchmark::kMicrosecond)->Apply(RingArgs);   // ->Complexity(benchmark::oAuto);
+BENCHMARK(NativeINTTInPlace)->Unit(benchmark::kMicrosecond)->Apply(RingArgs);  // ->Complexity(benchmark::oAuto);
+
+BENCHMARK(BFVrns_KeyGen)->Unit(benchmark::kMicrosecond);
+BENCHMARK(BFVrns_MultKeyGen)->Unit(benchmark::kMicrosecond);
+BENCHMARK(BFVrns_EvalAtIndexKeyGen)->Unit(benchmark::kMicrosecond);
+BENCHMARK(BFVrns_Encryption)->Unit(benchmark::kMicrosecond);
+BENCHMARK(BFVrns_Decryption)->Unit(benchmark::kMicrosecond);
+BENCHMARK(BFVrns_Add)->Unit(benchmark::kMicrosecond);
+BENCHMARK(BFVrns_AddInPlace)->Unit(benchmark::kMicrosecond);
+BENCHMARK(BFVrns_MultNoRelin)->Unit(benchmark::kMicrosecond)->Apply(DepthArgs);  // ->Complexity(benchmark::oAuto);
+BENCHMARK(BFVrns_MultRelin)->Unit(benchmark::kMicrosecond)->Apply(DepthArgs);    // ->Complexity(benchmark::oAuto);
+BENCHMARK(BFVrns_EvalAtIndex)->Unit(benchmark::kMicrosecond);
+BENCHMARK(BFVrns_EvalFastRotation)->Unit(benchmark::kMicrosecond)->Apply(DepthArgs);
+
+BENCHMARK(CKKSrns_KeyGen)->Unit(benchmark::kMicrosecond);
+BENCHMARK(CKKSrns_MultKeyGen)->Unit(benchmark::kMicrosecond);
+BENCHMARK(CKKSrns_EvalAtIndexKeyGen)->Unit(benchmark::kMicrosecond);
+BENCHMARK(CKKSrns_Encryption)->Unit(benchmark::kMicrosecond);
+BENCHMARK(CKKSrns_Decryption)->Unit(benchmark::kMicrosecond);
+BENCHMARK(CKKSrns_Add)->Unit(benchmark::kMicrosecond);
+BENCHMARK(CKKSrns_AddInPlace)->Unit(benchmark::kMicrosecond);
+BENCHMARK(CKKSrns_MultNoRelin)->Unit(benchmark::kMicrosecond)->Apply(DepthArgs);  // ->Complexity(benchmark::oAuto);
+BENCHMARK(CKKSrns_MultRelin)->Unit(benchmark::kMicrosecond)->Apply(DepthArgs);    // ->Complexity(benchmark::oAuto);
+BENCHMARK(CKKSrns_Relin)->Unit(benchmark::kMicrosecond);
+BENCHMARK(CKKSrns_RelinInPlace)->Unit(benchmark::kMicrosecond);
+BENCHMARK(CKKSrns_Rescale)->Unit(benchmark::kMicrosecond);
+BENCHMARK(CKKSrns_RescaleInPlace)->Unit(benchmark::kMicrosecond);
+BENCHMARK(CKKSrns_EvalAtIndex)->Unit(benchmark::kMicrosecond);
+BENCHMARK(CKKSrns_EvalFastRotation)->Unit(benchmark::kMicrosecond)->Apply(DepthArgs);
+
+BENCHMARK(BGVrns_KeyGen)->Unit(benchmark::kMicrosecond);
+BENCHMARK(BGVrns_MultKeyGen)->Unit(benchmark::kMicrosecond);
+BENCHMARK(BGVrns_EvalAtIndexKeyGen)->Unit(benchmark::kMicrosecond);
+BENCHMARK(BGVrns_Encryption)->Unit(benchmark::kMicrosecond);
+BENCHMARK(BGVrns_Decryption)->Unit(benchmark::kMicrosecond);
+BENCHMARK(BGVrns_Add)->Unit(benchmark::kMicrosecond);
+BENCHMARK(BGVrns_AddInPlace)->Unit(benchmark::kMicrosecond);
+BENCHMARK(BGVrns_MultNoRelin)->Unit(benchmark::kMicrosecond)->Apply(DepthArgs);  // ->Complexity(benchmark::oAuto);
+BENCHMARK(BGVrns_MultRelin)->Unit(benchmark::kMicrosecond)->Apply(DepthArgs);    // ->Complexity(benchmark::oAuto);
+BENCHMARK(BGVrns_Relin)->Unit(benchmark::kMicrosecond);
+BENCHMARK(BGVrns_RelinInPlace)->Unit(benchmark::kMicrosecond);
+BENCHMARK(BGVrns_ModSwitch)->Unit(benchmark::kMicrosecond);
+BENCHMARK(BGVrns_ModSwitchInPlace)->Unit(benchmark::kMicrosecond);
+BENCHMARK(BGVrns_EvalAtIndex)->Unit(benchmark::kMicrosecond);
 BENCHMARK(BGVrns_EvalFastRotation)->Unit(benchmark::kMicrosecond)->Apply(DepthArgs);
 
 BENCHMARK_MAIN();

--- a/src/pke/include/keyswitch/keyswitch-base.h
+++ b/src/pke/include/keyswitch/keyswitch-base.h
@@ -113,8 +113,7 @@ public:
     // CORE OPERATIONS
     /////////////////////////////////////////
 
-    virtual std::shared_ptr<std::vector<Element>> KeySwitchCore(const Element& a,
-                                                                const EvalKey<Element> evalKey) const {
+    virtual std::vector<Element> KeySwitchCore(const Element& a, const EvalKey<Element> evalKey) const {
         OPENFHE_THROW(NOT_SUPPORTED_ERROR);
     }
 
@@ -123,15 +122,15 @@ public:
         OPENFHE_THROW(NOT_SUPPORTED_ERROR);
     }
 
-    virtual std::shared_ptr<std::vector<Element>> EvalFastKeySwitchCore(
-        const std::shared_ptr<std::vector<Element>> digits, const EvalKey<Element> evalKey,
-        const std::shared_ptr<ParmType> paramsQl) const {
+    virtual std::vector<Element> EvalFastKeySwitchCore(const std::shared_ptr<std::vector<Element>> digits,
+                                                       const EvalKey<Element> evalKey,
+                                                       const std::shared_ptr<ParmType> paramsQl) const {
         OPENFHE_THROW(NOT_SUPPORTED_ERROR);
     }
 
-    virtual std::shared_ptr<std::vector<Element>> EvalFastKeySwitchCoreExt(
-        const std::shared_ptr<std::vector<Element>> digits, const EvalKey<Element> evalKey,
-        const std::shared_ptr<ParmType> paramsQl) const {
+    virtual std::vector<Element> EvalFastKeySwitchCoreExt(const std::shared_ptr<std::vector<Element>> digits,
+                                                          const EvalKey<Element> evalKey,
+                                                          const std::shared_ptr<ParmType> paramsQl) const {
         OPENFHE_THROW(NOT_SUPPORTED_ERROR);
     }
 };

--- a/src/pke/include/keyswitch/keyswitch-bv.h
+++ b/src/pke/include/keyswitch/keyswitch-bv.h
@@ -80,15 +80,14 @@ public:
     // CORE OPERATIONS
     /////////////////////////////////////////
 
-    std::shared_ptr<std::vector<DCRTPoly>> KeySwitchCore(const DCRTPoly& a,
-                                                         const EvalKey<DCRTPoly> evalKey) const override;
+    std::vector<DCRTPoly> KeySwitchCore(const DCRTPoly& a, const EvalKey<DCRTPoly> evalKey) const override;
 
     std::shared_ptr<std::vector<DCRTPoly>> EvalKeySwitchPrecomputeCore(
         const DCRTPoly& c, std::shared_ptr<CryptoParametersBase<DCRTPoly>> cryptoParamsBase) const override;
 
-    std::shared_ptr<std::vector<DCRTPoly>> EvalFastKeySwitchCore(
-        const std::shared_ptr<std::vector<DCRTPoly>> digits, const EvalKey<DCRTPoly> evalKey,
-        const std::shared_ptr<ParmType> paramsQl) const override;
+    std::vector<DCRTPoly> EvalFastKeySwitchCore(const std::shared_ptr<std::vector<DCRTPoly>> digits,
+                                                const EvalKey<DCRTPoly> evalKey,
+                                                const std::shared_ptr<ParmType> paramsQl) const override;
 
     /////////////////////////////////////////
     // SERIALIZATION

--- a/src/pke/include/keyswitch/keyswitch-hybrid.h
+++ b/src/pke/include/keyswitch/keyswitch-hybrid.h
@@ -94,19 +94,18 @@ public:
     // CORE OPERATIONS
     /////////////////////////////////////////
 
-    std::shared_ptr<std::vector<DCRTPoly>> KeySwitchCore(const DCRTPoly& a,
-                                                         const EvalKey<DCRTPoly> evalKey) const override;
+    std::vector<DCRTPoly> KeySwitchCore(const DCRTPoly& a, const EvalKey<DCRTPoly> evalKey) const override;
 
     std::shared_ptr<std::vector<DCRTPoly>> EvalKeySwitchPrecomputeCore(
         const DCRTPoly& c, std::shared_ptr<CryptoParametersBase<DCRTPoly>> cryptoParamsBase) const override;
 
-    std::shared_ptr<std::vector<DCRTPoly>> EvalFastKeySwitchCore(
-        const std::shared_ptr<std::vector<DCRTPoly>> digits, const EvalKey<DCRTPoly> evalKey,
-        const std::shared_ptr<ParmType> paramsQl) const override;
+    std::vector<DCRTPoly> EvalFastKeySwitchCore(const std::shared_ptr<std::vector<DCRTPoly>> digits,
+                                                const EvalKey<DCRTPoly> evalKey,
+                                                const std::shared_ptr<ParmType> paramsQl) const override;
 
-    std::shared_ptr<std::vector<DCRTPoly>> EvalFastKeySwitchCoreExt(
-        const std::shared_ptr<std::vector<DCRTPoly>> digits, const EvalKey<DCRTPoly> evalKey,
-        const std::shared_ptr<ParmType> paramsQl) const override;
+    std::vector<DCRTPoly> EvalFastKeySwitchCoreExt(const std::shared_ptr<std::vector<DCRTPoly>> digits,
+                                                   const EvalKey<DCRTPoly> evalKey,
+                                                   const std::shared_ptr<ParmType> paramsQl) const override;
 
     /////////////////////////////////////////
     // SERIALIZATION

--- a/src/pke/include/schemebase/base-scheme.h
+++ b/src/pke/include/schemebase/base-scheme.h
@@ -291,9 +291,9 @@ public:
         return m_KeySwitch->EvalKeySwitchPrecomputeCore(c, cryptoParamsBase);
     }
 
-    virtual std::shared_ptr<std::vector<Element>> EvalFastKeySwitchCoreExt(
-        const std::shared_ptr<std::vector<Element>> digits, const EvalKey<Element> evalKey,
-        const std::shared_ptr<ParmType> params) const {
+    virtual std::vector<Element> EvalFastKeySwitchCoreExt(const std::shared_ptr<std::vector<Element>> digits,
+                                                          const EvalKey<Element> evalKey,
+                                                          const std::shared_ptr<ParmType> params) const {
         VerifyKeySwitchEnabled(__func__);
         if (nullptr == digits)
             OPENFHE_THROW("Input digits is nullptr");
@@ -306,9 +306,9 @@ public:
         return m_KeySwitch->EvalFastKeySwitchCoreExt(digits, evalKey, params);
     }
 
-    virtual std::shared_ptr<std::vector<Element>> EvalFastKeySwitchCore(
-        const std::shared_ptr<std::vector<Element>> digits, const EvalKey<Element> evalKey,
-        const std::shared_ptr<ParmType> params) const {
+    virtual std::vector<Element> EvalFastKeySwitchCore(const std::shared_ptr<std::vector<Element>> digits,
+                                                       const EvalKey<Element> evalKey,
+                                                       const std::shared_ptr<ParmType> params) const {
         VerifyKeySwitchEnabled(__func__);
         if (nullptr == digits)
             OPENFHE_THROW("Input digits is nullptr");
@@ -321,8 +321,7 @@ public:
         return m_KeySwitch->EvalFastKeySwitchCore(digits, evalKey, params);
     }
 
-    virtual std::shared_ptr<std::vector<Element>> KeySwitchCore(const Element& a,
-                                                                const EvalKey<Element> evalKey) const {
+    virtual std::vector<Element> KeySwitchCore(const Element& a, const EvalKey<Element> evalKey) const {
         VerifyKeySwitchEnabled(__func__);
         if (!evalKey)
             OPENFHE_THROW("Input evaluation key is nullptr");

--- a/src/pke/lib/keyswitch/keyswitch-bv.cpp
+++ b/src/pke/lib/keyswitch/keyswitch-bv.cpp
@@ -227,23 +227,19 @@ EvalKey<DCRTPoly> KeySwitchBV::KeySwitchGenInternal(const PrivateKey<DCRTPoly> o
 void KeySwitchBV::KeySwitchInPlace(Ciphertext<DCRTPoly>& ciphertext, const EvalKey<DCRTPoly> ek) const {
     auto& cv = ciphertext->GetElements();
     auto ba  = KeySwitchCore(cv.back(), ek);
-
     cv[0].SetFormat(Format::EVALUATION);
-    cv[0] += (*ba)[0];
-
+    cv[0] += ba[0];
     if (cv.size() > 2) {
         cv[1].SetFormat(Format::EVALUATION);
-        cv[1] += (*ba)[1];
+        cv[1] += ba[1];
     }
     else {
-        cv[1] = (*ba)[1];
+        cv[1] = ba[1];
     }
-
     cv.resize(2);
 }
 
-std::shared_ptr<std::vector<DCRTPoly>> KeySwitchBV::KeySwitchCore(const DCRTPoly& a,
-                                                                  const EvalKey<DCRTPoly> evalKey) const {
+std::vector<DCRTPoly> KeySwitchBV::KeySwitchCore(const DCRTPoly& a, const EvalKey<DCRTPoly> evalKey) const {
     return EvalFastKeySwitchCore(EvalKeySwitchPrecomputeCore(a, evalKey->GetCryptoParameters()), evalKey,
                                  a.GetParams());
 }
@@ -254,9 +250,9 @@ std::shared_ptr<std::vector<DCRTPoly>> KeySwitchBV::EvalKeySwitchPrecomputeCore(
     return std::make_shared<std::vector<DCRTPoly>>(c.CRTDecompose(cryptoParams->GetDigitSize()));
 }
 
-std::shared_ptr<std::vector<DCRTPoly>> KeySwitchBV::EvalFastKeySwitchCore(
-    const std::shared_ptr<std::vector<DCRTPoly>> digits, const EvalKey<DCRTPoly> evalKey,
-    const std::shared_ptr<ParmType> paramsQl) const {
+std::vector<DCRTPoly> KeySwitchBV::EvalFastKeySwitchCore(const std::shared_ptr<std::vector<DCRTPoly>> digits,
+                                                         const EvalKey<DCRTPoly> evalKey,
+                                                         const std::shared_ptr<ParmType> paramsQl) const {
     std::vector<DCRTPoly> bv(evalKey->GetBVector());
     std::vector<DCRTPoly> av(evalKey->GetAVector());
     const auto diffQl    = bv[0].GetParams()->GetParams().size() - paramsQl->GetParams().size();
@@ -268,13 +264,14 @@ std::shared_ptr<std::vector<DCRTPoly>> KeySwitchBV::EvalFastKeySwitchCore(
         av[i].DropLastElements(diffQl);
         av[i] *= (*digits)[i];
     }
-
-    std::vector<DCRTPoly> res{std::move(bv[0]), std::move(av[0])};
     for (uint32_t i = 1; i < limit; ++i) {
-        res[0] += bv[i];
-        res[1] += av[i];
+        bv[0] += bv[i];
+        av[0] += av[i];
     }
-    return std::make_shared<std::vector<DCRTPoly>>(std::move(res));
+    std::vector<DCRTPoly> res;
+    res.emplace_back(std::move(bv[0]));
+    res.emplace_back(std::move(av[0]));
+    return res;
 }
 
 }  // namespace lbcrypto

--- a/src/pke/lib/keyswitch/keyswitch-hybrid.cpp
+++ b/src/pke/lib/keyswitch/keyswitch-hybrid.cpp
@@ -199,18 +199,15 @@ EvalKey<DCRTPoly> KeySwitchHYBRID::KeySwitchGenInternal(const PrivateKey<DCRTPol
 void KeySwitchHYBRID::KeySwitchInPlace(Ciphertext<DCRTPoly>& ciphertext, const EvalKey<DCRTPoly> ek) const {
     auto& cv = ciphertext->GetElements();
     auto ba  = KeySwitchCore(cv.back(), ek);
-
     cv[0].SetFormat(Format::EVALUATION);
-    cv[0] += (*ba)[0];
-
+    cv[0] += ba[0];
     if (cv.size() > 2) {
         cv[1].SetFormat(Format::EVALUATION);
-        cv[1] += (*ba)[1];
+        cv[1] += ba[1];
     }
     else {
-        cv[1] = (*ba)[1];
+        cv[1] = ba[1];
     }
-
     cv.resize(2);
 }
 
@@ -305,8 +302,7 @@ DCRTPoly KeySwitchHYBRID::KeySwitchDownFirstElement(ConstCiphertext<DCRTPoly> ci
                             cryptoParams->GettInvModpPrecon(), t, cryptoParams->GettModqPrecon());
 }
 
-std::shared_ptr<std::vector<DCRTPoly>> KeySwitchHYBRID::KeySwitchCore(const DCRTPoly& a,
-                                                                      const EvalKey<DCRTPoly> evalKey) const {
+std::vector<DCRTPoly> KeySwitchHYBRID::KeySwitchCore(const DCRTPoly& a, const EvalKey<DCRTPoly> evalKey) const {
     return EvalFastKeySwitchCore(EvalKeySwitchPrecomputeCore(a, evalKey->GetCryptoParameters()), evalKey,
                                  a.GetParams());
 }
@@ -378,30 +374,30 @@ std::shared_ptr<std::vector<DCRTPoly>> KeySwitchHYBRID::EvalKeySwitchPrecomputeC
     return result;
 }
 
-std::shared_ptr<std::vector<DCRTPoly>> KeySwitchHYBRID::EvalFastKeySwitchCore(
-    const std::shared_ptr<std::vector<DCRTPoly>> digits, const EvalKey<DCRTPoly> evalKey,
-    const std::shared_ptr<ParmType> paramsQl) const {
+std::vector<DCRTPoly> KeySwitchHYBRID::EvalFastKeySwitchCore(const std::shared_ptr<std::vector<DCRTPoly>> digits,
+                                                             const EvalKey<DCRTPoly> evalKey,
+                                                             const std::shared_ptr<ParmType> paramsQl) const {
     const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersRNS>(evalKey->GetCryptoParameters());
 
     const PlaintextModulus t = (cryptoParams->GetNoiseScale() == 1) ? 0 : cryptoParams->GetPlaintextModulus();
 
-    auto result  = EvalFastKeySwitchCoreExt(digits, evalKey, paramsQl);
-    (*result)[0] = (*result)[0].ApproxModDown(paramsQl, cryptoParams->GetParamsP(), cryptoParams->GetPInvModq(),
-                                              cryptoParams->GetPInvModqPrecon(), cryptoParams->GetPHatInvModp(),
-                                              cryptoParams->GetPHatInvModpPrecon(), cryptoParams->GetPHatModq(),
-                                              cryptoParams->GetModqBarrettMu(), cryptoParams->GettInvModp(),
-                                              cryptoParams->GettInvModpPrecon(), t, cryptoParams->GettModqPrecon());
-    (*result)[1] = (*result)[1].ApproxModDown(paramsQl, cryptoParams->GetParamsP(), cryptoParams->GetPInvModq(),
-                                              cryptoParams->GetPInvModqPrecon(), cryptoParams->GetPHatInvModp(),
-                                              cryptoParams->GetPHatInvModpPrecon(), cryptoParams->GetPHatModq(),
-                                              cryptoParams->GetModqBarrettMu(), cryptoParams->GettInvModp(),
-                                              cryptoParams->GettInvModpPrecon(), t, cryptoParams->GettModqPrecon());
+    auto result = EvalFastKeySwitchCoreExt(digits, evalKey, paramsQl);
+    result[0]   = result[0].ApproxModDown(paramsQl, cryptoParams->GetParamsP(), cryptoParams->GetPInvModq(),
+                                          cryptoParams->GetPInvModqPrecon(), cryptoParams->GetPHatInvModp(),
+                                          cryptoParams->GetPHatInvModpPrecon(), cryptoParams->GetPHatModq(),
+                                          cryptoParams->GetModqBarrettMu(), cryptoParams->GettInvModp(),
+                                          cryptoParams->GettInvModpPrecon(), t, cryptoParams->GettModqPrecon());
+    result[1]   = result[1].ApproxModDown(paramsQl, cryptoParams->GetParamsP(), cryptoParams->GetPInvModq(),
+                                          cryptoParams->GetPInvModqPrecon(), cryptoParams->GetPHatInvModp(),
+                                          cryptoParams->GetPHatInvModpPrecon(), cryptoParams->GetPHatModq(),
+                                          cryptoParams->GetModqBarrettMu(), cryptoParams->GettInvModp(),
+                                          cryptoParams->GettInvModpPrecon(), t, cryptoParams->GettModqPrecon());
     return result;
 }
 
-std::shared_ptr<std::vector<DCRTPoly>> KeySwitchHYBRID::EvalFastKeySwitchCoreExt(
-    const std::shared_ptr<std::vector<DCRTPoly>> digits, const EvalKey<DCRTPoly> evalKey,
-    const std::shared_ptr<ParmType> paramsQl) const {
+std::vector<DCRTPoly> KeySwitchHYBRID::EvalFastKeySwitchCoreExt(const std::shared_ptr<std::vector<DCRTPoly>> digits,
+                                                                const EvalKey<DCRTPoly> evalKey,
+                                                                const std::shared_ptr<ParmType> paramsQl) const {
     const auto paramsQlP   = (*digits)[0].GetParams();
     const uint32_t sizeQlP = paramsQlP->GetParams().size();
 
@@ -413,11 +409,9 @@ std::shared_ptr<std::vector<DCRTPoly>> KeySwitchHYBRID::EvalFastKeySwitchCoreExt
     const auto& av = evalKey->GetAVector();
     const auto& bv = evalKey->GetBVector();
 
-    auto result = std::make_shared<std::vector<DCRTPoly>>();
-    result->reserve(2);
-    result->emplace_back(paramsQlP, Format::EVALUATION, true);
-    result->emplace_back(paramsQlP, Format::EVALUATION, true);
-    auto& elements = (*result);
+    std::vector<DCRTPoly> result;
+    result.emplace_back(paramsQlP, Format::EVALUATION, true);
+    result.emplace_back(paramsQlP, Format::EVALUATION, true);
 
     for (uint32_t j = 0; j < limit; ++j) {
 #pragma omp parallel for num_threads(OpenFHEParallelControls.GetThreadLimit(sizeQlP))
@@ -426,8 +420,8 @@ std::shared_ptr<std::vector<DCRTPoly>> KeySwitchHYBRID::EvalFastKeySwitchCoreExt
             const auto& cji = (*digits)[j].GetElementAtIndex(i);
             const auto& bji = bv[j].GetElementAtIndex(idx);
             const auto& aji = av[j].GetElementAtIndex(idx);
-            elements[0].SetElementAtIndex(i, elements[0].GetElementAtIndex(i) + cji * bji);
-            elements[1].SetElementAtIndex(i, elements[1].GetElementAtIndex(i) + cji * aji);
+            result[0].SetElementAtIndex(i, result[0].GetElementAtIndex(i) + cji * bji);
+            result[1].SetElementAtIndex(i, result[1].GetElementAtIndex(i) + cji * aji);
         }
     }
 

--- a/src/pke/lib/scheme/bfvrns/bfvrns-leveledshe.cpp
+++ b/src/pke/lib/scheme/bfvrns/bfvrns-leveledshe.cpp
@@ -264,8 +264,8 @@ Ciphertext<DCRTPoly> LeveledSHEBFVRNS::EvalMult(ConstCiphertext<DCRTPoly>& ciphe
         uint32_t c1depth = ciphertext1->GetNoiseScaleDeg();
         uint32_t c2depth = ciphertext2->GetNoiseScaleDeg();
 
-        uint32_t levels = std::max(c1depth, c2depth) - 1;
-        double dcrtBits = cv1[0].GetElementAtIndex(0).GetModulus().GetMSB();
+        uint32_t levels   = std::max(c1depth, c2depth) - 1;
+        uint32_t dcrtBits = cv1[0].GetElementAtIndex(0).GetModulus().GetMSB();
 
         // how many levels to drop
         uint32_t levelsDropped = FindLevelsToDrop(levels, cryptoParams, dcrtBits, false);
@@ -491,9 +491,9 @@ Ciphertext<DCRTPoly> LeveledSHEBFVRNS::EvalSquare(ConstCiphertext<DCRTPoly>& cip
         }
     }
     else if ((cryptoParams->GetMultiplicationTechnique() == HPSPOVERQLEVELED) && (sizeQ == sizeQM)) {
-        size_t cdepth   = ciphertext->GetNoiseScaleDeg();
-        size_t levels   = cdepth - 1;
-        double dcrtBits = cv[0].GetElementAtIndex(0).GetModulus().GetMSB();
+        uint32_t cdepth   = ciphertext->GetNoiseScaleDeg();
+        uint32_t levels   = cdepth - 1;
+        uint32_t dcrtBits = cv[0].GetElementAtIndex(0).GetModulus().GetMSB();
 
         // how many levels to drop
         uint32_t levelsDropped = FindLevelsToDrop(levels, cryptoParams, dcrtBits, false);
@@ -796,9 +796,9 @@ std::shared_ptr<std::vector<DCRTPoly>> LeveledSHEBFVRNS::EvalFastRotationPrecomp
         return algo->EvalKeySwitchPrecomputeCore(ciphertext->GetElements()[1], ciphertext->GetCryptoParameters());
     }
     else {
-        DCRTPoly c1     = ciphertext->GetElements()[1];
-        size_t levels   = ciphertext->GetNoiseScaleDeg() - 1;
-        double dcrtBits = c1.GetElementAtIndex(0).GetModulus().GetMSB();
+        DCRTPoly c1       = ciphertext->GetElements()[1];
+        uint32_t levels   = ciphertext->GetNoiseScaleDeg() - 1;
+        uint32_t dcrtBits = c1.GetElementAtIndex(0).GetModulus().GetMSB();
         // how many levels to drop
         uint32_t levelsDropped = FindLevelsToDrop(levels, cryptoParams, dcrtBits, true);
         // l is index corresponding to leveled parameters in cryptoParameters precomputations in HPSPOVERQLEVELED
@@ -815,9 +815,8 @@ std::shared_ptr<std::vector<DCRTPoly>> LeveledSHEBFVRNS::EvalFastRotationPrecomp
 Ciphertext<DCRTPoly> LeveledSHEBFVRNS::EvalFastRotation(ConstCiphertext<DCRTPoly>& ciphertext, const uint32_t index,
                                                         const uint32_t m,
                                                         const std::shared_ptr<std::vector<DCRTPoly>> digits) const {
-    if (index == 0) {
+    if (index == 0)
         return ciphertext->Clone();
-    }
 
     const auto cc = ciphertext->GetCryptoContext();
 
@@ -830,9 +829,6 @@ Ciphertext<DCRTPoly> LeveledSHEBFVRNS::EvalFastRotation(ConstCiphertext<DCRTPoly
         OPENFHE_THROW("EvalKey for index [" + std::to_string(autoIndex) + "] is not found.");
     }
     auto evalKey = evalKeyIterator->second;
-
-    auto algo                       = cc->GetScheme();
-    const std::vector<DCRTPoly>& cv = ciphertext->GetElements();
 
     const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersBFVRNS>(ciphertext->GetCryptoParameters());
 
@@ -847,37 +843,33 @@ Ciphertext<DCRTPoly> LeveledSHEBFVRNS::EvalFastRotation(ConstCiphertext<DCRTPoly
         }
     }
 
-    std::shared_ptr<std::vector<DCRTPoly>> ba =
-        algo->EvalFastKeySwitchCore(digits, evalKey, std::make_shared<DCRTPoly::Params>(elemParams));
+    auto ba = cc->GetScheme()->EvalFastKeySwitchCore(digits, evalKey, std::make_shared<DCRTPoly::Params>(elemParams));
 
-    size_t sizeQ             = ciphertext->GetElements()[0].GetNumOfElements();
     const auto elementParams = cryptoParams->GetElementParams();
-    // Maximum number of RNS limbs in the crypto context
-    size_t sizeQM = elementParams->GetParams().size();
 
     // In the HPSPOVERQLEVELED mode, we need to increase the modulus back to Q
+    const auto& cv = ciphertext->GetElements();
+    size_t sizeQ   = cv[0].GetNumOfElements();
+    size_t sizeQM  = elementParams->GetParams().size();
     if ((cryptoParams->GetMultiplicationTechnique() == HPSPOVERQLEVELED) && (sizeQ == sizeQM)) {
-        size_t sizeQ = cv[0].GetNumOfElements();
         // l is index corresponding to leveled parameters in cryptoParameters precomputations in HPSPOVERQLEVELED, after the level dropping
         uint32_t l = elemParams.GetParams().size() - 1;
-
-        (*ba)[0].ExpandCRTBasisQlHat(cryptoParams->GetElementParams(), cryptoParams->GetQlHatModq(l),
-                                     cryptoParams->GetQlHatModqPrecon(l), sizeQ);
-        (*ba)[1].ExpandCRTBasisQlHat(cryptoParams->GetElementParams(), cryptoParams->GetQlHatModq(l),
-                                     cryptoParams->GetQlHatModqPrecon(l), sizeQ);
+        ba[0].ExpandCRTBasisQlHat(cryptoParams->GetElementParams(), cryptoParams->GetQlHatModq(l),
+                                  cryptoParams->GetQlHatModqPrecon(l), sizeQ);
+        ba[1].ExpandCRTBasisQlHat(cryptoParams->GetElementParams(), cryptoParams->GetQlHatModq(l),
+                                  cryptoParams->GetQlHatModqPrecon(l), sizeQ);
     }
 
-    uint32_t N = cryptoParams->GetElementParams()->GetRingDimension();
+    uint32_t N = cc->GetRingDimension();
     std::vector<uint32_t> vec(N);
     PrecomputeAutoMap(N, autoIndex, &vec);
 
-    (*ba)[0] += cv[0];
-
-    (*ba)[0] = (*ba)[0].AutomorphismTransform(autoIndex, vec);
-    (*ba)[1] = (*ba)[1].AutomorphismTransform(autoIndex, vec);
+    ba[0] += cv[0];
+    ba[0] = ba[0].AutomorphismTransform(autoIndex, vec);
+    ba[1] = ba[1].AutomorphismTransform(autoIndex, vec);
 
     auto result = ciphertext->CloneEmpty();
-    result->SetElements({std::move((*ba)[0]), std::move((*ba)[1])});
+    result->SetElements(std::move(ba));
     return result;
 }
 
@@ -887,22 +879,20 @@ uint32_t LeveledSHEBFVRNS::FindAutomorphismIndex(uint32_t index, uint32_t m) con
 
 void LeveledSHEBFVRNS::RelinearizeCore(Ciphertext<DCRTPoly>& ciphertext, const EvalKey<DCRTPoly> evalKey) const {
     const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersBFVRNS>(ciphertext->GetCryptoParameters());
-    // l is index corresponding to leveled parameters in cryptoParameters precomputations in HPSPOVERQLEVELED
-    uint32_t l = 0;
 
-    std::vector<DCRTPoly>& cv = ciphertext->GetElements();
-    bool isKeySwitch          = (cv.size() == 2);
-    auto algo                 = ciphertext->GetCryptoContext()->GetScheme();
-    size_t sel                = 1 + !isKeySwitch;
+    auto& cv         = ciphertext->GetElements();
+    bool isKeySwitch = (cv.size() == 2);
+    auto algo        = ciphertext->GetCryptoContext()->GetScheme();
+    size_t sel       = 1 + !isKeySwitch;
 
-    size_t sizeQ             = cv[0].GetNumOfElements();
     const auto elementParams = cryptoParams->GetElementParams();
-    // Maximum number of RNS limbs in the crypto context
-    size_t sizeQM = elementParams->GetParams().size();
 
+    size_t sizeQ  = cv[0].GetNumOfElements();
+    size_t sizeQM = elementParams->GetParams().size();
+    uint32_t l    = 0;
     if ((cryptoParams->GetMultiplicationTechnique() == HPSPOVERQLEVELED) && (sizeQM == sizeQ)) {
-        size_t levels   = ciphertext->GetNoiseScaleDeg() - 1;
-        double dcrtBits = cv[0].GetElementAtIndex(0).GetModulus().GetMSB();
+        uint32_t levels   = ciphertext->GetNoiseScaleDeg() - 1;
+        uint32_t dcrtBits = cv[0].GetElementAtIndex(0).GetModulus().GetMSB();
 
         // how many levels to drop
         l = sizeQ - 1 - FindLevelsToDrop(levels, cryptoParams, dcrtBits, isKeySwitch);
@@ -916,24 +906,21 @@ void LeveledSHEBFVRNS::RelinearizeCore(Ciphertext<DCRTPoly>& ciphertext, const E
     auto ab = algo->KeySwitchCore(cv[sel], evalKey);
 
     if ((cryptoParams->GetMultiplicationTechnique() == HPSPOVERQLEVELED) && (sizeQM == sizeQ)) {
-        size_t sizeQ = cv[0].GetNumOfElements();
-        (*ab)[0].ExpandCRTBasisQlHat(cryptoParams->GetElementParams(), cryptoParams->GetQlHatModq(l),
-                                     cryptoParams->GetQlHatModqPrecon(l), sizeQ);
-        (*ab)[1].ExpandCRTBasisQlHat(cryptoParams->GetElementParams(), cryptoParams->GetQlHatModq(l),
-                                     cryptoParams->GetQlHatModqPrecon(l), sizeQ);
+        ab[0].ExpandCRTBasisQlHat(cryptoParams->GetElementParams(), cryptoParams->GetQlHatModq(l),
+                                  cryptoParams->GetQlHatModqPrecon(l), sizeQ);
+        ab[1].ExpandCRTBasisQlHat(cryptoParams->GetElementParams(), cryptoParams->GetQlHatModq(l),
+                                  cryptoParams->GetQlHatModqPrecon(l), sizeQ);
     }
 
     cv[0].SetFormat(Format::EVALUATION);
-    cv[0] += (*ab)[0];
-
+    cv[0] += ab[0];
     if (isKeySwitch) {
-        cv[1] = std::move((*ab)[1]);
+        cv[1] = std::move(ab[1]);
     }
     else {
         cv[1].SetFormat(Format::EVALUATION);
-        cv[1] += (*ab)[1];
+        cv[1] += ab[1];
     }
-
     cv.resize(2);
 }
 

--- a/src/pke/lib/scheme/ckksrns/ckksrns-leveledshe.cpp
+++ b/src/pke/lib/scheme/ckksrns/ckksrns-leveledshe.cpp
@@ -556,7 +556,7 @@ Ciphertext<DCRTPoly> LeveledSHECKKSRNS::EvalFastRotationExt(
     const auto paramsQl = cv[0].GetParams();
 
     const auto cc = ciphertext->GetCryptoContext();
-    auto cTilda   = *cc->GetScheme()->EvalFastKeySwitchCoreExt(digits, evalKey, paramsQl);
+    auto cTilda   = cc->GetScheme()->EvalFastKeySwitchCoreExt(digits, evalKey, paramsQl);
 
     if (addFirst) {
         DCRTPoly psiC0(cTilda[0].GetParams(), Format::EVALUATION, true);

--- a/src/pke/lib/schemebase/base-leveledshe.cpp
+++ b/src/pke/lib/schemebase/base-leveledshe.cpp
@@ -207,8 +207,8 @@ Ciphertext<Element> LeveledSHEBase<Element>::EvalMult(ConstCiphertext<Element>& 
     auto& cv = ciphertext->GetElements();
 
     auto ab = ciphertext->GetCryptoContext()->GetScheme()->KeySwitchCore(cv[2], evalKey);
-    cv[0] += (*ab)[0];
-    cv[1] += (*ab)[1];
+    cv[0] += ab[0];
+    cv[1] += ab[1];
     cv.resize(2);
     return ciphertext;
 }
@@ -221,8 +221,8 @@ void LeveledSHEBase<Element>::EvalMultInPlace(Ciphertext<Element>& ciphertext1, 
     auto& cv = ciphertext1->GetElements();
 
     auto ab = ciphertext1->GetCryptoContext()->GetScheme()->KeySwitchCore(cv[2], evalKey);
-    cv[0] += (*ab)[0];
-    cv[1] += (*ab)[1];
+    cv[0] += ab[0];
+    cv[1] += ab[1];
     cv.resize(2);
 }
 
@@ -235,8 +235,8 @@ Ciphertext<Element> LeveledSHEBase<Element>::EvalMultMutable(Ciphertext<Element>
     auto& cv = ciphertext->GetElements();
 
     auto ab = ciphertext->GetCryptoContext()->GetScheme()->KeySwitchCore(cv[2], evalKey);
-    cv[0] += (*ab)[0];
-    cv[1] += (*ab)[1];
+    cv[0] += ab[0];
+    cv[1] += ab[1];
     cv.resize(2);
     return ciphertext;
 }
@@ -249,8 +249,8 @@ Ciphertext<Element> LeveledSHEBase<Element>::EvalSquare(ConstCiphertext<Element>
     auto& cv = csquare->GetElements();
 
     auto ab = csquare->GetCryptoContext()->GetScheme()->KeySwitchCore(cv[2], evalKey);
-    cv[0] += (*ab)[0];
-    cv[1] += (*ab)[1];
+    cv[0] += ab[0];
+    cv[1] += ab[1];
     cv.resize(2);
     return csquare;
 }
@@ -262,8 +262,8 @@ void LeveledSHEBase<Element>::EvalSquareInPlace(Ciphertext<Element>& ciphertext,
     auto& cv = ciphertext->GetElements();
 
     auto ab = ciphertext->GetCryptoContext()->GetScheme()->KeySwitchCore(cv[2], evalKey);
-    cv[0] += (*ab)[0];
-    cv[1] += (*ab)[1];
+    cv[0] += ab[0];
+    cv[1] += ab[1];
     cv.resize(2);
 }
 
@@ -275,8 +275,8 @@ Ciphertext<Element> LeveledSHEBase<Element>::EvalSquareMutable(Ciphertext<Elemen
     auto& cv = csquare->GetElements();
 
     auto ab = csquare->GetCryptoContext()->GetScheme()->KeySwitchCore(cv[2], evalKey);
-    cv[0] += (*ab)[0];
-    cv[1] += (*ab)[1];
+    cv[0] += ab[0];
+    cv[1] += ab[1];
     cv.resize(2);
     return csquare;
 }
@@ -289,8 +289,8 @@ void LeveledSHEBase<Element>::EvalMultMutableInPlace(Ciphertext<Element>& cipher
     auto& cv = ciphertext1->GetElements();
 
     auto ab = ciphertext1->GetCryptoContext()->GetScheme()->KeySwitchCore(cv[2], evalKey);
-    cv[0] += (*ab)[0];
-    cv[1] += (*ab)[1];
+    cv[0] += ab[0];
+    cv[1] += ab[1];
     cv.resize(2);
 }
 
@@ -322,8 +322,8 @@ void LeveledSHEBase<Element>::RelinearizeInPlace(Ciphertext<Element>& ciphertext
 
     for (size_t j = 2; j < cv.size(); ++j) {
         auto ab = algo->KeySwitchCore(cv[j], evalKeyVec[j - 2]);
-        cv[0] += (*ab)[0];
-        cv[1] += (*ab)[1];
+        cv[0] += ab[0];
+        cv[1] += ab[1];
     }
     cv.resize(2);
 }
@@ -364,7 +364,7 @@ std::shared_ptr<std::map<uint32_t, EvalKey<Element>>> LeveledSHEBase<Element>::E
         (*evalKeys)[indx];
 
     const uint32_t sz = newIndices.size();
-#pragma omp parallel for
+#pragma omp parallel for num_threads(OpenFHEParallelControls.GetThreadLimit(sz))
     for (uint32_t i = 0; i < sz; ++i) {
         auto index = NativeInteger(newIndices[i]).ModInverse(M).ConvertToInt<uint32_t>();
         std::vector<uint32_t> vec(N);
@@ -442,6 +442,7 @@ Ciphertext<Element> LeveledSHEBase<Element>::EvalFastRotation(
     auto evalKeyIterator = evalKeyMap.find(autoIndex);
     if (evalKeyIterator == evalKeyMap.end())
         OPENFHE_THROW("EvalKey for index [" + std::to_string(autoIndex) + "] is not found.");
+    auto& evalKey = evalKeyIterator->second;
 
     const uint32_t N = cc->GetRingDimension();
     std::vector<uint32_t> vec(N);
@@ -449,14 +450,50 @@ Ciphertext<Element> LeveledSHEBase<Element>::EvalFastRotation(
 
     const auto& cv0 = ciphertext->GetElements()[0];
 
-    auto ba = *cc->GetScheme()->EvalFastKeySwitchCore(digits, evalKeyIterator->second, cv0.GetParams());
-    ba[0] += cv0;
-    ba[0] = ba[0].AutomorphismTransform(autoIndex, vec);
-    ba[1] = ba[1].AutomorphismTransform(autoIndex, vec);
+    const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersRNS>(evalKey->GetCryptoParameters());
 
-    auto result = ciphertext->CloneEmpty();
-    result->SetElements(std::move(ba));
-    return result;
+    if (cryptoParams->GetKeySwitchTechnique() == HYBRID) {
+        //  This branch trades slightly higher complexity for significant performance boost on GPU backend
+
+        const PlaintextModulus t = (cryptoParams->GetNoiseScale() == 1) ? 0 : cryptoParams->GetPlaintextModulus();
+
+        auto ba = cc->GetScheme()->EvalFastKeySwitchCoreExt(digits, evalKey, cv0.GetParams());
+
+        // ba[0] += cv[0] * P;
+        uint32_t sizeQ = cv0.GetNumOfElements();
+#pragma omp parallel for num_threads(OpenFHEParallelControls.GetThreadLimit(sizeQ))
+        for (uint32_t i = 0; i < sizeQ; ++i)
+            ba[0].GetAllElements()[i] += (cv0.GetAllElements()[i] * cryptoParams->GetPModq()[i]);
+
+        ba[0] = ba[0]
+                    .AutomorphismTransform(autoIndex, vec)
+                    .ApproxModDown(cv0.GetParams(), cryptoParams->GetParamsP(), cryptoParams->GetPInvModq(),
+                                   cryptoParams->GetPInvModqPrecon(), cryptoParams->GetPHatInvModp(),
+                                   cryptoParams->GetPHatInvModpPrecon(), cryptoParams->GetPHatModq(),
+                                   cryptoParams->GetModqBarrettMu(), cryptoParams->GettInvModp(),
+                                   cryptoParams->GettInvModpPrecon(), t, cryptoParams->GettModqPrecon());
+        ba[1] = ba[1]
+                    .AutomorphismTransform(autoIndex, vec)
+                    .ApproxModDown(cv0.GetParams(), cryptoParams->GetParamsP(), cryptoParams->GetPInvModq(),
+                                   cryptoParams->GetPInvModqPrecon(), cryptoParams->GetPHatInvModp(),
+                                   cryptoParams->GetPHatInvModpPrecon(), cryptoParams->GetPHatModq(),
+                                   cryptoParams->GetModqBarrettMu(), cryptoParams->GettInvModp(),
+                                   cryptoParams->GettInvModpPrecon(), t, cryptoParams->GettModqPrecon());
+
+        auto result = ciphertext->CloneEmpty();
+        result->SetElements(std::move(ba));
+        return result;
+    }
+    else {
+        auto ba = cc->GetScheme()->EvalFastKeySwitchCore(digits, evalKey, cv0.GetParams());
+        ba[0] += cv0;
+        ba[0] = ba[0].AutomorphismTransform(autoIndex, vec);
+        ba[1] = ba[1].AutomorphismTransform(autoIndex, vec);
+
+        auto result = ciphertext->CloneEmpty();
+        result->SetElements(std::move(ba));
+        return result;
+    }
 }
 
 template <class Element>


### PR DESCRIPTION
Modified the implementation of EvalFastRotation() for Hybrid Keyswitching to invert the order of ModDown() and AutomorphismTransform() as described in equation 11 of [KLK+22](https://ieeexplore.ieee.org/document/9923889). The change trades slightly higher computation for better memory performance and a significant performance boost on GPU backends. Other optimizations within KeySwitchCore lead to faster performance than the previous implementation.