### PR TITLE
Add API for serializing/deserializing bootstrapping keys

### DIFF
--- a/src/pke/examples/ckks-bootstrap-keys-serial.cpp
+++ b/src/pke/examples/ckks-bootstrap-keys-serial.cpp
@@ -127,7 +127,8 @@ int main() {
 
     std::ofstream bootstrapKeyOut(DATAFOLDER + bootstrapKeyLocation, std::ios::out | std::ios::binary);
     ErrorCheck(bootstrapKeyOut.is_open(), "Error opening bootstrap eval-key output file");
-    ErrorCheck(serverCC->SerializeEvalBootstrapKey(bootstrapKeyOut, SerType::BINARY, keyPair.secretKey, numSlots),
+    ErrorCheck(serverCC->SerializeEvalBootstrapKey(bootstrapKeyOut, SerType::BINARY, serverCC,
+                                                   keyPair.secretKey->GetKeyTag(), numSlots),
                "Error serializing bootstrap eval keys");
     bootstrapKeyOut.close();
 
@@ -148,6 +149,8 @@ int main() {
                "Error deserializing secret key");
     ErrorCheck(Serial::DeserializeFromFile(DATAFOLDER + ciphertextLocation, clientCiphertext, SerType::BINARY),
                "Error deserializing ciphertext");
+    clientCC->EvalBootstrapSetup(levelBudget, {0, 0}, numSlots);
+    const auto bootstrapKeyIndices = clientCC->GetScheme()->EvalBootstrapKeyMapIndices(clientCC, numSlots);
 
     std::ifstream multKeyIn(DATAFOLDER + multKeyLocation, std::ios::in | std::ios::binary);
     ErrorCheck(multKeyIn.is_open(), "Error opening eval-mult key input file");
@@ -156,11 +159,17 @@ int main() {
 
     std::ifstream bootstrapKeyIn(DATAFOLDER + bootstrapKeyLocation, std::ios::in | std::ios::binary);
     ErrorCheck(bootstrapKeyIn.is_open(), "Error opening bootstrap eval-key input file");
-    ErrorCheck(clientCC->DeserializeEvalAutomorphismKey(bootstrapKeyIn, SerType::BINARY),
+    ErrorCheck(clientCC->DeserializeEvalBootstrapKey(bootstrapKeyIn, SerType::BINARY, clientCC,
+                                                     secretKey->GetKeyTag(), numSlots),
                "Error deserializing bootstrap eval keys");
     bootstrapKeyIn.close();
 
-    clientCC->EvalBootstrapSetup(levelBudget, {0, 0}, numSlots);
+    std::ifstream bootstrapKeyInByIndex(DATAFOLDER + bootstrapKeyLocation, std::ios::in | std::ios::binary);
+    ErrorCheck(bootstrapKeyInByIndex.is_open(), "Error opening bootstrap eval-key input file");
+    ErrorCheck(clientCC->DeserializeEvalBootstrapKey(bootstrapKeyInByIndex, SerType::BINARY, secretKey->GetKeyTag(),
+                                                     bootstrapKeyIndices),
+               "Error deserializing bootstrap eval keys by index list");
+    bootstrapKeyInByIndex.close();
 
     auto ciphertextAfter = clientCC->EvalBootstrap(clientCiphertext);
 

--- a/src/pke/examples/ckks-bootstrap-keys-serial.cpp
+++ b/src/pke/examples/ckks-bootstrap-keys-serial.cpp
@@ -1,0 +1,177 @@
+//==================================================================================
+// BSD 2-Clause License
+//
+// Copyright (c) 2014-2026, NJIT, Duality Technologies Inc. and other contributors
+//
+// All rights reserved.
+//
+// Author TPOC: contact@openfhe.org
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//==================================================================================
+
+/*
+  Example for serializing and deserializing CKKS bootstrap evaluation keys.
+ */
+
+#include "openfhe.h"
+
+// Header files needed for serialization
+#include "ciphertext-ser.h"
+#include "cryptocontext-ser.h"
+#include "key/key-ser.h"
+#include "scheme/ckksrns/ckksrns-ser.h"
+
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+using namespace lbcrypto;
+
+const std::string DATAFOLDER           = "demoData";
+const std::string ccLocation           = "/bootstrap-cryptocontext.txt";
+const std::string publicKeyLocation    = "/bootstrap-public-key.txt";
+const std::string secretKeyLocation    = "/bootstrap-secret-key.txt";
+const std::string ciphertextLocation   = "/bootstrap-ciphertext.txt";
+const std::string multKeyLocation      = "/bootstrap-eval-mult-keys.txt";
+const std::string bootstrapKeyLocation = "/bootstrap-eval-keys.txt";
+
+void ErrorCheck(bool condition, const std::string& message) {
+    if (!condition) {
+        std::cerr << message << std::endl;
+        std::exit(1);
+    }
+}
+
+int main() {
+    std::cout << "This program requires the `" << DATAFOLDER << "' directory to exist." << std::endl;
+
+    CCParams<CryptoContextCKKSRNS> parameters;
+    SecretKeyDist secretKeyDist = UNIFORM_TERNARY;
+    parameters.SetSecretKeyDist(secretKeyDist);
+    parameters.SetSecurityLevel(HEStd_NotSet);
+    parameters.SetRingDim(1 << 12);
+
+#if NATIVEINT == 128
+    ScalingTechnique rescaleTech = FIXEDAUTO;
+    uint32_t dcrtBits            = 78;
+    uint32_t firstMod            = 89;
+#else
+    ScalingTechnique rescaleTech = FLEXIBLEAUTO;
+    uint32_t dcrtBits            = 59;
+    uint32_t firstMod            = 60;
+#endif
+
+    parameters.SetScalingModSize(dcrtBits);
+    parameters.SetScalingTechnique(rescaleTech);
+    parameters.SetFirstModSize(firstMod);
+
+    std::vector<uint32_t> levelBudget      = {4, 4};
+    uint32_t levelsAvailableAfterBootstrap = 10;
+    uint32_t depth = levelsAvailableAfterBootstrap + FHECKKSRNS::GetBootstrapDepth(levelBudget, secretKeyDist);
+    parameters.SetMultiplicativeDepth(depth);
+
+    CryptoContext<DCRTPoly> serverCC = GenCryptoContext(parameters);
+    serverCC->Enable(PKE);
+    serverCC->Enable(KEYSWITCH);
+    serverCC->Enable(LEVELEDSHE);
+    serverCC->Enable(ADVANCEDSHE);
+    serverCC->Enable(FHE);
+
+    uint32_t numSlots = serverCC->GetRingDimension() / 2;
+    serverCC->EvalBootstrapSetup(levelBudget, {0, 0}, numSlots);
+
+    auto keyPair = serverCC->KeyGen();
+    serverCC->EvalMultKeyGen(keyPair.secretKey);
+    serverCC->EvalBootstrapKeyGen(keyPair.secretKey, numSlots);
+
+    std::vector<double> x = {0.25, 0.5, 0.75, 1.0};
+    auto plaintext        = serverCC->MakeCKKSPackedPlaintext(x, 1, depth - 1);
+    plaintext->SetLength(x.size());
+    auto ciphertext = serverCC->Encrypt(keyPair.publicKey, plaintext);
+
+    ErrorCheck(Serial::SerializeToFile(DATAFOLDER + ccLocation, serverCC, SerType::BINARY),
+               "Error serializing crypto context");
+    ErrorCheck(Serial::SerializeToFile(DATAFOLDER + publicKeyLocation, keyPair.publicKey, SerType::BINARY),
+               "Error serializing public key");
+    ErrorCheck(Serial::SerializeToFile(DATAFOLDER + secretKeyLocation, keyPair.secretKey, SerType::BINARY),
+               "Error serializing secret key");
+    ErrorCheck(Serial::SerializeToFile(DATAFOLDER + ciphertextLocation, ciphertext, SerType::BINARY),
+               "Error serializing ciphertext");
+
+    std::ofstream multKeyOut(DATAFOLDER + multKeyLocation, std::ios::out | std::ios::binary);
+    ErrorCheck(multKeyOut.is_open(), "Error opening eval-mult key output file");
+    ErrorCheck(serverCC->SerializeEvalMultKey(multKeyOut, SerType::BINARY), "Error serializing eval-mult keys");
+    multKeyOut.close();
+
+    std::ofstream bootstrapKeyOut(DATAFOLDER + bootstrapKeyLocation, std::ios::out | std::ios::binary);
+    ErrorCheck(bootstrapKeyOut.is_open(), "Error opening bootstrap eval-key output file");
+    ErrorCheck(serverCC->SerializeEvalBootstrapKey(bootstrapKeyOut, SerType::BINARY, keyPair.secretKey, numSlots),
+               "Error serializing bootstrap eval keys");
+    bootstrapKeyOut.close();
+
+    serverCC->ClearEvalMultKeys();
+    serverCC->ClearEvalAutomorphismKeys();
+    CryptoContextFactory<DCRTPoly>::ReleaseAllContexts();
+
+    CryptoContext<DCRTPoly> clientCC;
+    PublicKey<DCRTPoly> publicKey;
+    PrivateKey<DCRTPoly> secretKey;
+    Ciphertext<DCRTPoly> clientCiphertext;
+
+    ErrorCheck(Serial::DeserializeFromFile(DATAFOLDER + ccLocation, clientCC, SerType::BINARY),
+               "Error deserializing crypto context");
+    ErrorCheck(Serial::DeserializeFromFile(DATAFOLDER + publicKeyLocation, publicKey, SerType::BINARY),
+               "Error deserializing public key");
+    ErrorCheck(Serial::DeserializeFromFile(DATAFOLDER + secretKeyLocation, secretKey, SerType::BINARY),
+               "Error deserializing secret key");
+    ErrorCheck(Serial::DeserializeFromFile(DATAFOLDER + ciphertextLocation, clientCiphertext, SerType::BINARY),
+               "Error deserializing ciphertext");
+
+    std::ifstream multKeyIn(DATAFOLDER + multKeyLocation, std::ios::in | std::ios::binary);
+    ErrorCheck(multKeyIn.is_open(), "Error opening eval-mult key input file");
+    ErrorCheck(clientCC->DeserializeEvalMultKey(multKeyIn, SerType::BINARY), "Error deserializing eval-mult keys");
+    multKeyIn.close();
+
+    std::ifstream bootstrapKeyIn(DATAFOLDER + bootstrapKeyLocation, std::ios::in | std::ios::binary);
+    ErrorCheck(bootstrapKeyIn.is_open(), "Error opening bootstrap eval-key input file");
+    ErrorCheck(clientCC->DeserializeEvalAutomorphismKey(bootstrapKeyIn, SerType::BINARY),
+               "Error deserializing bootstrap eval keys");
+    bootstrapKeyIn.close();
+
+    clientCC->EvalBootstrapSetup(levelBudget, {0, 0}, numSlots);
+
+    auto ciphertextAfter = clientCC->EvalBootstrap(clientCiphertext);
+
+    Plaintext result;
+    clientCC->Decrypt(secretKey, ciphertextAfter, &result);
+    result->SetLength(x.size());
+
+    std::cout << "Input: " << plaintext << std::endl;
+    std::cout << "Output after deserialized-key bootstrapping: " << result << std::endl;
+
+    clientCC->ClearStaticMapsAndVectors();
+
+    return 0;
+}

--- a/src/pke/include/cryptocontext.h
+++ b/src/pke/include/cryptocontext.h
@@ -866,7 +866,7 @@ public:
     * @return true on success
     */
     template <typename ST>
-    static bool DeserializeEvalAutomorphismKey(std::ostream& ser, const ST& sertype, const std::string& keyTag,
+    static bool DeserializeEvalAutomorphismKey(std::istream& ser, const ST& sertype, const std::string& keyTag,
                                                const std::vector<uint32_t>& indexList) {
         if (indexList.empty())
             OPENFHE_THROW("indexList may not be empty");
@@ -884,8 +884,8 @@ public:
         // create a new map with evalkeys for the specified indices
         std::map<uint32_t, EvalKey<Element>> newMap;
         for (const uint32_t indx : indexList) {
-            const auto& key = keyMapIt->find(indx);
-            if (key == keyMapIt->end()) {
+            const auto& key = keyMapIt->second->find(indx);
+            if (key == keyMapIt->second->end()) {
                 OPENFHE_THROW("No automorphism key generated for index [" + std::to_string(indx) + "] within keyTag [" +
                               keyTag + "].");
             }
@@ -896,6 +896,42 @@ public:
             std::make_shared<std::map<uint32_t, EvalKey<Element>>>(newMap), keyTag);
 
         return true;
+    }
+
+    /**
+    * @brief Serializes EvalAutomorphism keys for an array of specific indices associated with the given keyTag
+    *
+    * @param ser stream to serialize to
+    * @param sertype type of serialization
+    * @param privateKey secret key
+    * @param slots number of slots for which the bootstrapping is performed
+    */
+    template <typename ST>
+    static bool SerializeEvalBootstrapKey(std::ostream& ser, const ST& sertype, const PrivateKey<DCRTPoly>& privateKey,
+                                          uint32_t slots) {
+        auto cc              = privateKey->GetCryptoContext();
+        const auto& keyTag   = privateKey->GetKeyTag();
+        const auto indexList = cc->GetScheme()->EvalBootstrapKeyMapIndices(privateKey, slots);
+        std::map<std::string, std::shared_ptr<std::map<uint32_t, EvalKey<Element>>>> keyMap = {
+            {keyTag, CryptoContextImpl<Element>::GetPartialEvalAutomorphismKeyMapPtr(keyTag, indexList)}};
+
+        Serial::Serialize(keyMap, ser, sertype);
+
+        return true;
+    }
+    /**
+    * @brief Deserializes EvalAutomorphism keys for an array of specific indices associated with the given keyTag
+    *
+    * @param ser stream to deserialize from
+    * @param sertype type of serialization
+    * @param keyTag secret key tag
+    * @param indexList array of specific indices to deserialize keys for
+    * @return true on success
+    */
+    template <typename ST>
+    static bool DeserializeEvalBootstrapKey(std::istream& ser, const ST& sertype, const std::string& keyTag,
+                                            const std::vector<uint32_t>& indexList) {
+        return CryptoContextImpl<Element>::DeserializeEvalAutomorphismKey(ser, sertype, keyTag, indexList);
     }
 
     /**
@@ -918,6 +954,18 @@ public:
             CryptoContextImpl<Element>::InsertEvalAutomorphismKey(k.second, k.first);
         }
         return true;
+    }
+
+    /**
+    * @brief Deserializes all bootstrap (and possibly all other EvalAutomorphism) keys from the stream
+    *
+    * @param ser stream to deserialize from
+    * @param sertype type of serialization
+    * @return true on success
+    */
+    template <typename ST>
+    static bool DeserializeEvalBootstrapKey(std::istream& ser, const ST& sertype) {
+        return CryptoContextImpl<Element>::DeserializeEvalAutomorphismKey(ser, sertype);
     }
 
     /**

--- a/src/pke/include/cryptocontext.h
+++ b/src/pke/include/cryptocontext.h
@@ -899,7 +899,7 @@ public:
     }
 
     /**
-    * @brief Serializes EvalAutomorphism keys for an array of specific indices associated with the given keyTag
+    * @brief Serializes bootstrap EvalAutomorphism keys associated with the private key tag
     *
     * @param ser stream to serialize to
     * @param sertype type of serialization
@@ -920,7 +920,7 @@ public:
         return true;
     }
     /**
-    * @brief Deserializes EvalAutomorphism keys for an array of specific indices associated with the given keyTag
+    * @brief Deserializes bootstrap EvalAutomorphism keys for an array of specific indices associated with the given keyTag
     *
     * @param ser stream to deserialize from
     * @param sertype type of serialization
@@ -931,6 +931,24 @@ public:
     template <typename ST>
     static bool DeserializeEvalBootstrapKey(std::istream& ser, const ST& sertype, const std::string& keyTag,
                                             const std::vector<uint32_t>& indexList) {
+        return CryptoContextImpl<Element>::DeserializeEvalAutomorphismKey(ser, sertype, keyTag, indexList);
+    }
+
+    /**
+    * @brief Deserializes bootstrap EvalAutomorphism keys derived from the given private key and slots count
+    *
+    * @param ser stream to deserialize from
+    * @param sertype type of serialization
+    * @param privateKey secret key (used to derive keyTag and index list)
+    * @param slots number of slots for which the bootstrapping was performed
+    * @return true on success
+    */
+    template <typename ST>
+    static bool DeserializeEvalBootstrapKey(std::istream& ser, const ST& sertype,
+                                            const PrivateKey<DCRTPoly>& privateKey, uint32_t slots) {
+        auto cc              = privateKey->GetCryptoContext();
+        const auto& keyTag   = privateKey->GetKeyTag();
+        const auto indexList = cc->GetScheme()->EvalBootstrapKeyMapIndices(privateKey, slots);
         return CryptoContextImpl<Element>::DeserializeEvalAutomorphismKey(ser, sertype, keyTag, indexList);
     }
 
@@ -954,18 +972,6 @@ public:
             CryptoContextImpl<Element>::InsertEvalAutomorphismKey(k.second, k.first);
         }
         return true;
-    }
-
-    /**
-    * @brief Deserializes all bootstrap (and possibly all other EvalAutomorphism) keys from the stream
-    *
-    * @param ser stream to deserialize from
-    * @param sertype type of serialization
-    * @return true on success
-    */
-    template <typename ST>
-    static bool DeserializeEvalBootstrapKey(std::istream& ser, const ST& sertype) {
-        return CryptoContextImpl<Element>::DeserializeEvalAutomorphismKey(ser, sertype);
     }
 
     /**

--- a/src/pke/include/cryptocontext.h
+++ b/src/pke/include/cryptocontext.h
@@ -899,19 +899,18 @@ public:
     }
 
     /**
-    * @brief Serializes bootstrap EvalAutomorphism keys associated with the private key tag
+    * @brief Serializes bootstrap EvalAutomorphism keys associated with the given key tag
     *
     * @param ser stream to serialize to
     * @param sertype type of serialization
-    * @param privateKey secret key
+    * @param cc crypto context
+    * @param keyTag secret key tag
     * @param slots number of slots for which the bootstrapping is performed
     */
     template <typename ST>
-    static bool SerializeEvalBootstrapKey(std::ostream& ser, const ST& sertype, const PrivateKey<DCRTPoly>& privateKey,
-                                          uint32_t slots) {
-        auto cc              = privateKey->GetCryptoContext();
-        const auto& keyTag   = privateKey->GetKeyTag();
-        const auto indexList = cc->GetScheme()->EvalBootstrapKeyMapIndices(privateKey, slots);
+    static bool SerializeEvalBootstrapKey(std::ostream& ser, const ST& sertype, const CryptoContext<Element>& cc,
+                                          const std::string& keyTag, uint32_t slots) {
+        const auto indexList = cc->GetScheme()->EvalBootstrapKeyMapIndices(cc, slots);
         std::map<std::string, std::shared_ptr<std::map<uint32_t, EvalKey<Element>>>> keyMap = {
             {keyTag, CryptoContextImpl<Element>::GetPartialEvalAutomorphismKeyMapPtr(keyTag, indexList)}};
 
@@ -935,20 +934,19 @@ public:
     }
 
     /**
-    * @brief Deserializes bootstrap EvalAutomorphism keys derived from the given private key and slots count
+    * @brief Deserializes bootstrap EvalAutomorphism keys derived from the given crypto context, key tag, and slots count
     *
     * @param ser stream to deserialize from
     * @param sertype type of serialization
-    * @param privateKey secret key (used to derive keyTag and index list)
+    * @param cc crypto context
+    * @param keyTag secret key tag
     * @param slots number of slots for which the bootstrapping was performed
     * @return true on success
     */
     template <typename ST>
-    static bool DeserializeEvalBootstrapKey(std::istream& ser, const ST& sertype,
-                                            const PrivateKey<DCRTPoly>& privateKey, uint32_t slots) {
-        auto cc              = privateKey->GetCryptoContext();
-        const auto& keyTag   = privateKey->GetKeyTag();
-        const auto indexList = cc->GetScheme()->EvalBootstrapKeyMapIndices(privateKey, slots);
+    static bool DeserializeEvalBootstrapKey(std::istream& ser, const ST& sertype, const CryptoContext<Element>& cc,
+                                            const std::string& keyTag, uint32_t slots) {
+        const auto indexList = cc->GetScheme()->EvalBootstrapKeyMapIndices(cc, slots);
         return CryptoContextImpl<Element>::DeserializeEvalAutomorphismKey(ser, sertype, keyTag, indexList);
     }
 

--- a/src/pke/include/scheme/ckksrns/ckksrns-fhe.h
+++ b/src/pke/include/scheme/ckksrns/ckksrns-fhe.h
@@ -150,6 +150,8 @@ public:
     std::shared_ptr<std::map<uint32_t, EvalKey<DCRTPoly>>> EvalBootstrapKeyGen(const PrivateKey<DCRTPoly> privateKey,
                                                                                uint32_t slots) override;
 
+    std::vector<uint32_t> EvalBootstrapKeyMapIndices(const PrivateKey<DCRTPoly> privateKey, uint32_t slots) override;
+
     void EvalBootstrapPrecompute(const CryptoContextImpl<DCRTPoly>& cc, uint32_t slots) override;
 
     Ciphertext<DCRTPoly> EvalBootstrap(ConstCiphertext<DCRTPoly>& ciphertext, uint32_t numIterations,

--- a/src/pke/include/scheme/ckksrns/ckksrns-fhe.h
+++ b/src/pke/include/scheme/ckksrns/ckksrns-fhe.h
@@ -150,7 +150,7 @@ public:
     std::shared_ptr<std::map<uint32_t, EvalKey<DCRTPoly>>> EvalBootstrapKeyGen(const PrivateKey<DCRTPoly> privateKey,
                                                                                uint32_t slots) override;
 
-    std::vector<uint32_t> EvalBootstrapKeyMapIndices(const PrivateKey<DCRTPoly> privateKey, uint32_t slots) override;
+    std::vector<uint32_t> EvalBootstrapKeyMapIndices(const CryptoContext<DCRTPoly>& cc, uint32_t slots) override;
 
     void EvalBootstrapPrecompute(const CryptoContextImpl<DCRTPoly>& cc, uint32_t slots) override;
 

--- a/src/pke/include/schemebase/base-fhe.h
+++ b/src/pke/include/schemebase/base-fhe.h
@@ -108,6 +108,17 @@ public:
     }
 
     /**
+   * Returns the eval-key map indices required to serialize bootstrap keys.
+   *
+   * @param privateKey private key.
+   * @param slots - number of slots to be bootstrapped
+   * @return the list of eval-key map indices.
+   */
+    virtual std::vector<uint32_t> EvalBootstrapKeyMapIndices(const PrivateKey<Element> privateKey, uint32_t slots) {
+        OPENFHE_THROW(NOT_SUPPORTED_SIMPLE_ERROR);
+    }
+
+    /**
    * Computes the plaintexts for encoding and decoding for both linear and FFT-like methods. Supported in CKKS only.
    *
    * @param slots - number of slots to be bootstrapped

--- a/src/pke/include/schemebase/base-fhe.h
+++ b/src/pke/include/schemebase/base-fhe.h
@@ -110,11 +110,11 @@ public:
     /**
    * Returns the eval-key map indices required to serialize bootstrap keys.
    *
-   * @param privateKey private key.
+   * @param cc crypto context.
    * @param slots - number of slots to be bootstrapped
    * @return the list of eval-key map indices.
    */
-    virtual std::vector<uint32_t> EvalBootstrapKeyMapIndices(const PrivateKey<Element> privateKey, uint32_t slots) {
+    virtual std::vector<uint32_t> EvalBootstrapKeyMapIndices(const CryptoContext<Element>& cc, uint32_t slots) {
         OPENFHE_THROW(NOT_SUPPORTED_SIMPLE_ERROR);
     }
 

--- a/src/pke/include/schemebase/base-scheme.h
+++ b/src/pke/include/schemebase/base-scheme.h
@@ -1152,9 +1152,9 @@ public:
         return m_FHE->EvalBootstrapKeyGen(privateKey, slots);
     }
 
-    std::vector<uint32_t> EvalBootstrapKeyMapIndices(const PrivateKey<Element> privateKey, uint32_t slots) {
+    std::vector<uint32_t> EvalBootstrapKeyMapIndices(const CryptoContext<Element>& cc, uint32_t slots) {
         VerifyFHEEnabled(__func__);
-        return m_FHE->EvalBootstrapKeyMapIndices(privateKey, slots);
+        return m_FHE->EvalBootstrapKeyMapIndices(cc, slots);
     }
 
     void EvalBootstrapPrecompute(const CryptoContextImpl<Element>& cc, uint32_t slots = 0) {

--- a/src/pke/include/schemebase/base-scheme.h
+++ b/src/pke/include/schemebase/base-scheme.h
@@ -1152,6 +1152,11 @@ public:
         return m_FHE->EvalBootstrapKeyGen(privateKey, slots);
     }
 
+    std::vector<uint32_t> EvalBootstrapKeyMapIndices(const PrivateKey<Element> privateKey, uint32_t slots) {
+        VerifyFHEEnabled(__func__);
+        return m_FHE->EvalBootstrapKeyMapIndices(privateKey, slots);
+    }
+
     void EvalBootstrapPrecompute(const CryptoContextImpl<Element>& cc, uint32_t slots = 0) {
         VerifyFHEEnabled(__func__);
         m_FHE->EvalBootstrapPrecompute(cc, slots);

--- a/src/pke/lib/scheme/ckksrns/ckksrns-fhe.cpp
+++ b/src/pke/lib/scheme/ckksrns/ckksrns-fhe.cpp
@@ -299,20 +299,19 @@ std::shared_ptr<std::map<uint32_t, EvalKey<DCRTPoly>>> FHECKKSRNS::EvalBootstrap
     return evalKeys;
 }
 
-std::vector<uint32_t> FHECKKSRNS::EvalBootstrapKeyMapIndices(const PrivateKey<DCRTPoly> privateKey, uint32_t slots) {
-    const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersCKKSRNS>(privateKey->GetCryptoParameters());
+std::vector<uint32_t> FHECKKSRNS::EvalBootstrapKeyMapIndices(const CryptoContext<DCRTPoly>& cc, uint32_t slots) {
+    const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersCKKSRNS>(cc->GetCryptoParameters());
     if (!cryptoParams)
         OPENFHE_THROW("Invalid crypto parameters: expected CryptoParametersCKKSRNS");
 
-    auto cc = privateKey->GetCryptoContext();
     auto M  = cc->GetCyclotomicOrder();
 
     slots                         = (slots == 0) ? M / 4 : slots;
-    const auto bootstrapRotations = FindBootstrapRotationIndices(slots, M);
+    const auto bootstrapRotationsIndices = FindBootstrapRotationIndices(slots, M);
 
     std::set<uint32_t> indexList;
-    for (const auto rotation : bootstrapRotations)
-        indexList.insert(FindAutomorphismIndex2nComplex(rotation, M));
+    for (const auto rotationIndex : bootstrapRotationsIndices)
+        indexList.insert(FindAutomorphismIndex2nComplex(rotationIndex, M));
 
     indexList.insert(M - 1);
 

--- a/src/pke/lib/scheme/ckksrns/ckksrns-fhe.cpp
+++ b/src/pke/lib/scheme/ckksrns/ckksrns-fhe.cpp
@@ -299,6 +299,35 @@ std::shared_ptr<std::map<uint32_t, EvalKey<DCRTPoly>>> FHECKKSRNS::EvalBootstrap
     return evalKeys;
 }
 
+std::vector<uint32_t> FHECKKSRNS::EvalBootstrapKeyMapIndices(const PrivateKey<DCRTPoly> privateKey, uint32_t slots) {
+    const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersCKKSRNS>(privateKey->GetCryptoParameters());
+    if (!cryptoParams)
+        OPENFHE_THROW("Invalid crypto parameters: expected CryptoParametersCKKSRNS");
+
+    auto cc = privateKey->GetCryptoContext();
+    auto M  = cc->GetCyclotomicOrder();
+
+    slots                         = (slots == 0) ? M / 4 : slots;
+    const auto bootstrapRotations = FindBootstrapRotationIndices(slots, M);
+
+    std::vector<uint32_t> indexList;
+    indexList.reserve(bootstrapRotations.size() + 3);
+    for (const auto rotation : bootstrapRotations)
+        indexList.push_back(FindAutomorphismIndex2nComplex(rotation, M));
+
+    indexList.push_back(M - 1);
+
+    if (cryptoParams->GetSecretKeyDist() == SPARSE_ENCAPSULATED) {
+        indexList.push_back(M - 2);
+        indexList.push_back(M - 4);
+    }
+
+    std::sort(indexList.begin(), indexList.end());
+    indexList.erase(std::unique(indexList.begin(), indexList.end()), indexList.end());
+
+    return indexList;
+}
+
 void FHECKKSRNS::EvalBootstrapPrecompute(const CryptoContextImpl<DCRTPoly>& cc, uint32_t numSlots) {
     const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersCKKSRNS>(cc.GetCryptoParameters());
 

--- a/src/pke/lib/scheme/ckksrns/ckksrns-fhe.cpp
+++ b/src/pke/lib/scheme/ckksrns/ckksrns-fhe.cpp
@@ -310,22 +310,18 @@ std::vector<uint32_t> FHECKKSRNS::EvalBootstrapKeyMapIndices(const PrivateKey<DC
     slots                         = (slots == 0) ? M / 4 : slots;
     const auto bootstrapRotations = FindBootstrapRotationIndices(slots, M);
 
-    std::vector<uint32_t> indexList;
-    indexList.reserve(bootstrapRotations.size() + 3);
+    std::set<uint32_t> indexList;
     for (const auto rotation : bootstrapRotations)
-        indexList.push_back(FindAutomorphismIndex2nComplex(rotation, M));
+        indexList.insert(FindAutomorphismIndex2nComplex(rotation, M));
 
-    indexList.push_back(M - 1);
+    indexList.insert(M - 1);
 
     if (cryptoParams->GetSecretKeyDist() == SPARSE_ENCAPSULATED) {
-        indexList.push_back(M - 2);
-        indexList.push_back(M - 4);
+        indexList.insert(M - 2);
+        indexList.insert(M - 4);
     }
 
-    std::sort(indexList.begin(), indexList.end());
-    indexList.erase(std::unique(indexList.begin(), indexList.end()), indexList.end());
-
-    return indexList;
+    return std::vector<uint32_t>(indexList.begin(), indexList.end());
 }
 
 void FHECKKSRNS::EvalBootstrapPrecompute(const CryptoContextImpl<DCRTPoly>& cc, uint32_t numSlots) {

--- a/src/pke/unittest/utckksrns/UnitTestCKKSrnsCompositeScalingBootstrap.cpp
+++ b/src/pke/unittest/utckksrns/UnitTestCKKSrnsCompositeScalingBootstrap.cpp
@@ -54,6 +54,7 @@ enum TEST_CASE_TYPE : int {
     BOOTSTRAP_ITERATIVE,
     BOOTSTRAP_NUM_TOWERS,
     BOOTSTRAP_SERIALIZE,
+    BOOTSTRAP_KEY_SERIALIZE,
 };
 
 static std::ostream& operator<<(std::ostream& os, const TEST_CASE_TYPE& type) {
@@ -79,6 +80,9 @@ static std::ostream& operator<<(std::ostream& os, const TEST_CASE_TYPE& type) {
             break;
         case BOOTSTRAP_SERIALIZE:
             typeName = "BOOTSTRAP_SERIALIZE";
+            break;
+        case BOOTSTRAP_KEY_SERIALIZE:
+            typeName = "BOOTSTRAP_KEY_SERIALIZE";
             break;
         default:
             typeName = "UNKNOWN";
@@ -136,68 +140,57 @@ constexpr uint32_t FMODSIZED2 = 60;
 
 // clang-format off
 static std::vector<TEST_CASE_UTCKKSRNSCS_BOOT> testCases = {
-    // TestType,     Descr, Scheme,          RDim, MultDepth,  SModSize,     DSize, BatchSz, SecKeyDist,      MaxRelinSkDeg, FModSize,  SecLvl,       KSTech, ScalTech,        LDigits,      PtMod, StdDev, EvalAddCt, KSCt, MultTech, EncTech, PREMode, multipartyMode, decryptionNoiseMode, executionMode, noiseEstimate, registerWordSize, compositeDegree, LvLBudget, Dim1,       Slots
-    { BOOTSTRAP_FULL, "01", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH, SMODSIZED2,     DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,          FMODSIZED2,  HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,       NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT, DFLT, DFLT, DFLT, DFLT, 32, DFLT},   { 1, 1 },  { 32, 32 }, RDIM/2 },
-    { BOOTSTRAP_FULL, "02", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH, SMODSIZED3,     DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,          FMODSIZED3,  HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,       NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT, DFLT, DFLT, DFLT, DFLT, 32, DFLT},   { 1, 1 },  { 32, 32 }, RDIM/2 },
+    // TestType,      Descr, Scheme,         RDim, MultDepth,  SModSize,   DSize, BatchSz, SecKeyDist,      MaxRelinSkDeg, FModSize,   SecLvl,       KSTech, ScalTech,               LDigits,      PtMod, StdDev, EvalAddCt, KSCt, MultTech, EncTech, PREMode, multipartyMode, decryptionNoiseMode, executionMode, noiseEstimate, registerWordSize, compositeDegree, LvLBudget, Dim1,       Slots
+    { BOOTSTRAP_FULL, "01", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH, SMODSIZED2, DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,          FMODSIZED2, HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,   NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT,    DFLT,           DFLT,                DFLT,          DFLT,          32,               DFLT},           { 1, 1 },  { 32, 32 }, RDIM/2 },
+    { BOOTSTRAP_FULL, "02", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH, SMODSIZED3, DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,          FMODSIZED3, HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,   NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT,    DFLT,           DFLT,                DFLT,          DFLT,          32,               DFLT},           { 1, 1 },  { 32, 32 }, RDIM/2 },
+    { BOOTSTRAP_FULL, "03", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH, SMODSIZED2, DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,          FMODSIZED2, HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,   NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT,    DFLT,           DFLT,                DFLT,          DFLT,          32,               DFLT},           { 3, 3 },  { 0, 0 },   RDIM/2 },
+    { BOOTSTRAP_FULL, "04", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH, SMODSIZED3, DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,          FMODSIZED3, HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,   NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT,    DFLT,           DFLT,                DFLT,          DFLT,          32,               DFLT},           { 3, 3 },  { 0, 0 },   RDIM/2 },
+    { BOOTSTRAP_FULL, "05", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH, SMODSIZED2, DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,          FMODSIZED2, HEStd_NotSet, HYBRID, COMPOSITESCALINGMANUAL, NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT,    DFLT,           DFLT,                DFLT,          DFLT,          30,               2},              { 3, 3 },  { 0, 0 },   RDIM/2 },
+    { BOOTSTRAP_FULL, "06", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH, SMODSIZED3, DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,          FMODSIZED3, HEStd_NotSet, HYBRID, COMPOSITESCALINGMANUAL, NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT,    DFLT,           DFLT,                DFLT,          DFLT,          30,               3},              { 3, 3 },  { 0, 0 },   RDIM/2 },
     // ==========================================
-    // TestType,     Descr, Scheme,          RDim, MultDepth,  SModSize,     DSize, BatchSz, SecKeyDist,      MaxRelinSkDeg, FModSize,  SecLvl,       KSTech, ScalTech,        LDigits,      PtMod, StdDev, EvalAddCt, KSCt, MultTech, EncTech, PREMode, multipartyMode, decryptionNoiseMode, executionMode, noiseEstimate, registerWordSize, compositeDegree, LvLBudget, Dim1,     Slots
-    { BOOTSTRAP_FULL, "11", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH, SMODSIZED2,     DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,          FMODSIZED2,  HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,       NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT, DFLT, DFLT, DFLT, DFLT, 32, DFLT},   { 3, 3 },  { 0, 0 }, RDIM/2 },
-    { BOOTSTRAP_FULL, "12", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH, SMODSIZED3,     DFLT,  DFLT,    UNIFORM_TERNARY,  DFLT,         FMODSIZED3,  HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,       NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT, DFLT, DFLT, DFLT, DFLT, 32, DFLT},   { 3, 3 },  { 0, 0 }, RDIM/2 },
-    // TestType,     Descr, Scheme,          RDim, MultDepth,  SModSize,     DSize, BatchSz, SecKeyDist,      MaxRelinSkDeg, FModSize,  SecLvl,       KSTech, ScalTech,        LDigits,      PtMod, StdDev, EvalAddCt, KSCt, MultTech, EncTech, PREMode, multipartyMode, decryptionNoiseMode, executionMode, noiseEstimate, registerWordSize, compositeDegree, LvlBudget, Dim1,     Slots
-    { BOOTSTRAP_FULL, "21", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH, SMODSIZED2,     DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,          FMODSIZED2,  HEStd_NotSet, HYBRID, COMPOSITESCALINGMANUAL,       NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT, DFLT, DFLT, DFLT, DFLT, 30, 2},   { 3, 3 },  { 0, 0 }, RDIM/2 },
-    { BOOTSTRAP_FULL, "22", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH, SMODSIZED3,     DFLT,  DFLT,    UNIFORM_TERNARY,  DFLT,         FMODSIZED3,  HEStd_NotSet, HYBRID, COMPOSITESCALINGMANUAL,       NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT, DFLT, DFLT, DFLT, DFLT, 30, 3},   { 3, 3 },  { 0, 0 }, RDIM/2 },
+    // TestType,      Descr, Scheme,         RDim, MultDepth,  SModSize,   DSize, BatchSz, SecKeyDist,      MaxRelinSkDeg, FModSize,   SecLvl,       KSTech, ScalTech,               LDigits,      PtMod, StdDev, EvalAddCt, KSCt, MultTech, EncTech, PREMode, multipartyMode, decryptionNoiseMode, executionMode, noiseEstimate, registerWordSize, compositeDegree, LvLBudget, Dim1,     Slots
+    { BOOTSTRAP_EDGE, "01", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH, SMODSIZED2, DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,          FMODSIZED2, HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,   NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT,    DFLT,           DFLT,                DFLT,          DFLT,          32,               DFLT},           { 1, 1 },  { 0, 0 },   RDIM/4 },
+    { BOOTSTRAP_EDGE, "02", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH, SMODSIZED3, DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,          FMODSIZED3, HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,   NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT,    DFLT,           DFLT,                DFLT,          DFLT,          32,               DFLT},           { 1, 1 },  { 0, 0 },   RDIM/4 },
+    { BOOTSTRAP_EDGE, "03", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH, SMODSIZED2, DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,          FMODSIZED2, HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,   NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT,    DFLT,           DFLT,                DFLT,          DFLT,          32,               DFLT},           { 2, 2 },  { 0, 0 },   RDIM/4 },
+    { BOOTSTRAP_EDGE, "04", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH, SMODSIZED3, DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,          FMODSIZED3, HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,   NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT,    DFLT,           DFLT,                DFLT,          DFLT,          32,               DFLT},           { 2, 2 },  { 0, 0 },   RDIM/4 },
     // ==========================================
-    // TestType,      Descr, Scheme,          RDim, MultDepth,  SModSize,     DSize, BatchSz, SecKeyDist,      MaxRelinSkDeg, FModSize,  SecLvl,       KSTech, ScalTech,        LDigits,      PtMod, StdDev, EvalAddCt, KSCt, MultTech, EncTech, PREMode, multipartyMode, decryptionNoiseMode, executionMode, noiseEstimate, registerWordSize, compositeDegree, LvLBudget, Dim1,     Slots
-    { BOOTSTRAP_EDGE, "01", {CKKSRNS_SCHEME,  RDIM, MULT_DEPTH, SMODSIZED2,     DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,          FMODSIZED2,  HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,       NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT, DFLT, DFLT, DFLT, DFLT, 32, DFLT},   { 1, 1 },  { 0, 0 }, RDIM/4 },
-    { BOOTSTRAP_EDGE, "02", {CKKSRNS_SCHEME,  RDIM, MULT_DEPTH, SMODSIZED3,     DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,          FMODSIZED3,  HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,       NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT, DFLT, DFLT, DFLT, DFLT, 32, DFLT},   { 1, 1 },  { 0, 0 }, RDIM/4 },
+    // TestType,        Descr, Scheme,         RDim, MultDepth,  SModSize,   DSize, BatchSz, SecKeyDist,      MaxRelinSkDeg, FModSize,   SecLvl,       KSTech, ScalTech,               LDigits,      PtMod, StdDev, EvalAddCt, KSCt, MultTech, EncTech, PREMode, multipartyMode, decryptionNoiseMode, executionMode, noiseEstimate, registerWordSize, compositeDegree, LvLBudget, Dim1,     Slots
+    { BOOTSTRAP_SPARSE, "01", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH, SMODSIZED2, DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,          FMODSIZED2, HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,   NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT,    DFLT,           DFLT,                DFLT,          DFLT,          32,               DFLT},           { 1, 1 },  { 8, 8 },   8 },
+    { BOOTSTRAP_SPARSE, "02", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH, SMODSIZED3, DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,          FMODSIZED3, HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,   NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT,    DFLT,           DFLT,                DFLT,          DFLT,          32,               DFLT},           { 1, 1 },  { 8, 8 },   8 },
+    { BOOTSTRAP_SPARSE, "03", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH, SMODSIZED2, DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,          FMODSIZED2, HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,   NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT,    DFLT,           DFLT,                DFLT,          DFLT,          32,               DFLT},           { 2, 2 },  { 0, 0 },   8 },
+    { BOOTSTRAP_SPARSE, "04", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH, SMODSIZED3, DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,          FMODSIZED3, HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,   NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT,    DFLT,           DFLT,                DFLT,          DFLT,          32,               DFLT},           { 2, 2 },  { 0, 0 },   8 },
+    { BOOTSTRAP_SPARSE, "05", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH, SMODSIZED2, DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,          FMODSIZED2, HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,   NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT,    DFLT,           DFLT,                DFLT,          DFLT,          32,               DFLT},           { 1, 1 },  { 0, 0 },   8 },
+    { BOOTSTRAP_SPARSE, "06", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH, SMODSIZED3, DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,          FMODSIZED3, HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,   NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT,    DFLT,           DFLT,                DFLT,          DFLT,          32,               DFLT},           { 1, 1 },  { 0, 0 },   8 },
+    { BOOTSTRAP_SPARSE, "07", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH, SMODSIZED2, DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,          FMODSIZED2, HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,   NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT,    DFLT,           DFLT,                DFLT,          DFLT,          32,               DFLT},           { 3, 2 },  { 0, 0 },   8 },
+    { BOOTSTRAP_SPARSE, "08", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH, SMODSIZED3, DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,          FMODSIZED3, HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,   NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT,    DFLT,           DFLT,                DFLT,          DFLT,          32,               DFLT},           { 3, 2 },  { 0, 0 },   8 },
+    { BOOTSTRAP_SPARSE, "09", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH, SMODSIZED2, DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,          FMODSIZED2, HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,   NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT,    DFLT,           DFLT,                DFLT,          DFLT,          32,               DFLT},           { 1, 1 },  { 0, 0 },   1 },
+    { BOOTSTRAP_SPARSE, "10", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH, SMODSIZED3, DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,          FMODSIZED3, HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,   NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT,    DFLT,           DFLT,                DFLT,          DFLT,          32,               DFLT},           { 1, 1 },  { 0, 0 },   1 },
+    { BOOTSTRAP_SPARSE, "11", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH, SMODSIZED2, DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,          FMODSIZED2, HEStd_NotSet, HYBRID, COMPOSITESCALINGMANUAL, NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT,    DFLT,           DFLT,                DFLT,          DFLT,          30,               2},              { 1, 1 },  { 0, 0 },   8 },
+    { BOOTSTRAP_SPARSE, "12", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH, SMODSIZED3, DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,          FMODSIZED3, HEStd_NotSet, HYBRID, COMPOSITESCALINGMANUAL, NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT,    DFLT,           DFLT,                DFLT,          DFLT,          30,               3},              { 1, 1 },  { 0, 0 },   8 },
     // ==========================================
-    // TestType,      Descr, Scheme,          RDim, MultDepth,  SModSize,     DSize, BatchSz, SecKeyDist,      MaxRelinSkDeg, FModSize,  SecLvl,       KSTech, ScalTech,        LDigits,      PtMod, StdDev, EvalAddCt, KSCt, MultTech, EncTech, PREMode, multipartyMode, decryptionNoiseMode, executionMode, noiseEstimate, registerWordSize, compositeDegree, LvLBudget, Dim1,     Slots
-    { BOOTSTRAP_EDGE, "11", {CKKSRNS_SCHEME,  RDIM, MULT_DEPTH, SMODSIZED2,     DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,          FMODSIZED2,  HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,       NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT, DFLT, DFLT, DFLT, DFLT, 32, DFLT},   { 2, 2 },  { 0, 0 }, RDIM/4 },
-    { BOOTSTRAP_EDGE, "12", {CKKSRNS_SCHEME,  RDIM, MULT_DEPTH, SMODSIZED3,     DFLT,  DFLT,    UNIFORM_TERNARY,  DFLT,         FMODSIZED3,  HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,       NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT, DFLT, DFLT, DFLT, DFLT, 32, DFLT},   { 2, 2 },  { 0, 0 }, RDIM/4 },
+    // TestType,            Descr, Scheme,         RDim, MultDepth,  SModSize,   DSize, BatchSz, SecKeyDist,      MaxRelinSkDeg, FModSize,   SecLvl,       KSTech, ScalTech,               LDigits,      PtMod, StdDev, EvalAddCt, KSCt, MultTech, EncTech, PREMode, multipartyMode, decryptionNoiseMode, executionMode, noiseEstimate, registerWordSize, compositeDegree, LvLBudget, Dim1
+    { BOOTSTRAP_KEY_SWITCH, "01", {CKKSRNS_SCHEME, 2048, MULT_DEPTH, SMODSIZED2, DFLT,  8,       UNIFORM_TERNARY, DFLT,          FMODSIZED2, HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,   NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT,    DFLT,           DFLT,                DFLT,          DFLT,          32,               DFLT},           { 3, 2 },  { 0, 0 } },
+    { BOOTSTRAP_KEY_SWITCH, "02", {CKKSRNS_SCHEME, 2048, MULT_DEPTH, SMODSIZED3, DFLT,  8,       UNIFORM_TERNARY, DFLT,          FMODSIZED3, HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,   NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT,    DFLT,           DFLT,                DFLT,          DFLT,          32,               DFLT},           { 3, 2 },  { 0, 0 } },
     // ==========================================
-    // TestType,        Descr, Scheme,          RDim, MultDepth,  SModSize,     DSize, BatchSz, SecKeyDist,      MaxRelinSkDeg, FModSize,  SecLvl,       KSTech, ScalTech,        LDigits,      PtMod, StdDev, EvalAddCt, KSCt, MultTech, EncTech, PREMode, multipartyMode, decryptionNoiseMode, executionMode, noiseEstimate, registerWordSize, compositeDegree, LvLBudget, Dim1,     Slots
-    { BOOTSTRAP_SPARSE, "01", {CKKSRNS_SCHEME,  RDIM, MULT_DEPTH, SMODSIZED2,     DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,          FMODSIZED2,  HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,       NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT, DFLT, DFLT, DFLT, DFLT, 32, DFLT},   { 1, 1 },  { 8, 8 }, 8 },
-    { BOOTSTRAP_SPARSE, "02", {CKKSRNS_SCHEME,  RDIM, MULT_DEPTH, SMODSIZED3,     DFLT,  DFLT,    UNIFORM_TERNARY,  DFLT,         FMODSIZED3,  HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,       NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT, DFLT, DFLT, DFLT, DFLT, 32, DFLT},   { 1, 1 },  { 8, 8 }, 8 },
+    // TestType,           Descr, Scheme,         RDim, MultDepth,  SModSize,   DSize, BatchSz, SecKeyDist,      MaxRelinSkDeg, FModSize,   SecLvl,       KSTech, ScalTech,               LDigits,      PtMod, StdDev, EvalAddCt, KSCt, MultTech, EncTech, PREMode, multipartyMode, decryptionNoiseMode, executionMode, noiseEstimate, registerWordSize, compositeDegree, LvLBudget, Dim1,     Slots
+    { BOOTSTRAP_ITERATIVE, "01", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH, SMODSIZED2, DFLT,  8,       UNIFORM_TERNARY, DFLT,          FMODSIZED2, HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,   NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT,    DFLT,           DFLT,                DFLT,          DFLT,          32,               DFLT},           { 3, 3 },  { 0, 0 },   8 },
+    { BOOTSTRAP_ITERATIVE, "02", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH, SMODSIZED3, DFLT,  8,       UNIFORM_TERNARY, DFLT,          FMODSIZED3, HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,   NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT,    DFLT,           DFLT,                DFLT,          DFLT,          32,               DFLT},           { 3, 3 },  { 0, 0 },   8 },
+    { BOOTSTRAP_ITERATIVE, "03", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH, SMODSIZED2, DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,          FMODSIZED2, HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,   NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT,    DFLT,           DFLT,                DFLT,          DFLT,          32,               DFLT},           { 3, 3 },  { 0, 0 },   RDIM/2 },
+    { BOOTSTRAP_ITERATIVE, "04", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH, SMODSIZED3, DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,          FMODSIZED3, HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,   NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT,    DFLT,           DFLT,                DFLT,          DFLT,          32,               DFLT},           { 3, 3 },  { 0, 0 },   RDIM/2 },
     // ==========================================
-    // TestType,        Descr, Scheme,          RDim, MultDepth,  SModSize,     DSize, BatchSz, SecKeyDist,      MaxRelinSkDeg, FModSize,  SecLvl,       KSTech, ScalTech,        LDigits,      PtMod, StdDev, EvalAddCt, KSCt, MultTech, EncTech, PREMode, multipartyMode, decryptionNoiseMode, executionMode, noiseEstimate, registerWordSize, compositeDegree, LvLBudget, Dim1,     Slots
-    { BOOTSTRAP_SPARSE, "11", {CKKSRNS_SCHEME,  RDIM, MULT_DEPTH, SMODSIZED2,     DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,          FMODSIZED2,  HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,       NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT, DFLT, DFLT, DFLT, DFLT, 32, DFLT},   { 2, 2 },  { 0, 0 }, 8 },
-    { BOOTSTRAP_SPARSE, "12", {CKKSRNS_SCHEME,  RDIM, MULT_DEPTH, SMODSIZED3,     DFLT,  DFLT,    UNIFORM_TERNARY,  DFLT,          FMODSIZED3,  HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,       NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT, DFLT, DFLT, DFLT, DFLT, 32, DFLT},   { 2, 2 },  { 0, 0 }, 8 },
+    // TestType,           Descr, Scheme,         RDim, MultDepth,  SModSize,   DSize, BatchSz, SecKeyDist,      MaxRelinSkDeg, FModSize,   SecLvl,       KSTech, ScalTech,               LDigits,      PtMod, StdDev, EvalAddCt, KSCt, MultTech, EncTech, PREMode, multipartyMode, decryptionNoiseMode, executionMode, noiseEstimate, registerWordSize, compositeDegree, LvLBudget, Dim1,     Slots
+    { BOOTSTRAP_NUM_TOWERS, "01", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH, SMODSIZED2, DFLT,  8,       UNIFORM_TERNARY, DFLT,          FMODSIZED2, HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,   NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT,    DFLT,           DFLT,                DFLT,          DFLT,          32,               DFLT},           { 3, 2 },  { 0, 0 },   8 },
+    { BOOTSTRAP_NUM_TOWERS, "02", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH, SMODSIZED3, DFLT,  8,       UNIFORM_TERNARY, DFLT,          FMODSIZED3, HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,   NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT,    DFLT,           DFLT,                DFLT,          DFLT,          32,               DFLT},           { 3, 2 },  { 0, 0 },   8 },
+    { BOOTSTRAP_NUM_TOWERS, "03", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH, SMODSIZED2, DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,          FMODSIZED2, HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,   NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT,    DFLT,           DFLT,                DFLT,          DFLT,          32,               DFLT},           { 3, 2 },  { 0, 0 },   RDIM/2 },
+    { BOOTSTRAP_NUM_TOWERS, "04", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH, SMODSIZED3, DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,          FMODSIZED3, HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,   NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT,    DFLT,           DFLT,                DFLT,          DFLT,          32,               DFLT},           { 3, 2 },  { 0, 0 },   RDIM/2 },
     // ==========================================
-    // TestType,        Descr, Scheme,          RDim, MultDepth,  SModSize,     DSize, BatchSz, SecKeyDist,      MaxRelinSkDeg, FModSize,  SecLvl,       KSTech, ScalTech,        LDigits,      PtMod, StdDev, EvalAddCt, KSCt, MultTech, EncTech, PREMode, multipartyMode, decryptionNoiseMode, executionMode, noiseEstimate, registerWordSize, compositeDegree, LvLBudget, Dim1,     Slots
-    { BOOTSTRAP_SPARSE, "21", {CKKSRNS_SCHEME,  RDIM, MULT_DEPTH, SMODSIZED2,     DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,          FMODSIZED2,  HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,       NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT, DFLT, DFLT, DFLT, DFLT, 32, DFLT},   { 1, 1 },  { 0, 0 }, 8 },
-    { BOOTSTRAP_SPARSE, "22", {CKKSRNS_SCHEME,  RDIM, MULT_DEPTH, SMODSIZED3,     DFLT,  DFLT,    UNIFORM_TERNARY,  DFLT,          FMODSIZED3,  HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,       NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT, DFLT, DFLT, DFLT, DFLT, 32, DFLT},   { 1, 1 },  { 0, 0 }, 8 },
+    // TestType,           Descr, Scheme,         RDim, MultDepth,  SModSize,   DSize, BatchSz, SecKeyDist,      MaxRelinSkDeg, FModSize,   SecLvl,       KSTech, ScalTech,               LDigits,      PtMod, StdDev, EvalAddCt, KSCt, MultTech, EncTech, PREMode, multipartyMode, decryptionNoiseMode, executionMode, noiseEstimate, registerWordSize, compositeDegree, LvLBudget, Dim1,       Slots
+    { BOOTSTRAP_SERIALIZE, "01", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH, SMODSIZED2, DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,          FMODSIZED2, HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,   NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT,    DFLT,           DFLT,                DFLT,          DFLT,          32,               DFLT},           { 1, 1 },  { 32, 32 }, RDIM/2 },
+    { BOOTSTRAP_SERIALIZE, "02", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH, SMODSIZED3, DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,          FMODSIZED3, HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,   NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT,    DFLT,           DFLT,                DFLT,          DFLT,          32,               DFLT},           { 1, 1 },  { 32, 32 }, RDIM/2 },
     // ==========================================
-    // TestType,        Descr, Scheme,          RDim, MultDepth,  SModSize,     DSize, BatchSz, SecKeyDist,      MaxRelinSkDeg, FModSize,  SecLvl,       KSTech, ScalTech,        LDigits,      PtMod, StdDev, EvalAddCt, KSCt, MultTech, EncTech, PREMode, multipartyMode, decryptionNoiseMode, executionMode, noiseEstimate, registerWordSize, compositeDegree, LvLBudget, Dim1,     Slots
-    { BOOTSTRAP_SPARSE, "31", {CKKSRNS_SCHEME,  RDIM, MULT_DEPTH, SMODSIZED2,     DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,          FMODSIZED2,  HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,       NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT, DFLT, DFLT, DFLT, DFLT, 32, DFLT},   { 3, 2 },  { 0, 0 }, 8 },
-    { BOOTSTRAP_SPARSE, "32", {CKKSRNS_SCHEME,  RDIM, MULT_DEPTH, SMODSIZED3,     DFLT,  DFLT,    UNIFORM_TERNARY,  DFLT,         FMODSIZED3,  HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,       NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT, DFLT, DFLT, DFLT, DFLT, 32, DFLT},   { 3, 2 },  { 0, 0 }, 8 },
-    { BOOTSTRAP_SPARSE, "39", {CKKSRNS_SCHEME,  RDIM, MULT_DEPTH, SMODSIZED2,     DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,          FMODSIZED2,  HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,       NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT, DFLT, DFLT, DFLT, DFLT, 32, DFLT},   { 1, 1 },  { 0, 0 }, 1 },
-    { BOOTSTRAP_SPARSE, "40", {CKKSRNS_SCHEME,  RDIM, MULT_DEPTH, SMODSIZED3,     DFLT,  DFLT,    UNIFORM_TERNARY,  DFLT,          FMODSIZED3,  HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,       NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT, DFLT, DFLT, DFLT, DFLT, 32, DFLT},   { 1, 1 },  { 0, 0 }, 1 },
-        // ==========================================
-    // TestType,        Descr, Scheme,          RDim, MultDepth,  SModSize,     DSize, BatchSz, SecKeyDist,      MaxRelinSkDeg, FModSize,  SecLvl,       KSTech, ScalTech,        LDigits,      PtMod, StdDev, EvalAddCt, KSCt, MultTech, EncTech, PREMode, multipartyMode, decryptionNoiseMode, executionMode, noiseEstimate, registerWordSize, compositeDegree, LvLBudget, Dim1,     Slots
-    { BOOTSTRAP_SPARSE, "51", {CKKSRNS_SCHEME,  RDIM, MULT_DEPTH, SMODSIZED2,     DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,          FMODSIZED2,  HEStd_NotSet, HYBRID, COMPOSITESCALINGMANUAL,       NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT, DFLT, DFLT, DFLT, DFLT, 30, 2},   { 1, 1 },  { 0, 0 }, 8 },
-    { BOOTSTRAP_SPARSE, "52", {CKKSRNS_SCHEME,  RDIM, MULT_DEPTH, SMODSIZED3,     DFLT,  DFLT,    UNIFORM_TERNARY,  DFLT,          FMODSIZED3,  HEStd_NotSet, HYBRID, COMPOSITESCALINGMANUAL,       NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT, DFLT, DFLT, DFLT, DFLT, 30, 3},   { 1, 1 },  { 0, 0 }, 8 },
-    // ==========================================
-    // TestType,            Descr, Scheme,          RDim, MultDepth,  SModSize,     DSize, BatchSz, SecKeyDist,      MaxRelinSkDeg, FModSize,  SecLvl,       KSTech, ScalTech,        LDigits,      PtMod, StdDev, EvalAddCt, KSCt, MultTech, EncTech, PREMode, multipartyMode, decryptionNoiseMode, executionMode, noiseEstimate, registerWordSize, compositeDegree, LvLBudget, Dim1
-    { BOOTSTRAP_KEY_SWITCH, "01", {CKKSRNS_SCHEME,  2048, MULT_DEPTH, SMODSIZED2,     DFLT,  8,       UNIFORM_TERNARY,  DFLT,          FMODSIZED2,  HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,       NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT, DFLT, DFLT, DFLT, DFLT, 32, DFLT},   { 3, 2 },  { 0, 0 } },
-    { BOOTSTRAP_KEY_SWITCH, "02", {CKKSRNS_SCHEME,  2048, MULT_DEPTH, SMODSIZED3,     DFLT,  8,       UNIFORM_TERNARY, DFLT,          FMODSIZED3,  HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,       NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT, DFLT, DFLT, DFLT, DFLT, 32, DFLT},   { 3, 2 },  { 0, 0 } },
-    // ==========================================
-    // TestType,           Descr, Scheme,          RDim, MultDepth,  SModSize,     DSize, BatchSz, SecKeyDist,      MaxRelinSkDeg, FModSize,  SecLvl,       KSTech, ScalTech,        LDigits,      PtMod, StdDev, EvalAddCt, KSCt, MultTech, EncTech, PREMode, multipartyMode, decryptionNoiseMode, executionMode, noiseEstimate, registerWordSize, compositeDegree, LvLBudget, Dim1,     Slots
-    { BOOTSTRAP_ITERATIVE, "01", {CKKSRNS_SCHEME,  RDIM, MULT_DEPTH, SMODSIZED2,     DFLT,  8,       UNIFORM_TERNARY,  DFLT,          FMODSIZED2,  HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,       NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT, DFLT, DFLT, DFLT, DFLT, 32, DFLT},   { 3, 3 },  { 0, 0 }, 8},
-    { BOOTSTRAP_ITERATIVE, "02", {CKKSRNS_SCHEME,  RDIM, MULT_DEPTH, SMODSIZED3,     DFLT,  8,       UNIFORM_TERNARY, DFLT,          FMODSIZED3,  HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,       NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT, DFLT, DFLT, DFLT, DFLT, 32, DFLT},   { 3, 3 },  { 0, 0 }, 8},
-    // TestType,           Descr, Scheme,          RDim, MultDepth,  SModSize,     DSize, BatchSz, SecKeyDist,      MaxRelinSkDeg, FModSize,  SecLvl,       KSTech, ScalTech,        LDigits,      PtMod, StdDev, EvalAddCt, KSCt, MultTech, EncTech, PREMode, multipartyMode, decryptionNoiseMode, executionMode, noiseEstimate, registerWordSize, compositeDegree, LvLBudget, Dim1,     Slots
-    { BOOTSTRAP_ITERATIVE, "09", {CKKSRNS_SCHEME,  RDIM, MULT_DEPTH, SMODSIZED2,     DFLT,  DFLT,    UNIFORM_TERNARY,  DFLT,         FMODSIZED2,  HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,       NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT, DFLT, DFLT, DFLT, DFLT, 32, DFLT},   { 3, 3 },  { 0, 0 }, RDIM/2},
-    { BOOTSTRAP_ITERATIVE, "10", {CKKSRNS_SCHEME,  RDIM, MULT_DEPTH, SMODSIZED3,     DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,          FMODSIZED3,  HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,       NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT, DFLT, DFLT, DFLT, DFLT, 32, DFLT},   { 3, 3 },  { 0, 0 }, RDIM/2},
-    // ==========================================
-    // TestType,           Descr, Scheme,          RDim, MultDepth,  SModSize,     DSize, BatchSz, SecKeyDist,      MaxRelinSkDeg, FModSize,  SecLvl,       KSTech, ScalTech,        LDigits,      PtMod, StdDev, EvalAddCt, KSCt, MultTech, EncTech, PREMode, multipartyMode, decryptionNoiseMode, executionMode, noiseEstimate, registerWordSize, compositeDegree, LvLBudget, Dim1,     Slots
-    { BOOTSTRAP_NUM_TOWERS, "01", {CKKSRNS_SCHEME,  RDIM, MULT_DEPTH, SMODSIZED2,     DFLT,  8,       UNIFORM_TERNARY, DFLT,         FMODSIZED2,  HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,       NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT, DFLT, DFLT, DFLT, DFLT, 32, DFLT},   { 3, 2 },  { 0, 0 }, 8},
-    { BOOTSTRAP_NUM_TOWERS, "02", {CKKSRNS_SCHEME,  RDIM, MULT_DEPTH, SMODSIZED3,     DFLT,  8,       UNIFORM_TERNARY, DFLT,          FMODSIZED3,  HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,       NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT, DFLT, DFLT, DFLT, DFLT, 32, DFLT},   { 3, 2 },  { 0, 0 }, 8},
-    // TestType,            Descr, Scheme,          RDim, MultDepth,  SModSize,     DSize, BatchSz, SecKeyDist,      MaxRelinSkDeg, FModSize,  SecLvl,       KSTech, ScalTech,        LDigits,      PtMod, StdDev, EvalAddCt, KSCt, MultTech, EncTech, PREMode, multipartyMode, decryptionNoiseMode, executionMode, noiseEstimate, registerWordSize, compositeDegree, LvLBudget, Dim1,     Slots
-    { BOOTSTRAP_NUM_TOWERS, "09", {CKKSRNS_SCHEME,  RDIM, MULT_DEPTH, SMODSIZED2,     DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,         FMODSIZED2,  HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,       NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT, DFLT, DFLT, DFLT, DFLT, 32, DFLT},   { 3, 2 },  { 0, 0 }, RDIM/2},
-    { BOOTSTRAP_NUM_TOWERS, "10", {CKKSRNS_SCHEME,  RDIM, MULT_DEPTH, SMODSIZED3,     DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,          FMODSIZED3,  HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,       NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT, DFLT, DFLT, DFLT, DFLT, 32, DFLT},   { 3, 2 },  { 0, 0 }, RDIM/2},
-    // ==========================================
-    // TestType,           Descr, Scheme,         RDim, MultDepth,  SModSize,     DSize, BatchSz, SecKeyDist,      MaxRelinSkDeg, FModSize,  SecLvl,       KSTech, ScalTech,        LDigits,      PtMod, StdDev, EvalAddCt, KSCt, MultTech, EncTech, PREMode, multipartyMode, decryptionNoiseMode, executionMode, noiseEstimate, registerWordSize, compositeDegree, LvLBudget, Dim1,       Slots
-    { BOOTSTRAP_SERIALIZE, "01", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH, SMODSIZED2,     DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,          FMODSIZED2,  HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,       NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT, DFLT, DFLT, DFLT, DFLT, 32, DFLT},   { 1, 1 },  { 32, 32 }, RDIM/2 },
-    { BOOTSTRAP_SERIALIZE, "02", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH, SMODSIZED3,     DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,          FMODSIZED3,  HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,       NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT, DFLT, DFLT, DFLT, DFLT, 32, DFLT},   { 1, 1 },  { 32, 32 }, RDIM/2 },
+    // TestType,               Descr, Scheme,         RDim, MultDepth,  SModSize,   DSize, BatchSz, SecKeyDist,      MaxRelinSkDeg, FModSize,   SecLvl,       KSTech, ScalTech,               LDigits,      PtMod, StdDev, EvalAddCt, KSCt, MultTech, EncTech, PREMode, multipartyMode, decryptionNoiseMode, executionMode, noiseEstimate, registerWordSize, compositeDegree, LvLBudget, Dim1,       Slots
+    { BOOTSTRAP_KEY_SERIALIZE, "01", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH, SMODSIZED2, DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,          FMODSIZED2, HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,   NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT,    DFLT,           DFLT,                DFLT,          DFLT,          32,               DFLT},           { 1, 1 },  { 32, 32 }, RDIM/2 },
+    { BOOTSTRAP_KEY_SERIALIZE, "02", {CKKSRNS_SCHEME, RDIM, MULT_DEPTH, SMODSIZED3, DFLT,  DFLT,    UNIFORM_TERNARY, DFLT,          FMODSIZED3, HEStd_NotSet, HYBRID, COMPOSITESCALINGAUTO,   NUM_LRG_DIGS, DFLT,  DFLT,   DFLT,      DFLT, DFLT,     DFLT,    DFLT,    DFLT,           DFLT,                DFLT,          DFLT,          32,               DFLT},           { 1, 1 },  { 32, 32 }, RDIM/2 },
     // ==========================================
 };
 // clang-format on
@@ -603,6 +596,118 @@ protected:
             UNIT_TEST_HANDLE_ALL_EXCEPTIONS;
         }
     }
+
+    // Tests SerializeEvalBootstrapKey / DeserializeEvalBootstrapKey.
+    // For testData.slots: uses the (keyTag, indexList) overload of DeserializeEvalBootstrapKey.
+    // For testData.slots/2: uses the (privateKey, slots) overload of DeserializeEvalBootstrapKey.
+    void UnitTest_Bootstrap_SerializeBootstrapKey(const TEST_CASE_UTCKKSRNSCS_BOOT& testData,
+                                                  const std::string& failmsg = std::string()) {
+        try {
+            CryptoContextImpl<DCRTPoly>::ClearEvalMultKeys();
+            CryptoContextImpl<DCRTPoly>::ClearEvalSumKeys();
+            CryptoContextImpl<DCRTPoly>::ClearEvalAutomorphismKeys();
+            CryptoContextFactory<DCRTPoly>::ReleaseAllContexts();
+
+            CryptoContext<Element> ccInit(UnitTestGenerateContext(testData.params));
+            ccInit->EvalBootstrapSetup(testData.levelBudget, testData.dim1, testData.slots, 0, false);
+            ccInit->EvalBootstrapSetup(testData.levelBudget, testData.dim1, testData.slots / 2, 0, false);
+
+            auto keyPairInit = ccInit->KeyGen();
+            ccInit->EvalMultKeyGen(keyPairInit.secretKey);
+            ccInit->EvalBootstrapKeyGen(keyPairInit.secretKey, testData.slots);
+            ccInit->EvalBootstrapKeyGen(keyPairInit.secretKey, testData.slots / 2);
+            //==============================================================
+            // Serialize
+            std::stringstream cc_stream;
+            Serial::Serialize(ccInit, cc_stream, SerType::BINARY);
+
+            std::stringstream secretKey_stream;
+            Serial::Serialize(keyPairInit.secretKey, secretKey_stream, SerType::BINARY);
+
+            std::stringstream publicKey_stream;
+            Serial::Serialize(keyPairInit.publicKey, publicKey_stream, SerType::BINARY);
+
+            std::stringstream evalMultKey_stream;
+            CryptoContextImpl<DCRTPoly>::SerializeEvalMultKey(evalMultKey_stream, SerType::BINARY);
+
+            std::stringstream bootstrapKey_stream1;
+            CryptoContextImpl<DCRTPoly>::SerializeEvalBootstrapKey(bootstrapKey_stream1, SerType::BINARY,
+                                                                   keyPairInit.secretKey, testData.slots);
+
+            std::stringstream bootstrapKey_stream2;
+            CryptoContextImpl<DCRTPoly>::SerializeEvalBootstrapKey(bootstrapKey_stream2, SerType::BINARY,
+                                                                   keyPairInit.secretKey, testData.slots / 2);
+            //==============================================================
+            CryptoContextImpl<DCRTPoly>::ClearEvalMultKeys();
+            CryptoContextImpl<DCRTPoly>::ClearEvalSumKeys();
+            CryptoContextImpl<DCRTPoly>::ClearEvalAutomorphismKeys();
+            CryptoContextFactory<DCRTPoly>::ReleaseAllContexts();
+            //==============================================================
+            // Deserialize
+            CryptoContext<Element> cc;
+            Serial::Deserialize(cc, cc_stream, SerType::BINARY);
+
+            KeyPair<Element> keyPair;
+            Serial::Deserialize(keyPair.secretKey, secretKey_stream, SerType::BINARY);
+            Serial::Deserialize(keyPair.publicKey, publicKey_stream, SerType::BINARY);
+            CryptoContextImpl<DCRTPoly>::DeserializeEvalMultKey(evalMultKey_stream, SerType::BINARY);
+
+            // (keyTag, indexList) overload for testData.slots
+            const auto& keyTag   = keyPair.secretKey->GetKeyTag();
+            const auto indexList = cc->GetScheme()->EvalBootstrapKeyMapIndices(keyPair.secretKey, testData.slots);
+            CryptoContextImpl<DCRTPoly>::DeserializeEvalBootstrapKey(bootstrapKey_stream1, SerType::BINARY, keyTag,
+                                                                     indexList);
+
+            // (privateKey, slots) overload for testData.slots / 2
+            CryptoContextImpl<DCRTPoly>::DeserializeEvalBootstrapKey(bootstrapKey_stream2, SerType::BINARY,
+                                                                     keyPair.secretKey, testData.slots / 2);
+
+            cc->EvalBootstrapPrecompute(testData.slots);
+            cc->EvalBootstrapPrecompute(testData.slots / 2);
+            //==============================================================
+            auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersCKKSRNS>(cc->GetCryptoParameters());
+
+            auto input(Fill<std::complex<double>>(
+                {0.111111, 0.222222, 0.333333, 0.444444, 0.555555, 0.666666, 0.777777, 0.888888}, testData.slots));
+            size_t encodedLength = input.size();
+
+            Plaintext plaintext1 = cc->MakeCKKSPackedPlaintext(
+                input, 1, cryptoParams->GetCompositeDegree() * (MULT_DEPTH - 1), nullptr, testData.slots);
+            auto ciphertext1      = cc->Encrypt(keyPair.publicKey, plaintext1);
+            auto ciphertext1After = cc->EvalBootstrap(ciphertext1);
+
+            Plaintext result;
+            cc->Decrypt(keyPair.secretKey, ciphertext1After, &result);
+            result->SetLength(encodedLength);
+            plaintext1->SetLength(encodedLength);
+            checkEquality(result->GetCKKSPackedValue(), plaintext1->GetCKKSPackedValue(), eps,
+                          failmsg + " Bootstrapping for fully packed ciphertexts fails");
+
+            //==============================================================
+            auto input2(Fill<std::complex<double>>({0.111111, 0.222222, 0.333333, 0.444444}, testData.slots / 2));
+            size_t encodedLength2 = input2.size();
+
+            Plaintext plaintext2 = cc->MakeCKKSPackedPlaintext(
+                input2, 1, cryptoParams->GetCompositeDegree() * (MULT_DEPTH - 1), nullptr, testData.slots / 2);
+            auto ciphertext2      = cc->Encrypt(keyPair.publicKey, plaintext2);
+            auto ciphertext2After = cc->EvalBootstrap(ciphertext2);
+
+            cc->Decrypt(keyPair.secretKey, ciphertext2After, &result);
+            result->SetLength(encodedLength2);
+            plaintext2->SetLength(encodedLength2);
+            checkEquality(result->GetCKKSPackedValue(), plaintext2->GetCKKSPackedValue(), eps,
+                          failmsg + " Bootstrapping for sparsely packed ciphertexts fails");
+
+            EXPECT_TRUE(1 == 1) << failmsg;
+        }
+        catch (std::exception& e) {
+            std::cerr << "Exception thrown from " << __func__ << "(): " << e.what() << std::endl;
+            EXPECT_TRUE(0 == 1) << failmsg;
+        }
+        catch (...) {
+            UNIT_TEST_HANDLE_ALL_EXCEPTIONS;
+        }
+    }
 };
 
 //===========================================================================================================
@@ -629,6 +734,9 @@ TEST_P(UTCKKSRNSCS_BOOT, CKKSRNS) {
             break;
         case BOOTSTRAP_SERIALIZE:
             UnitTest_Bootstrap_Serialize(test, test.buildTestName());
+            break;
+        case BOOTSTRAP_KEY_SERIALIZE:
+            UnitTest_Bootstrap_SerializeBootstrapKey(test, test.buildTestName());
             break;
         default:
             break;

--- a/src/pke/unittest/utckksrns/UnitTestCKKSrnsCompositeScalingBootstrap.cpp
+++ b/src/pke/unittest/utckksrns/UnitTestCKKSrnsCompositeScalingBootstrap.cpp
@@ -599,7 +599,7 @@ protected:
 
     // Tests SerializeEvalBootstrapKey / DeserializeEvalBootstrapKey.
     // For testData.slots: uses the (keyTag, indexList) overload of DeserializeEvalBootstrapKey.
-    // For testData.slots/2: uses the (privateKey, slots) overload of DeserializeEvalBootstrapKey.
+    // For testData.slots/2: uses the (cc, keyTag, slots) overload of DeserializeEvalBootstrapKey.
     void UnitTest_Bootstrap_SerializeBootstrapKey(const TEST_CASE_UTCKKSRNSCS_BOOT& testData,
                                                   const std::string& failmsg = std::string()) {
         try {
@@ -632,11 +632,13 @@ protected:
 
             std::stringstream bootstrapKey_stream1;
             CryptoContextImpl<DCRTPoly>::SerializeEvalBootstrapKey(bootstrapKey_stream1, SerType::BINARY,
-                                                                   keyPairInit.secretKey, testData.slots);
+                                                                   ccInit, keyPairInit.secretKey->GetKeyTag(),
+                                                                   testData.slots);
 
             std::stringstream bootstrapKey_stream2;
             CryptoContextImpl<DCRTPoly>::SerializeEvalBootstrapKey(bootstrapKey_stream2, SerType::BINARY,
-                                                                   keyPairInit.secretKey, testData.slots / 2);
+                                                                   ccInit, keyPairInit.secretKey->GetKeyTag(),
+                                                                   testData.slots / 2);
             //==============================================================
             CryptoContextImpl<DCRTPoly>::ClearEvalMultKeys();
             CryptoContextImpl<DCRTPoly>::ClearEvalSumKeys();
@@ -654,13 +656,15 @@ protected:
 
             // (keyTag, indexList) overload for testData.slots
             const auto& keyTag   = keyPair.secretKey->GetKeyTag();
-            const auto indexList = cc->GetScheme()->EvalBootstrapKeyMapIndices(keyPair.secretKey, testData.slots);
-            CryptoContextImpl<DCRTPoly>::DeserializeEvalBootstrapKey(bootstrapKey_stream1, SerType::BINARY, keyTag,
-                                                                     indexList);
+            const auto indexList = cc->GetScheme()->EvalBootstrapKeyMapIndices(cc, testData.slots);
+            EXPECT_TRUE(CryptoContextImpl<DCRTPoly>::DeserializeEvalBootstrapKey(bootstrapKey_stream1, SerType::BINARY,
+                                                                                 keyTag, indexList))
+                << failmsg + " DeserializeEvalBootstrapKey(keyTag, indexList) failed";
 
-            // (privateKey, slots) overload for testData.slots / 2
-            CryptoContextImpl<DCRTPoly>::DeserializeEvalBootstrapKey(bootstrapKey_stream2, SerType::BINARY,
-                                                                     keyPair.secretKey, testData.slots / 2);
+            // (cc, keyTag, slots) overload for testData.slots / 2
+            EXPECT_TRUE(CryptoContextImpl<DCRTPoly>::DeserializeEvalBootstrapKey(bootstrapKey_stream2, SerType::BINARY,
+                                                                                 cc, keyTag, testData.slots / 2))
+                << failmsg + " DeserializeEvalBootstrapKey(cc, keyTag, slots) failed";
 
             cc->EvalBootstrapPrecompute(testData.slots);
             cc->EvalBootstrapPrecompute(testData.slots / 2);


### PR DESCRIPTION
1.added API for serializing/deserializing bootstrapping keys
2. fixed a bug in 
static bool DeserializeEvalAutomorphismKey(std::istream& ser, const ST& sertype, const std::string& keyTag,
                                               const std::vector<uint32_t>& indexList)