### PR TITLE
Used data members directly instead of their getters in function members of the same class

### DIFF
--- a/src/core/include/lattice/hal/dcrtpoly-interface.h
+++ b/src/core/include/lattice/hal/dcrtpoly-interface.h
@@ -508,9 +508,7 @@ public:
    */
     DerivedType Transpose() const final {
         if (this->GetDerived().GetFormat() == Format::COEFFICIENT)
-            OPENFHE_THROW(
-                "DCRTPolyInterface element transposition is currently "
-                "implemented only in the Evaluation representation.");
+            OPENFHE_THROW("Transposition is currently implemented only in the Evaluation representation.");
         return this->GetDerived().AutomorphismTransform(this->GetDerived().GetCyclotomicOrder() - 1);
     }
 

--- a/src/core/include/math/hal/bigintdyn/ubintdyn.h
+++ b/src/core/include/math/hal/bigintdyn/ubintdyn.h
@@ -791,7 +791,7 @@ public:
 
     // TODO hardcoded for base 2?
     uint32_t GetLengthForBase(uint32_t base) const {
-        return GetMSB();
+        return m_MSB;
     }
 
     /**
@@ -864,8 +864,6 @@ public:
 
     /**
    * ostream output << operator
-   * Algorithm used is double and add
-   * http://www.wikihow.com/Convert-from-Binary-to-Decimal
    *
    * @param os is the std ostream object.
    * @param ptr_obj is ubint to be printed.
@@ -875,11 +873,6 @@ public:
         os << ptr_obj.ToString();
         return os;
     }
-
-    /**
-   * documentation function, prints sizes of constats.
-   */
-    static void PrintIntegerConstants();
 
     template <class Archive>
     void save(Archive& ar, std::uint32_t const version) const {

--- a/src/core/include/math/hal/bigintfxd/mubintvecfxd.h
+++ b/src/core/include/math/hal/bigintfxd/mubintvecfxd.h
@@ -173,12 +173,12 @@ public:
    * @return Assigned BigVectorFixedT.
    */
     BigVectorFixedT& operator=(uint64_t val) {
-        this->m_data[0] = val;
-        if (this->m_modulus != 0) {
-            this->m_data[0] %= this->m_modulus;
+        m_data[0] = val;
+        if (m_modulus != 0) {
+            m_data[0] %= m_modulus;
         }
-        for (size_t i = 1; i < GetLength(); ++i) {
-            this->m_data[i] = 0;
+        for (size_t i = 1; i < m_length; ++i) {
+            m_data[i] = 0;
         }
         return *this;
     }
@@ -192,17 +192,17 @@ public:
    * @param index is the index to set a value at.
    */
     IntegerType& at(size_t i) {
-        if (!this->IndexCheck(i)) {
+        if (!IndexCheck(i)) {
             OPENFHE_THROW("BigVector index out of range");
         }
-        return this->m_data[i];
+        return m_data[i];
     }
 
     const IntegerType& at(size_t i) const {
-        if (!this->IndexCheck(i)) {
+        if (!IndexCheck(i)) {
             OPENFHE_THROW("BigVector index out of range");
         }
-        return this->m_data[i];
+        return m_data[i];
     }
 
     /**
@@ -211,11 +211,11 @@ public:
    * @return is the value at the index.
    */
     IntegerType& operator[](size_t idx) {
-        return (this->m_data[idx]);
+        return m_data[idx];
     }
 
     const IntegerType& operator[](size_t idx) const {
-        return (this->m_data[idx]);
+        return m_data[idx];
     }
 
     /**
@@ -224,7 +224,9 @@ public:
    * @param value is the value to set.
    * @param value is the modulus value to set.
    */
-    void SetModulus(const IntegerType& value);
+    void SetModulus(const IntegerType& value) {
+        m_modulus = value;
+    }
 
     /**
    * Sets the vector modulus and changes the values to match the new modulus.
@@ -244,7 +246,7 @@ public:
    * @return the vector modulus.
    */
     const IntegerType& GetModulus() const {
-        return this->m_modulus;
+        return m_modulus;
     }
 
     /**
@@ -253,7 +255,7 @@ public:
    * @return vector length.
    */
     size_t GetLength() const {
-        return this->m_length;
+        return m_length;
     }
 
     // MODULAR ARITHMETIC OPERATIONS

--- a/src/core/include/math/hal/bigintfxd/ubintfxd.h
+++ b/src/core/include/math/hal/bigintfxd/ubintfxd.h
@@ -886,9 +886,9 @@ public:
         uint32_t ceilInt = m_nSize - ceilIntByUInt(m_MSB);
         // copy the values by shift and add
         for (uint32_t i = 0; i < num && (m_nSize - i - 1) >= ceilInt; i++) {
-            result += ((T)this->m_value[m_nSize - i - 1] << (m_uintBitLength * i));
+            result += ((T)m_value[m_nSize - i - 1] << (m_uintBitLength * i));
         }
-        if (this->m_MSB > bits) {
+        if (m_MSB > bits) {
             OPENFHE_THROW(std::string("MSB cannot be bigger than ") + std::to_string(bits));
         }
         return result;
@@ -925,7 +925,10 @@ public:
    *
    * @return the index of the most significant bit.
    */
-    uint32_t GetMSB() const;
+    uint32_t GetMSB() const {
+        return m_MSB;
+    }
+
 
     /**
    * Get the number of digits using a specific base - support for arbitrary base
@@ -935,7 +938,7 @@ public:
    * @return the length of the representation in a specific base.
    */
     uint32_t GetLengthForBase(uint32_t base) const {
-        return GetMSB();
+        return m_MSB;
     }
 
     /**
@@ -999,7 +1002,7 @@ public:
    */
     std::string GetInternalRepresentation(void) const {
         std::string ret("");
-        size_t ceilInt  = ceilIntByUInt(this->m_MSB);  // max limb used
+        size_t ceilInt  = ceilIntByUInt(m_MSB);  // max limb used
         size_t minIndex = static_cast<size_t>(m_nSize - ceilInt);
 
         for (size_t i = m_nSize - 1; i >= minIndex; i--) {

--- a/src/core/include/math/hal/bigintntl/ubintntl.h
+++ b/src/core/include/math/hal/bigintntl/ubintntl.h
@@ -417,7 +417,6 @@ public:
         myZZ temp(1);
         temp <<= (2 * this->GetMSB() + 3);
         return temp.DividedBy(*this);
-        return temp;
     }
 
     /**

--- a/src/core/lib/lattice/stdlatticeparms.cpp
+++ b/src/core/lib/lattice/stdlatticeparms.cpp
@@ -61,8 +61,7 @@ SecurityLevel convertToSecurityLevel(const std::string& str) {
     else if (str == "HEStd_NotSet")
         return HEStd_NotSet;
 
-    std::string errMsg(std::string("Unknown SecurityLevel ") + str);
-    OPENFHE_THROW(errMsg);
+    OPENFHE_THROW(std::string("Unknown SecurityLevel ") + str);
 }
 SecurityLevel convertToSecurityLevel(uint32_t num) {
     auto secLevel = static_cast<SecurityLevel>(num);
@@ -79,8 +78,7 @@ SecurityLevel convertToSecurityLevel(uint32_t num) {
             break;
     }
 
-    std::string errMsg(std::string("Unknown value for SecurityLevel ") + std::to_string(num));
-    OPENFHE_THROW(errMsg);
+    OPENFHE_THROW(std::string("Unknown value for SecurityLevel ") + std::to_string(num));
 }
 
 std::ostream& operator<<(std::ostream& s, SecurityLevel sl) {

--- a/src/core/lib/math/hal/bigintdyn/ubintdyn.cpp
+++ b/src/core/lib/math/hal/bigintdyn/ubintdyn.cpp
@@ -1008,23 +1008,6 @@ uint8_t ubint<limb_t>::GetBitAtIndex(uint32_t index) const {
 
 template class bigintdyn::ubint<expdtype>;
 
-template <typename limb_t>
-void ubint<limb_t>::PrintIntegerConstants() {
-    std::cout << "sizeof UINT8_C  " << sizeof(UINT8_C(1)) << std::endl;
-    std::cout << "sizeof UINT16_C " << sizeof(UINT16_C(1)) << std::endl;
-    std::cout << "sizeof UINT32_C " << sizeof(UINT32_C(1)) << std::endl;
-    std::cout << "sizeof UINT64_C " << sizeof(UINT64_C(1)) << std::endl;
-    std::cout << "sizeof uint8_t  " << sizeof(uint8_t) << std::endl;
-    std::cout << "sizeof uint16_t " << sizeof(uint16_t) << std::endl;
-    std::cout << "sizeof uint32_t " << sizeof(uint32_t) << std::endl;
-    std::cout << "sizeof uint64_t " << sizeof(uint64_t) << std::endl;
-    #if defined(HAVE_INT128)
-    // std::cout << "sizeof UINT128_C "<< sizeof (UINT128_C(1)) << std::endl;
-    // dbc commented out  unsupported on some machines
-    std::cout << "sizeof uint128_t " << sizeof(uint128_t) << std::endl;
-    #endif
-}
-
     #if 0
 // to stream internal representation
 template std::ostream& operator<<<expdtype>(std::ostream& os, const std::vector<expdtype>& v);

--- a/src/core/lib/math/hal/bigintfxd/mubintvecfxd.cpp
+++ b/src/core/lib/math/hal/bigintfxd/mubintvecfxd.cpp
@@ -188,11 +188,6 @@ BigVectorFixedT<IntegerType>& BigVectorFixedT<IntegerType>::operator=(std::initi
 
 // ACCESSORS
 
-template <class IntegerType>
-void BigVectorFixedT<IntegerType>::SetModulus(const IntegerType& value) {
-    this->m_modulus = value;
-}
-
 /**Switches the integers in the vector to values corresponding to the new
  * modulus Algorithm: Integer i, Old Modulus om, New Modulus nm, delta =
  * abs(om-nm): Case 1: om < nm if i > i > om/2 i' = i + delta Case 2: om > nm i
@@ -223,14 +218,14 @@ void BigVectorFixedT<IntegerType>::SwitchModulus(const IntegerType& newModulus) 
             }
         }
     }
-    this->SetModulus(newModulus);
+    m_modulus = newModulus;
 }
 
 template <class IntegerType>
 void BigVectorFixedT<IntegerType>::LazySwitchModulus(const IntegerType& modulus) {
     for (uint32_t i = 0; i < m_length; ++i)
         this->m_data[i].ModEq(modulus);
-    this->SetModulus(modulus);
+    m_modulus = modulus;
 }
 
 // MODULAR ARITHMETIC OPERATIONS
@@ -248,10 +243,10 @@ BigVectorFixedT<IntegerType>& BigVectorFixedT<IntegerType>::ModEq(const IntegerT
         return this->ModByTwoEq();
     }
     else {
-        IntegerType halfQ(this->GetModulus() >> 1);
-        for (uint32_t i = 0; i < this->GetLength(); i++) {
+        IntegerType halfQ(m_modulus >> 1);
+        for (uint32_t i = 0; i < m_length; i++) {
             if (this->m_data[i] > halfQ) {
-                this->m_data[i].ModSubEq(this->GetModulus(), modulus);
+                this->m_data[i].ModSubEq(m_modulus, modulus);
             }
             else {
                 this->m_data[i].ModEq(modulus);
@@ -286,7 +281,7 @@ BigVectorFixedT<IntegerType> BigVectorFixedT<IntegerType>::ModAddAtIndex(uint32_
 
 template <class IntegerType>
 BigVectorFixedT<IntegerType>& BigVectorFixedT<IntegerType>::ModAddAtIndexEq(uint32_t i, const IntegerType& b) {
-    if (i > this->GetLength() - 1) {
+    if (i > m_length - 1) {
         OPENFHE_THROW("mubintvecfxd::ModAddAtIndex. Index is out of range. i = " + std::to_string(i));
     }
     this->m_data[i].ModAddEq(b, this->m_modulus);
@@ -482,8 +477,8 @@ BigVectorFixedT<IntegerType> BigVectorFixedT<IntegerType>::ModByTwo() const {
 
 template <class IntegerType>
 BigVectorFixedT<IntegerType>& BigVectorFixedT<IntegerType>::ModByTwoEq() {
-    IntegerType halfQ(this->GetModulus() >> 1);
-    for (uint32_t i = 0; i < this->GetLength(); i++) {
+    IntegerType halfQ(m_modulus >> 1);
+    for (uint32_t i = 0; i < m_length; i++) {
         if (this->m_data[i] > halfQ) {
             if (this->m_data[i].Mod(2) == 1) {
                 this->m_data[i] = IntegerType(0);

--- a/src/core/lib/math/hal/bigintfxd/ubintfxd.cpp
+++ b/src/core/lib/math/hal/bigintfxd/ubintfxd.cpp
@@ -857,9 +857,8 @@ BigIntegerFixedT<uint_type, BITLENGTH>& BigIntegerFixedT<uint_type, BITLENGTH>::
 template <typename uint_type, uint32_t BITLENGTH>
 BigIntegerFixedT<uint_type, BITLENGTH> BigIntegerFixedT<uint_type, BITLENGTH>::ComputeMu() const {
     BigIntegerFixedT temp(1);
-    temp <<= (2 * this->GetMSB() + 3);
+    temp <<= (2 * m_MSB + 3);
     return temp.DividedBy(*this);
-    return temp;
 }
 
 /*
@@ -1617,11 +1616,6 @@ BigIntegerFixedT<uint_type, BITLENGTH> BigIntegerFixedT<uint_type, BITLENGTH>::i
 }
 
 // OTHER OPERATIONS
-
-template <typename uint_type, uint32_t BITLENGTH>
-uint32_t BigIntegerFixedT<uint_type, BITLENGTH>::GetMSB() const {
-    return m_MSB;
-}
 
 template <typename uint_type, uint32_t BITLENGTH>
 bool BigIntegerFixedT<uint_type, BITLENGTH>::CheckIfPowerOfTwo(const BigIntegerFixedT& m_numToCheck) {

--- a/src/pke/include/cryptocontext.h
+++ b/src/pke/include/cryptocontext.h
@@ -135,7 +135,7 @@ class CryptoContextImpl : public Serializable {
     */
     Plaintext MakePlaintext(const PlaintextEncodings encoding, const std::vector<int64_t>& value, size_t depth,
                             uint32_t level) const {
-        const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersRNS>(GetCryptoParameters());
+        const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersRNS>(m_params);
         if (!cryptoParams)
             OPENFHE_THROW("Invalid crypto parameters: expected CryptoParametersRNS");
 
@@ -366,7 +366,7 @@ protected:
                                                       size_t noiseScaleDeg, uint32_t level,
                                                       const std::shared_ptr<ParmType> params, uint32_t slots) const {
         VerifyCKKSScheme(__func__);
-        const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersRNS>(GetCryptoParameters());
+        const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersRNS>(m_params);
         if (!cryptoParams)
             OPENFHE_THROW("Invalid crypto parameters: expected CryptoParametersRNS");
         if (level > 0) {
@@ -462,7 +462,7 @@ protected:
     }
 
 #ifdef DEBUG_KEY
-    PrivateKey<Element> privateKey;
+    PrivateKey<Element> m_privateKey;
 #endif
 
 public:
@@ -489,20 +489,20 @@ public:
         std::cerr << "Warning - SetPrivateKey is only intended to be used for debugging "
                      "purposes - not for production systems."
                   << std::endl;
-        this->privateKey = privateKey;
+        m_privateKey = privateKey;
     }
 
     const PrivateKey<Element>& GetPrivateKey() const {
-        return this->privateKey;
+        return m_privateKey;
     }
 #endif
 
     void setSchemeId(SCHEME schemeTag) {
-        this->m_schemeId = schemeTag;
+        m_schemeId = schemeTag;
     }
 
     SCHEME getSchemeId() const {
-        return this->m_schemeId;
+        return m_schemeId;
     }
 
     /**
@@ -516,10 +516,10 @@ public:
     // and the other one takes shared_ptr
     CryptoContextImpl(CryptoParametersBase<Element>* params = nullptr, SchemeBase<Element>* scheme = nullptr,
                       SCHEME schemeId = SCHEME::INVALID_SCHEME) {
-        this->m_params.reset(params);
-        this->m_scheme.reset(scheme);
-        this->m_keyGenLevel = 0;
-        this->m_schemeId    = schemeId;
+        m_params.reset(params);
+        m_scheme.reset(scheme);
+        m_keyGenLevel = 0;
+        m_schemeId    = schemeId;
     }
 
     /**
@@ -531,10 +531,10 @@ public:
     */
     CryptoContextImpl(std::shared_ptr<CryptoParametersBase<Element>> params,
                       std::shared_ptr<SchemeBase<Element>> scheme, SCHEME schemeId = SCHEME::INVALID_SCHEME) {
-        this->m_params      = params;
-        this->m_scheme      = scheme;
-        this->m_keyGenLevel = 0;
-        this->m_schemeId    = schemeId;
+        m_params      = params;
+        m_scheme      = scheme;
+        m_keyGenLevel = 0;
+        m_schemeId    = schemeId;
     }
 
     /**
@@ -1227,7 +1227,7 @@ public:
     * @return Generated key pair.
     */
     KeyPair<Element> KeyGen() const {
-        return GetScheme()->KeyGen(GetContextForPointer(this), false);
+        return m_scheme->KeyGen(GetContextForPointer(this), false);
     }
 
     /**
@@ -1237,7 +1237,7 @@ public:
     * @attention Not supported by any crypto scheme currently.
     */
     KeyPair<Element> SparseKeyGen() const {
-        return GetScheme()->KeyGen(GetContextForPointer(this), true);
+        return m_scheme->KeyGen(GetContextForPointer(this), true);
     }
 
     /**
@@ -1252,7 +1252,7 @@ public:
             OPENFHE_THROW("Input plaintext is nullptr");
         ValidateKey(publicKey);
 
-        Ciphertext<Element> ciphertext = GetScheme()->Encrypt(plaintext->GetElement<Element>(), publicKey);
+        Ciphertext<Element> ciphertext = m_scheme->Encrypt(plaintext->GetElement<Element>(), publicKey);
 
         if (ciphertext) {
             ciphertext->SetSlots(plaintext->GetSlots());
@@ -1289,7 +1289,7 @@ public:
         //      OPENFHE_THROW( "Input plaintext is nullptr");
         ValidateKey(privateKey);
 
-        Ciphertext<Element> ciphertext = GetScheme()->Encrypt(plaintext->GetElement<Element>(), privateKey);
+        Ciphertext<Element> ciphertext = m_scheme->Encrypt(plaintext->GetElement<Element>(), privateKey);
 
         if (ciphertext) {
             ciphertext->SetSlots(plaintext->GetSlots());
@@ -1353,7 +1353,7 @@ public:
                                   const PrivateKey<Element>& newPrivateKey) const {
         ValidateKey(oldPrivateKey);
         ValidateKey(newPrivateKey);
-        return GetScheme()->KeySwitchGen(oldPrivateKey, newPrivateKey);
+        return m_scheme->KeySwitchGen(oldPrivateKey, newPrivateKey);
     }
 
     /**
@@ -1366,7 +1366,7 @@ public:
     Ciphertext<Element> KeySwitch(ConstCiphertext<Element>& ciphertext, const EvalKey<Element>& evalKey) const {
         ValidateCiphertext(ciphertext);
         ValidateKey(evalKey);
-        return GetScheme()->KeySwitch(ciphertext, evalKey);
+        return m_scheme->KeySwitch(ciphertext, evalKey);
     }
 
     /**
@@ -1378,7 +1378,7 @@ public:
     void KeySwitchInPlace(Ciphertext<Element>& ciphertext, const EvalKey<Element>& evalKey) const {
         ValidateCiphertext(ciphertext);
         ValidateKey(evalKey);
-        GetScheme()->KeySwitchInPlace(ciphertext, evalKey);
+        m_scheme->KeySwitchInPlace(ciphertext, evalKey);
     }
 
     //------------------------------------------------------------------------------
@@ -1393,7 +1393,7 @@ public:
     */
     Ciphertext<Element> EvalNegate(ConstCiphertext<Element>& ciphertext) const {
         ValidateCiphertext(ciphertext);
-        return GetScheme()->EvalNegate(ciphertext);
+        return m_scheme->EvalNegate(ciphertext);
     }
 
     /**
@@ -1403,7 +1403,7 @@ public:
     */
     void EvalNegateInPlace(Ciphertext<Element>& ciphertext) const {
         ValidateCiphertext(ciphertext);
-        GetScheme()->EvalNegateInPlace(ciphertext);
+        m_scheme->EvalNegateInPlace(ciphertext);
     }
 
     //------------------------------------------------------------------------------
@@ -1419,7 +1419,7 @@ public:
     */
     Ciphertext<Element> EvalAdd(ConstCiphertext<Element>& ciphertext1, ConstCiphertext<Element>& ciphertext2) const {
         TypeCheck(ciphertext1, ciphertext2);
-        return GetScheme()->EvalAdd(ciphertext1, ciphertext2);
+        return m_scheme->EvalAdd(ciphertext1, ciphertext2);
     }
 
     /**
@@ -1430,7 +1430,7 @@ public:
     */
     void EvalAddInPlace(Ciphertext<Element>& ciphertext1, ConstCiphertext<Element>& ciphertext2) const {
         TypeCheck(ciphertext1, ciphertext2);
-        GetScheme()->EvalAddInPlace(ciphertext1, ciphertext2);
+        m_scheme->EvalAddInPlace(ciphertext1, ciphertext2);
     }
 
     void EvalAddInPlaceNoCheck(Ciphertext<Element>& ctxt1, ConstCiphertext<Element>& ctxt2) const {
@@ -1450,7 +1450,7 @@ public:
     */
     Ciphertext<Element> EvalAddMutable(Ciphertext<Element>& ciphertext1, Ciphertext<Element>& ciphertext2) const {
         TypeCheck(ciphertext1, ciphertext2);
-        return GetScheme()->EvalAddMutable(ciphertext1, ciphertext2);
+        return m_scheme->EvalAddMutable(ciphertext1, ciphertext2);
     }
 
     /**
@@ -1461,7 +1461,7 @@ public:
     */
     void EvalAddMutableInPlace(Ciphertext<Element>& ciphertext1, Ciphertext<Element>& ciphertext2) const {
         TypeCheck(ciphertext1, ciphertext2);
-        GetScheme()->EvalAddMutableInPlace(ciphertext1, ciphertext2);
+        m_scheme->EvalAddMutableInPlace(ciphertext1, ciphertext2);
     }
 
     /**
@@ -1474,7 +1474,7 @@ public:
     Ciphertext<Element> EvalAdd(ConstCiphertext<Element>& ciphertext, Plaintext& plaintext) const {
         TypeCheck(ciphertext, plaintext);
         plaintext->SetFormat(EVALUATION);
-        return GetScheme()->EvalAdd(ciphertext, plaintext);
+        return m_scheme->EvalAdd(ciphertext, plaintext);
     }
 
     /**
@@ -1497,7 +1497,7 @@ public:
     void EvalAddInPlace(Ciphertext<Element>& ciphertext, Plaintext& plaintext) const {
         TypeCheck(ciphertext, plaintext);
         plaintext->SetFormat(EVALUATION);
-        GetScheme()->EvalAddInPlace(ciphertext, plaintext);
+        m_scheme->EvalAddInPlace(ciphertext, plaintext);
     }
 
     /**
@@ -1520,7 +1520,7 @@ public:
     Ciphertext<Element> EvalAddMutable(Ciphertext<Element>& ciphertext, Plaintext& plaintext) const {
         TypeCheck(ciphertext, plaintext);
         plaintext->SetFormat(EVALUATION);
-        return GetScheme()->EvalAddMutable(ciphertext, plaintext);
+        return m_scheme->EvalAddMutable(ciphertext, plaintext);
     }
 
     /**
@@ -1542,7 +1542,7 @@ public:
     * @return Resulting ciphertext.
     */
     Ciphertext<Element> EvalAdd(ConstCiphertext<Element>& ciphertext, double scalar) const {
-        return scalar >= 0. ? GetScheme()->EvalAdd(ciphertext, scalar) : GetScheme()->EvalSub(ciphertext, -scalar);
+        return scalar >= 0. ? m_scheme->EvalAdd(ciphertext, scalar) : m_scheme->EvalSub(ciphertext, -scalar);
     }
 
     /**
@@ -1566,9 +1566,9 @@ public:
         if (scalar == 0.)
             return;
         if (scalar > 0.)
-            GetScheme()->EvalAddInPlace(ciphertext, scalar);
+            m_scheme->EvalAddInPlace(ciphertext, scalar);
         else
-            GetScheme()->EvalSubInPlace(ciphertext, -scalar);
+            m_scheme->EvalSubInPlace(ciphertext, -scalar);
     }
 
     /**
@@ -1589,7 +1589,7 @@ public:
     * @return Resulting ciphertext.
     */
     Ciphertext<Element> EvalAdd(ConstCiphertext<Element>& ciphertext, std::complex<double> scalar) const {
-        return GetScheme()->EvalAdd(ciphertext, scalar);
+        return m_scheme->EvalAdd(ciphertext, scalar);
     }
 
     /**
@@ -1612,7 +1612,7 @@ public:
     void EvalAddInPlace(Ciphertext<Element>& ciphertext, std::complex<double> scalar) const {
         if (scalar == std::complex<double>(0.0, 0.0))
             return;
-        GetScheme()->EvalAddInPlace(ciphertext, scalar);
+        m_scheme->EvalAddInPlace(ciphertext, scalar);
     }
 
     /**
@@ -1638,7 +1638,7 @@ public:
     */
     Ciphertext<Element> EvalSub(ConstCiphertext<Element>& ciphertext1, ConstCiphertext<Element>& ciphertext2) const {
         TypeCheck(ciphertext1, ciphertext2);
-        return GetScheme()->EvalSub(ciphertext1, ciphertext2);
+        return m_scheme->EvalSub(ciphertext1, ciphertext2);
     }
 
     /**
@@ -1649,7 +1649,7 @@ public:
     */
     void EvalSubInPlace(Ciphertext<Element>& ciphertext1, ConstCiphertext<Element>& ciphertext2) const {
         TypeCheck(ciphertext1, ciphertext2);
-        GetScheme()->EvalSubInPlace(ciphertext1, ciphertext2);
+        m_scheme->EvalSubInPlace(ciphertext1, ciphertext2);
     }
 
     /**
@@ -1661,7 +1661,7 @@ public:
     */
     Ciphertext<Element> EvalSubMutable(Ciphertext<Element>& ciphertext1, Ciphertext<Element>& ciphertext2) const {
         TypeCheck(ciphertext1, ciphertext2);
-        return GetScheme()->EvalSubMutable(ciphertext1, ciphertext2);
+        return m_scheme->EvalSubMutable(ciphertext1, ciphertext2);
     }
 
     /**
@@ -1672,7 +1672,7 @@ public:
     */
     void EvalSubMutableInPlace(Ciphertext<Element>& ciphertext1, Ciphertext<Element>& ciphertext2) const {
         TypeCheck(ciphertext1, ciphertext2);
-        GetScheme()->EvalSubMutableInPlace(ciphertext1, ciphertext2);
+        m_scheme->EvalSubMutableInPlace(ciphertext1, ciphertext2);
     }
 
     /**
@@ -1684,7 +1684,7 @@ public:
     */
     Ciphertext<Element> EvalSub(ConstCiphertext<Element>& ciphertext, Plaintext& plaintext) const {
         TypeCheck(ciphertext, plaintext);
-        return GetScheme()->EvalSub(ciphertext, plaintext);
+        return m_scheme->EvalSub(ciphertext, plaintext);
     }
 
     /**
@@ -1707,7 +1707,7 @@ public:
     */
     Ciphertext<Element> EvalSubMutable(Ciphertext<Element>& ciphertext, Plaintext& plaintext) const {
         TypeCheck(ciphertext, plaintext);
-        return GetScheme()->EvalSubMutable(ciphertext, plaintext);
+        return m_scheme->EvalSubMutable(ciphertext, plaintext);
     }
 
     /**
@@ -1732,7 +1732,7 @@ public:
     */
     void EvalSubInPlace(Ciphertext<Element>& ciphertext, ConstPlaintext& plaintext) const {
         TypeCheck(ciphertext, plaintext);
-        GetScheme()->EvalSubInPlace(ciphertext, plaintext);
+        m_scheme->EvalSubInPlace(ciphertext, plaintext);
     }
 
     /**
@@ -1754,7 +1754,7 @@ public:
     * @return Resulting ciphertext (ciphertext - scalar).
     */
     Ciphertext<Element> EvalSub(ConstCiphertext<Element>& ciphertext, double scalar) const {
-        return scalar >= 0 ? GetScheme()->EvalSub(ciphertext, scalar) : GetScheme()->EvalAdd(ciphertext, -scalar);
+        return scalar >= 0 ? m_scheme->EvalSub(ciphertext, scalar) : m_scheme->EvalAdd(ciphertext, -scalar);
     }
 
     /**
@@ -1778,9 +1778,9 @@ public:
         if (scalar == 0.)
             return;
         if (scalar > 0.)
-            GetScheme()->EvalSubInPlace(ciphertext, scalar);
+            m_scheme->EvalSubInPlace(ciphertext, scalar);
         else
-            GetScheme()->EvalAddInPlace(ciphertext, -scalar);
+            m_scheme->EvalAddInPlace(ciphertext, -scalar);
     }
 
     /**
@@ -1802,7 +1802,7 @@ public:
     * @return Resulting ciphertext (ciphertext - scalar).
     */
     Ciphertext<Element> EvalSub(ConstCiphertext<Element>& ciphertext, std::complex<double> scalar) const {
-        return GetScheme()->EvalAdd(ciphertext, -scalar);
+        return m_scheme->EvalAdd(ciphertext, -scalar);
     }
 
     /**
@@ -1825,7 +1825,7 @@ public:
     void EvalSubInPlace(Ciphertext<Element>& ciphertext, std::complex<double> scalar) const {
         if (scalar == std::complex<double>(0.0, 0.0))
             return;
-        GetScheme()->EvalAddInPlace(ciphertext, -scalar);
+        m_scheme->EvalAddInPlace(ciphertext, -scalar);
     }
 
     /**
@@ -1875,7 +1875,7 @@ public:
         if (evalKeyVec.empty())
             OPENFHE_THROW("Evaluation key has not been generated for EvalMult");
 
-        return GetScheme()->EvalMult(ciphertext1, ciphertext2, evalKeyVec[0]);
+        return m_scheme->EvalMult(ciphertext1, ciphertext2, evalKeyVec[0]);
     }
 
     /**
@@ -1892,7 +1892,7 @@ public:
         if (evalKeyVec.empty())
             OPENFHE_THROW("Evaluation key has not been generated for EvalMultMutable");
 
-        return GetScheme()->EvalMultMutable(ciphertext1, ciphertext2, evalKeyVec[0]);
+        return m_scheme->EvalMultMutable(ciphertext1, ciphertext2, evalKeyVec[0]);
     }
 
     /**
@@ -1908,7 +1908,7 @@ public:
         if (evalKeyVec.empty())
             OPENFHE_THROW("Evaluation key has not been generated for EvalMultMutableInPlace");
 
-        GetScheme()->EvalMultMutableInPlace(ciphertext1, ciphertext2, evalKeyVec[0]);
+        m_scheme->EvalMultMutableInPlace(ciphertext1, ciphertext2, evalKeyVec[0]);
     }
 
     /**
@@ -1924,7 +1924,7 @@ public:
         if (evalKeyVec.empty())
             OPENFHE_THROW("Evaluation key has not been generated for EvalSquare");
 
-        return GetScheme()->EvalSquare(ciphertext, evalKeyVec[0]);
+        return m_scheme->EvalSquare(ciphertext, evalKeyVec[0]);
     }
 
     /**
@@ -1940,7 +1940,7 @@ public:
         if (evalKeyVec.empty())
             OPENFHE_THROW("Evaluation key has not been generated for EvalSquareMutable");
 
-        return GetScheme()->EvalSquareMutable(ciphertext, evalKeyVec[0]);
+        return m_scheme->EvalSquareMutable(ciphertext, evalKeyVec[0]);
     }
 
     /**
@@ -1955,7 +1955,7 @@ public:
         if (evalKeyVec.empty())
             OPENFHE_THROW("Evaluation key has not been generated for EvalSquareInPlace");
 
-        GetScheme()->EvalSquareInPlace(ciphertext, evalKeyVec[0]);
+        m_scheme->EvalSquareInPlace(ciphertext, evalKeyVec[0]);
     }
 
     /**
@@ -1968,7 +1968,7 @@ public:
     Ciphertext<Element> EvalMultNoRelin(ConstCiphertext<Element>& ciphertext1,
                                         ConstCiphertext<Element>& ciphertext2) const {
         TypeCheck(ciphertext1, ciphertext2);
-        return GetScheme()->EvalMult(ciphertext1, ciphertext2);
+        return m_scheme->EvalMult(ciphertext1, ciphertext2);
     }
 
     Ciphertext<Element> EvalMultNoRelinNoCheck(ConstCiphertext<Element>& ctxt1, ConstCiphertext<Element>& ctxt2) const {
@@ -2028,7 +2028,7 @@ public:
         if (evalKeyVec.size() < (ciphertext->NumberCiphertextElements() - 2))
             OPENFHE_THROW("Insufficient value was used for maxRelinSkDeg to generate keys for Relinearize");
 
-        return GetScheme()->Relinearize(ciphertext, evalKeyVec);
+        return m_scheme->Relinearize(ciphertext, evalKeyVec);
     }
 
     /**
@@ -2045,7 +2045,7 @@ public:
         if (evalKeyVec.size() < (ciphertext->NumberCiphertextElements() - 2))
             OPENFHE_THROW("Insufficient value was used for maxRelinSkDeg to generate keys for RelinearizeInPlace");
 
-        GetScheme()->RelinearizeInPlace(ciphertext, evalKeyVec);
+        m_scheme->RelinearizeInPlace(ciphertext, evalKeyVec);
     }
 
     /**
@@ -2067,7 +2067,7 @@ public:
             OPENFHE_THROW("Insufficient value was used for maxRelinSkDeg to generate keys for EvalMultAndRelinearize");
         }
 
-        return GetScheme()->EvalMultAndRelinearize(ciphertext1, ciphertext2, evalKeyVec);
+        return m_scheme->EvalMultAndRelinearize(ciphertext1, ciphertext2, evalKeyVec);
     }
 
     Ciphertext<Element> EvalMultNoCheck(ConstCiphertext<Element>& ctxt, NativeInteger k) const {
@@ -2088,7 +2088,7 @@ public:
     */
     Ciphertext<Element> EvalMult(ConstCiphertext<Element>& ciphertext, ConstPlaintext& plaintext) const {
         TypeCheck(ciphertext, plaintext);
-        return GetScheme()->EvalMult(ciphertext, plaintext);
+        return m_scheme->EvalMult(ciphertext, plaintext);
     }
 
     /**
@@ -2111,7 +2111,7 @@ public:
     */
     Ciphertext<Element> EvalMultMutable(Ciphertext<Element>& ciphertext, Plaintext& plaintext) const {
         TypeCheck(ciphertext, plaintext);
-        return GetScheme()->EvalMultMutable(ciphertext, plaintext);
+        return m_scheme->EvalMultMutable(ciphertext, plaintext);
     }
 
     /**
@@ -2135,7 +2135,7 @@ public:
     Ciphertext<Element> EvalMult(ConstCiphertext<Element>& ciphertext, double scalar) const {
         if (!ciphertext)
             OPENFHE_THROW("Input ciphertext is nullptr");
-        return GetScheme()->EvalMult(ciphertext, scalar);
+        return m_scheme->EvalMult(ciphertext, scalar);
     }
 
     /**
@@ -2158,7 +2158,7 @@ public:
     void EvalMultInPlace(Ciphertext<Element>& ciphertext, double scalar) const {
         if (!ciphertext)
             OPENFHE_THROW("Input ciphertext is nullptr");
-        GetScheme()->EvalMultInPlace(ciphertext, scalar);
+        m_scheme->EvalMultInPlace(ciphertext, scalar);
     }
 
     /**
@@ -2181,7 +2181,7 @@ public:
     Ciphertext<Element> EvalMult(ConstCiphertext<Element>& ciphertext, std::complex<double> scalar) const {
         if (!ciphertext)
             OPENFHE_THROW("Input ciphertext is nullptr");
-        return GetScheme()->EvalMult(ciphertext, scalar);
+        return m_scheme->EvalMult(ciphertext, scalar);
     }
 
     /**
@@ -2204,7 +2204,7 @@ public:
     void EvalMultInPlace(Ciphertext<Element>& ciphertext, std::complex<double> scalar) const {
         if (!ciphertext)
             OPENFHE_THROW("Input ciphertext is nullptr");
-        GetScheme()->EvalMultInPlace(ciphertext, scalar);
+        m_scheme->EvalMultInPlace(ciphertext, scalar);
     }
 
     /**
@@ -2233,7 +2233,7 @@ public:
         ValidateKey(privateKey);
         if (indexList.empty())
             OPENFHE_THROW("Input index vector is empty");
-        auto evalKeys = GetScheme()->EvalAutomorphismKeyGen(privateKey, indexList);
+        auto evalKeys = m_scheme->EvalAutomorphismKeyGen(privateKey, indexList);
         CryptoContextImpl<Element>::InsertEvalAutomorphismKey(evalKeys, privateKey->GetKeyTag());
         return evalKeys;
     }
@@ -2261,7 +2261,7 @@ public:
         auto evalKey = key->second;
         ValidateKey(evalKey);
 
-        return GetScheme()->EvalAutomorphism(ciphertext, i, evalKeyMap);
+        return m_scheme->EvalAutomorphism(ciphertext, i, evalKeyMap);
     }
 
     /**
@@ -2271,10 +2271,10 @@ public:
     * @return Corresponding automorphism index.
     */
     uint32_t FindAutomorphismIndex(const uint32_t idx) const {
-        const auto cryptoParams  = GetCryptoParameters();
+        const auto cryptoParams  = m_params;
         const auto elementParams = cryptoParams->GetElementParams();
         uint32_t m               = elementParams->GetCyclotomicOrder();
-        return GetScheme()->FindAutomorphismIndex(idx, m);
+        return m_scheme->FindAutomorphismIndex(idx, m);
     }
 
     /**
@@ -2303,7 +2303,7 @@ public:
         ValidateCiphertext(ciphertext);
 
         auto evalKeyMap = CryptoContextImpl<Element>::GetEvalAutomorphismKeyMap(ciphertext->GetKeyTag());
-        return GetScheme()->EvalAtIndex(ciphertext, index, evalKeyMap);
+        return m_scheme->EvalAtIndex(ciphertext, index, evalKeyMap);
     }
 
     /**
@@ -2329,7 +2329,7 @@ public:
     * @return Pointer to precomputed rotation data.
     */
     std::shared_ptr<std::vector<Element>> EvalFastRotationPrecompute(ConstCiphertext<Element>& ciphertext) const {
-        return GetScheme()->EvalFastRotationPrecompute(ciphertext);
+        return m_scheme->EvalFastRotationPrecompute(ciphertext);
     }
 
     /**
@@ -2361,7 +2361,7 @@ public:
     */
     Ciphertext<Element> EvalFastRotation(ConstCiphertext<Element>& ciphertext, const uint32_t index, const uint32_t m,
                                          const std::shared_ptr<std::vector<Element>> digits) const {
-        return GetScheme()->EvalFastRotation(ciphertext, index, m, digits);
+        return m_scheme->EvalFastRotation(ciphertext, index, m, digits);
     }
 
     /**
@@ -2409,7 +2409,7 @@ public:
     Ciphertext<Element> EvalFastRotationExt(ConstCiphertext<Element>& ciphertext, uint32_t index,
                                             const std::shared_ptr<std::vector<Element>> digits, bool addFirst) const {
         auto evalKeyMap = CryptoContextImpl<Element>::GetEvalAutomorphismKeyMap(ciphertext->GetKeyTag());
-        return GetScheme()->EvalFastRotationExt(ciphertext, index, digits, addFirst, evalKeyMap);
+        return m_scheme->EvalFastRotationExt(ciphertext, index, digits, addFirst, evalKeyMap);
     }
 
     /**
@@ -2420,7 +2420,7 @@ public:
     */
     Ciphertext<Element> KeySwitchDown(ConstCiphertext<Element>& ciphertext) const {
         ValidateCiphertext(ciphertext);
-        return GetScheme()->KeySwitchDown(ciphertext);
+        return m_scheme->KeySwitchDown(ciphertext);
     }
 
     /**
@@ -2431,7 +2431,7 @@ public:
     */
     Element KeySwitchDownFirstElement(ConstCiphertext<Element>& ciphertext) const {
         ValidateCiphertext(ciphertext);
-        return GetScheme()->KeySwitchDownFirstElement(ciphertext);
+        return m_scheme->KeySwitchDownFirstElement(ciphertext);
     }
 
     /**
@@ -2443,7 +2443,7 @@ public:
     */
     Ciphertext<Element> KeySwitchExt(ConstCiphertext<Element>& ciphertext, bool addFirst) const {
         ValidateCiphertext(ciphertext);
-        return GetScheme()->KeySwitchExt(ciphertext, addFirst);
+        return m_scheme->KeySwitchExt(ciphertext, addFirst);
     }
 
     /**
@@ -2495,7 +2495,7 @@ public:
         if (evalKeyVec.empty())
             OPENFHE_THROW("Evaluation key has not been generated for EvalMult");
 
-        return GetScheme()->ComposedEvalMult(ciphertext1, ciphertext2, evalKeyVec[0]);
+        return m_scheme->ComposedEvalMult(ciphertext1, ciphertext2, evalKeyVec[0]);
     }
 
     /**
@@ -2506,7 +2506,7 @@ public:
     */
     Ciphertext<Element> Rescale(ConstCiphertext<Element>& ciphertext) const {
         ValidateCiphertext(ciphertext);
-        return GetScheme()->ModReduce(ciphertext, GetCompositeDegreeFromCtxt());
+        return m_scheme->ModReduce(ciphertext, GetCompositeDegreeFromCtxt());
     }
 
     /**
@@ -2516,7 +2516,7 @@ public:
     */
     void RescaleInPlace(Ciphertext<Element>& ciphertext) const {
         ValidateCiphertext(ciphertext);
-        GetScheme()->ModReduceInPlace(ciphertext, GetCompositeDegreeFromCtxt());
+        m_scheme->ModReduceInPlace(ciphertext, GetCompositeDegreeFromCtxt());
     }
 
     /**
@@ -2527,7 +2527,7 @@ public:
     */
     Ciphertext<Element> ModReduce(ConstCiphertext<Element>& ciphertext) const {
         ValidateCiphertext(ciphertext);
-        return GetScheme()->ModReduce(ciphertext, GetCompositeDegreeFromCtxt());
+        return m_scheme->ModReduce(ciphertext, GetCompositeDegreeFromCtxt());
     }
 
     /**
@@ -2537,7 +2537,7 @@ public:
     */
     void ModReduceInPlace(Ciphertext<Element>& ciphertext) const {
         ValidateCiphertext(ciphertext);
-        GetScheme()->ModReduceInPlace(ciphertext, GetCompositeDegreeFromCtxt());
+        m_scheme->ModReduceInPlace(ciphertext, GetCompositeDegreeFromCtxt());
     }
 
     /**
@@ -2553,7 +2553,7 @@ public:
     Ciphertext<Element> LevelReduce(ConstCiphertext<Element>& ciphertext, const EvalKey<Element> evalKey,
                                     size_t levels = 1) const {
         ValidateCiphertext(ciphertext);
-        return GetScheme()->LevelReduce(ciphertext, evalKey, levels * GetCompositeDegreeFromCtxt());
+        return m_scheme->LevelReduce(ciphertext, evalKey, levels * GetCompositeDegreeFromCtxt());
     }
 
     /**
@@ -2568,7 +2568,7 @@ public:
     void LevelReduceInPlace(Ciphertext<Element>& ciphertext, const EvalKey<Element> evalKey, size_t levels = 1) const {
         ValidateCiphertext(ciphertext);
         if (levels > 0)
-            GetScheme()->LevelReduceInPlace(ciphertext, evalKey, levels * GetCompositeDegreeFromCtxt());
+            m_scheme->LevelReduceInPlace(ciphertext, evalKey, levels * GetCompositeDegreeFromCtxt());
     }
 
     /**
@@ -2588,7 +2588,7 @@ public:
             errorMsg += std::to_string(noiseScaleDeg) + "]";
             OPENFHE_THROW(errorMsg);
         }
-        return GetScheme()->Compress(ciphertext, towersLeft, noiseScaleDeg);
+        return m_scheme->Compress(ciphertext, towersLeft, noiseScaleDeg);
     }
 
     //------------------------------------------------------------------------------
@@ -2606,7 +2606,7 @@ public:
             OPENFHE_THROW("Empty input ciphertext vector");
         if (ciphertextVec.size() == 1)
             return ciphertextVec[0];
-        return GetScheme()->EvalAddMany(ciphertextVec);
+        return m_scheme->EvalAddMany(ciphertextVec);
     }
 
     /**
@@ -2618,7 +2618,7 @@ public:
     Ciphertext<Element> EvalAddManyInPlace(std::vector<Ciphertext<Element>>& ciphertextVec) const {
         if (ciphertextVec.empty())
             OPENFHE_THROW("Empty input ciphertext vector");
-        return GetScheme()->EvalAddManyInPlace(ciphertextVec);
+        return m_scheme->EvalAddManyInPlace(ciphertextVec);
     }
 
     /**
@@ -2640,7 +2640,7 @@ public:
         const auto evalKeyVec = CryptoContextImpl<Element>::GetEvalMultKeyVector(ciphertextVec[0]->GetKeyTag());
         if (evalKeyVec.size() < (ciphertextVec[0]->NumberCiphertextElements() - 2))
             OPENFHE_THROW("Insufficient value was used for maxRelinSkDeg to generate keys");
-        return GetScheme()->EvalMultMany(ciphertextVec, evalKeyVec);
+        return m_scheme->EvalMultMany(ciphertextVec, evalKeyVec);
     }
 
     //------------------------------------------------------------------------------
@@ -2657,7 +2657,7 @@ public:
     template <typename VectorDataType = double>
     Ciphertext<Element> EvalLinearWSum(std::vector<ReadOnlyCiphertext<Element>>& ciphertextVec,
                                        const std::vector<VectorDataType>& constantVec) const {
-        return GetScheme()->EvalLinearWSum(ciphertextVec, constantVec);
+        return m_scheme->EvalLinearWSum(ciphertextVec, constantVec);
     }
 
     /**
@@ -2683,7 +2683,7 @@ public:
     template <typename VectorDataType = double>
     Ciphertext<Element> EvalLinearWSumMutable(std::vector<Ciphertext<Element>>& ciphertextVec,
                                               const std::vector<VectorDataType>& constantsVec) const {
-        return GetScheme()->EvalLinearWSumMutable(ciphertextVec, constantsVec);
+        return m_scheme->EvalLinearWSumMutable(ciphertextVec, constantsVec);
     }
 
     /**
@@ -2716,7 +2716,7 @@ public:
     std::shared_ptr<seriesPowers<Element>> EvalPowers(ConstCiphertext<Element>& ciphertext,
                                                       const std::vector<VectorDataType>& coefficients) const {
         ValidateCiphertext(ciphertext);
-        return GetScheme()->EvalPowers(ciphertext, coefficients);
+        return m_scheme->EvalPowers(ciphertext, coefficients);
     }
 
     /**
@@ -2732,14 +2732,14 @@ public:
     Ciphertext<Element> EvalPoly(ConstCiphertext<Element>& ciphertext,
                                  const std::vector<VectorDataType>& coefficients) const {
         ValidateCiphertext(ciphertext);
-        return GetScheme()->EvalPoly(ciphertext, coefficients);
+        return m_scheme->EvalPoly(ciphertext, coefficients);
     }
 
     template <typename VectorDataType = double>
     Ciphertext<Element> EvalPolyWithPrecomp(std::shared_ptr<seriesPowers<Element>> powers,
                                             const std::vector<VectorDataType>& coefficients) const {
         ValidateSeriesPowers(powers);
-        return GetScheme()->EvalPolyWithPrecomp(powers, coefficients);
+        return m_scheme->EvalPolyWithPrecomp(powers, coefficients);
     }
 
     /**
@@ -2754,7 +2754,7 @@ public:
     Ciphertext<Element> EvalPolyLinear(ConstCiphertext<Element>& ciphertext,
                                        const std::vector<VectorDataType>& coefficients) const {
         ValidateCiphertext(ciphertext);
-        return GetScheme()->EvalPolyLinear(ciphertext, coefficients);
+        return m_scheme->EvalPolyLinear(ciphertext, coefficients);
     }
 
     /**
@@ -2769,7 +2769,7 @@ public:
     Ciphertext<Element> EvalPolyPS(ConstCiphertext<Element>& ciphertext,
                                    const std::vector<VectorDataType>& coefficients) const {
         ValidateCiphertext(ciphertext);
-        return GetScheme()->EvalPolyPS(ciphertext, coefficients);
+        return m_scheme->EvalPolyPS(ciphertext, coefficients);
     }
 
     //------------------------------------------------------------------------------
@@ -2794,7 +2794,7 @@ public:
                                                           const std::vector<VectorDataType>& coefficients, double a,
                                                           double b) const {
         ValidateCiphertext(ciphertext);
-        return GetScheme()->EvalChebyPolys(ciphertext, coefficients, a, b);
+        return m_scheme->EvalChebyPolys(ciphertext, coefficients, a, b);
     }
 
     /**
@@ -2813,14 +2813,14 @@ public:
     Ciphertext<Element> EvalChebyshevSeries(ConstCiphertext<Element>& ciphertext,
                                             const std::vector<VectorDataType>& coefficients, double a, double b) const {
         ValidateCiphertext(ciphertext);
-        return GetScheme()->EvalChebyshevSeries(ciphertext, coefficients, a, b);
+        return m_scheme->EvalChebyshevSeries(ciphertext, coefficients, a, b);
     }
 
     template <typename VectorDataType = double>
     Ciphertext<Element> EvalChebyshevSeriesWithPrecomp(std::shared_ptr<seriesPowers<Element>> polys,
                                                        const std::vector<VectorDataType>& coefficients) const {
         ValidateSeriesPowers(polys);
-        return GetScheme()->EvalChebyshevSeriesWithPrecomp(polys, coefficients);
+        return m_scheme->EvalChebyshevSeriesWithPrecomp(polys, coefficients);
     }
 
     /**
@@ -2838,7 +2838,7 @@ public:
                                                   const std::vector<VectorDataType>& coefficients, double a,
                                                   double b) const {
         ValidateCiphertext(ciphertext);
-        return GetScheme()->EvalChebyshevSeriesLinear(ciphertext, coefficients, a, b);
+        return m_scheme->EvalChebyshevSeriesLinear(ciphertext, coefficients, a, b);
     }
 
     /**
@@ -2856,7 +2856,7 @@ public:
                                               const std::vector<VectorDataType>& coefficients, double a,
                                               double b) const {
         ValidateCiphertext(ciphertext);
-        return GetScheme()->EvalChebyshevSeriesPS(ciphertext, coefficients, a, b);
+        return m_scheme->EvalChebyshevSeriesPS(ciphertext, coefficients, a, b);
     }
 
     /**
@@ -3043,7 +3043,7 @@ public:
     EvalKey<Element> ReKeyGen(const PrivateKey<Element> oldPrivateKey, const PublicKey<Element> newPublicKey) const {
         ValidateKey(oldPrivateKey);
         ValidateKey(newPublicKey);
-        return GetScheme()->ReKeyGen(oldPrivateKey, newPublicKey);
+        return m_scheme->ReKeyGen(oldPrivateKey, newPublicKey);
     }
 
     /**
@@ -3070,7 +3070,7 @@ public:
                                   const PublicKey<Element> publicKey = nullptr) const {
         ValidateCiphertext(ciphertext);
         ValidateKey(evalKey);
-        return GetScheme()->ReEncrypt(ciphertext, evalKey, publicKey);
+        return m_scheme->ReEncrypt(ciphertext, evalKey, publicKey);
     }
 
     //------------------------------------------------------------------------------
@@ -3088,7 +3088,7 @@ public:
     KeyPair<Element> MultipartyKeyGen(const std::vector<PrivateKey<Element>>& privateKeyVec) {
         if (privateKeyVec.empty())
             OPENFHE_THROW("Input private key vector is empty");
-        return GetScheme()->MultipartyKeyGen(GetContextForPointer(this), privateKeyVec, false);
+        return m_scheme->MultipartyKeyGen(GetContextForPointer(this), privateKeyVec, false);
     }
 
     /**
@@ -3102,7 +3102,7 @@ public:
     KeyPair<Element> MultipartyKeyGen(const PublicKey<Element> publicKey, bool makeSparse = false, bool fresh = false) {
         if (!publicKey)
             OPENFHE_THROW("Input public key is empty");
-        return GetScheme()->MultipartyKeyGen(GetContextForPointer(this), publicKey, makeSparse, fresh);
+        return m_scheme->MultipartyKeyGen(GetContextForPointer(this), publicKey, makeSparse, fresh);
     }
 
     /**
@@ -3118,7 +3118,7 @@ public:
         std::vector<Ciphertext<Element>> newCiphertextVec;
         for (const auto& ciphertext : ciphertextVec) {
             ValidateCiphertext(ciphertext);
-            newCiphertextVec.push_back(GetScheme()->MultipartyDecryptLead(ciphertext, privateKey));
+            newCiphertextVec.push_back(m_scheme->MultipartyDecryptLead(ciphertext, privateKey));
         }
         return newCiphertextVec;
     }
@@ -3136,7 +3136,7 @@ public:
         std::vector<Ciphertext<Element>> newCiphertextVec;
         for (const auto& ciphertext : ciphertextVec) {
             ValidateCiphertext(ciphertext);
-            newCiphertextVec.push_back(GetScheme()->MultipartyDecryptMain(ciphertext, privateKey));
+            newCiphertextVec.push_back(m_scheme->MultipartyDecryptMain(ciphertext, privateKey));
         }
         return newCiphertextVec;
     }
@@ -3170,7 +3170,7 @@ public:
             OPENFHE_THROW("Input second private key is nullptr");
         if (!evalKey)
             OPENFHE_THROW("Input evaluation key is nullptr");
-        return GetScheme()->MultiKeySwitchGen(originalPrivateKey, newPrivateKey, evalKey);
+        return m_scheme->MultiKeySwitchGen(originalPrivateKey, newPrivateKey, evalKey);
     }
 
     /**
@@ -3191,7 +3191,7 @@ public:
             OPENFHE_THROW("Input evaluation key map is nullptr");
         if (indexList.empty())
             OPENFHE_THROW("Input index vector is empty");
-        return GetScheme()->MultiEvalAutomorphismKeyGen(privateKey, evalKeyMap, indexList, keyTag);
+        return m_scheme->MultiEvalAutomorphismKeyGen(privateKey, evalKeyMap, indexList, keyTag);
     }
 
     /**
@@ -3212,7 +3212,7 @@ public:
             OPENFHE_THROW("Input evaluation key map is nullptr");
         if (indexList.empty())
             OPENFHE_THROW("Input index vector is empty");
-        return GetScheme()->MultiEvalAtIndexKeyGen(privateKey, evalKeyMap, indexList, keyTag);
+        return m_scheme->MultiEvalAtIndexKeyGen(privateKey, evalKeyMap, indexList, keyTag);
     }
 
     /**
@@ -3230,7 +3230,7 @@ public:
             OPENFHE_THROW("Input private key is nullptr");
         if (!evalKeyMap)
             OPENFHE_THROW("Input evaluation key map is nullptr");
-        return GetScheme()->MultiEvalSumKeyGen(privateKey, evalKeyMap, keyTag);
+        return m_scheme->MultiEvalSumKeyGen(privateKey, evalKeyMap, keyTag);
     }
 
     /**
@@ -3247,7 +3247,7 @@ public:
             OPENFHE_THROW("Input first evaluation key is nullptr");
         if (!evalKey2)
             OPENFHE_THROW("Input second evaluation key is nullptr");
-        return GetScheme()->MultiAddEvalKeys(evalKey1, evalKey2, keyTag);
+        return m_scheme->MultiAddEvalKeys(evalKey1, evalKey2, keyTag);
     }
 
     /**
@@ -3264,7 +3264,7 @@ public:
             OPENFHE_THROW("Input private key is nullptr");
         if (!evalKey)
             OPENFHE_THROW("Input evaluation key is nullptr");
-        return GetScheme()->MultiMultEvalKey(privateKey, evalKey, keyTag);
+        return m_scheme->MultiMultEvalKey(privateKey, evalKey, keyTag);
     }
 
     /**
@@ -3282,7 +3282,7 @@ public:
             OPENFHE_THROW("Input first evaluation key map is nullptr");
         if (!evalKeyMap2)
             OPENFHE_THROW("Input second evaluation key map is nullptr");
-        return GetScheme()->MultiAddEvalSumKeys(evalKeyMap1, evalKeyMap2, keyTag);
+        return m_scheme->MultiAddEvalSumKeys(evalKeyMap1, evalKeyMap2, keyTag);
     }
 
     /**
@@ -3300,7 +3300,7 @@ public:
             OPENFHE_THROW("Input first evaluation key map is nullptr");
         if (!evalKeyMap2)
             OPENFHE_THROW("Input second evaluation key map is nullptr");
-        return GetScheme()->MultiAddEvalAutomorphismKeys(evalKeyMap1, evalKeyMap2, keyTag);
+        return m_scheme->MultiAddEvalAutomorphismKeys(evalKeyMap1, evalKeyMap2, keyTag);
     }
 
     /**
@@ -3317,7 +3317,7 @@ public:
             OPENFHE_THROW("Input first public key is nullptr");
         if (!publicKey2)
             OPENFHE_THROW("Input second public key is nullptr");
-        return GetScheme()->MultiAddPubKeys(publicKey1, publicKey2, keyTag);
+        return m_scheme->MultiAddPubKeys(publicKey1, publicKey2, keyTag);
     }
 
     /**
@@ -3334,7 +3334,7 @@ public:
             OPENFHE_THROW("Input first evaluation key is nullptr");
         if (!evalKey2)
             OPENFHE_THROW("Input second evaluation key is nullptr");
-        return GetScheme()->MultiAddEvalMultKeys(evalKey1, evalKey2, keyTag);
+        return m_scheme->MultiAddEvalMultKeys(evalKey1, evalKey2, keyTag);
     }
 
     /**
@@ -3352,7 +3352,7 @@ public:
                                        ConstCiphertext<Element>& ciphertext) const {
         ValidateCiphertext(ciphertext);
         ValidateKey(privateKey);
-        return GetScheme()->IntBootDecrypt(privateKey, ciphertext);
+        return m_scheme->IntBootDecrypt(privateKey, ciphertext);
     }
 
     /**
@@ -3366,7 +3366,7 @@ public:
     Ciphertext<Element> IntBootEncrypt(const PublicKey<Element> publicKey, ConstCiphertext<Element>& ciphertext) const {
         ValidateCiphertext(ciphertext);
         ValidateKey(publicKey);
-        return GetScheme()->IntBootEncrypt(publicKey, ciphertext);
+        return m_scheme->IntBootEncrypt(publicKey, ciphertext);
     }
 
     /**
@@ -3380,7 +3380,7 @@ public:
     Ciphertext<Element> IntBootAdd(ConstCiphertext<Element>& ciphertext1, ConstCiphertext<Element>& ciphertext2) const {
         ValidateCiphertext(ciphertext1);
         ValidateCiphertext(ciphertext2);
-        return GetScheme()->IntBootAdd(ciphertext1, ciphertext2);
+        return m_scheme->IntBootAdd(ciphertext1, ciphertext2);
     }
 
     /**
@@ -3394,7 +3394,7 @@ public:
     */
     Ciphertext<Element> IntBootAdjustScale(ConstCiphertext<Element>& ciphertext) const {
         ValidateCiphertext(ciphertext);
-        return GetScheme()->IntBootAdjustScale(ciphertext);
+        return m_scheme->IntBootAdjustScale(ciphertext);
     }
 
     /**
@@ -3513,7 +3513,7 @@ public:
     void EvalBootstrapSetup(std::vector<uint32_t> levelBudget = {5, 4}, std::vector<uint32_t> dim1 = {0, 0},
                             uint32_t slots = 0, uint32_t correctionFactor = 0, bool precompute = true,
                             bool BTSlotsEncoding = false) {
-        GetScheme()->EvalBootstrapSetup(*this, levelBudget, dim1, slots, correctionFactor, precompute, BTSlotsEncoding);
+        m_scheme->EvalBootstrapSetup(*this, levelBudget, dim1, slots, correctionFactor, precompute, BTSlotsEncoding);
     }
 
     /**
@@ -3524,7 +3524,7 @@ public:
     */
     void EvalBootstrapKeyGen(const PrivateKey<Element> privateKey, uint32_t slots) {
         ValidateKey(privateKey);
-        auto evalKeys = GetScheme()->EvalBootstrapKeyGen(privateKey, slots);
+        auto evalKeys = m_scheme->EvalBootstrapKeyGen(privateKey, slots);
         CryptoContextImpl<Element>::InsertEvalAutomorphismKey(evalKeys, privateKey->GetKeyTag());
     }
 
@@ -3534,7 +3534,7 @@ public:
     * @param slots  Number of slots to be bootstrapped.
     */
     void EvalBootstrapPrecompute(uint32_t slots = 0) {
-        GetScheme()->EvalBootstrapPrecompute(*this, slots);
+        m_scheme->EvalBootstrapPrecompute(*this, slots);
     }
 
     /**
@@ -3547,12 +3547,12 @@ public:
     */
     Ciphertext<Element> EvalBootstrap(ConstCiphertext<Element>& ciphertext, uint32_t numIterations = 1,
                                       uint32_t precision = 0) const {
-        return GetScheme()->EvalBootstrap(ciphertext, numIterations, precision);
+        return m_scheme->EvalBootstrap(ciphertext, numIterations, precision);
     }
 
     Ciphertext<Element> EvalBootstrapStCFirst(ConstCiphertext<Element>& ciphertext, uint32_t numIterations = 1,
                                               uint32_t precision = 0) const {
-        return GetScheme()->EvalBootstrapStCFirst(ciphertext, numIterations, precision);
+        return m_scheme->EvalBootstrapStCFirst(ciphertext, numIterations, precision);
     }
 
     template <typename VectorDataType>
@@ -3560,7 +3560,7 @@ public:
                       const BigInteger& POut, const BigInteger& Bigq, const PublicKey<DCRTPoly>& pubKey,
                       const std::vector<uint32_t>& dim1, const std::vector<uint32_t>& levelBudget,
                       uint32_t lvlsAfterBoot = 0, uint32_t depthLeveledComputation = 0, size_t order = 1) {
-        GetScheme()->EvalFBTSetup(*this, coeffs, numSlots, PIn, POut, Bigq, pubKey, dim1, levelBudget, lvlsAfterBoot,
+        m_scheme->EvalFBTSetup(*this, coeffs, numSlots, PIn, POut, Bigq, pubKey, dim1, levelBudget, lvlsAfterBoot,
                                   depthLeveledComputation, order);
     }
 
@@ -3568,7 +3568,7 @@ public:
     Ciphertext<Element> EvalFBT(ConstCiphertext<Element>& ciphertext, const std::vector<VectorDataType>& coeffs,
                                 uint32_t digitBitSize, const BigInteger& initialScaling, uint64_t postScaling,
                                 uint32_t levelToReduce = 0, size_t order = 1) {
-        return GetScheme()->EvalFBT(ciphertext, coeffs, digitBitSize, initialScaling, postScaling, levelToReduce,
+        return m_scheme->EvalFBT(ciphertext, coeffs, digitBitSize, initialScaling, postScaling, levelToReduce,
                                     order);
     }
 
@@ -3576,12 +3576,12 @@ public:
     Ciphertext<Element> EvalFBTNoDecoding(ConstCiphertext<Element>& ciphertext,
                                           const std::vector<VectorDataType>& coeffs, uint32_t digitBitSize,
                                           const BigInteger& initialScaling, size_t order = 1) {
-        return GetScheme()->EvalFBTNoDecoding(ciphertext, coeffs, digitBitSize, initialScaling, order);
+        return m_scheme->EvalFBTNoDecoding(ciphertext, coeffs, digitBitSize, initialScaling, order);
     }
 
     Ciphertext<Element> EvalHomDecoding(ConstCiphertext<Element>& ciphertext, uint64_t postScaling,
                                         uint32_t levelToReduce = 0) {
-        return GetScheme()->EvalHomDecoding(ciphertext, postScaling, levelToReduce);
+        return m_scheme->EvalHomDecoding(ciphertext, postScaling, levelToReduce);
     }
 
     template <typename VectorDataType>
@@ -3589,21 +3589,21 @@ public:
                                                              const std::vector<VectorDataType>& coeffs,
                                                              uint32_t digitBitSize, const BigInteger& initialScaling,
                                                              size_t order = 1) {
-        return GetScheme()->EvalMVBPrecompute(ciphertext, coeffs, digitBitSize, initialScaling, order);
+        return m_scheme->EvalMVBPrecompute(ciphertext, coeffs, digitBitSize, initialScaling, order);
     }
 
     template <typename VectorDataType>
     Ciphertext<Element> EvalMVB(const std::shared_ptr<seriesPowers<Element>> ciphertexts,
                                 const std::vector<VectorDataType>& coeffs, uint32_t digitBitSize,
                                 const uint64_t postScaling, uint32_t levelToReduce = 0, size_t order = 1) {
-        return GetScheme()->EvalMVB(ciphertexts, coeffs, digitBitSize, postScaling, levelToReduce, order);
+        return m_scheme->EvalMVB(ciphertexts, coeffs, digitBitSize, postScaling, levelToReduce, order);
     }
 
     template <typename VectorDataType>
     Ciphertext<Element> EvalMVBNoDecoding(const std::shared_ptr<seriesPowers<Element>> ciphertexts,
                                           const std::vector<VectorDataType>& coeffs, uint32_t digitBitSize,
                                           size_t order = 1) {
-        return GetScheme()->EvalMVBNoDecoding(ciphertexts, coeffs, digitBitSize, order);
+        return m_scheme->EvalMVBNoDecoding(ciphertexts, coeffs, digitBitSize, order);
     }
 
     template <typename VectorDataType>
@@ -3611,15 +3611,15 @@ public:
                                               const std::vector<std::complex<double>>& coefficientsCheb, double a,
                                               double b, const std::vector<VectorDataType>& coefficientsHerm,
                                               size_t precomp = 0) {
-        return GetScheme()->EvalHermiteTrigSeries(ciphertext, coefficientsCheb, a, b, coefficientsHerm, precomp);
+        return m_scheme->EvalHermiteTrigSeries(ciphertext, coefficientsCheb, a, b, coefficientsHerm, precomp);
     }
 
     uint32_t GetCKKSBootCorrectionFactor() {
-        return GetScheme()->GetCKKSBootCorrectionFactor();
+        return m_scheme->GetCKKSBootCorrectionFactor();
     }
 
     void SetCKKSBootCorrectionFactor(uint32_t cf) {
-        return GetScheme()->SetCKKSBootCorrectionFactor(cf);
+        return m_scheme->SetCKKSBootCorrectionFactor(cf);
     }
 
     //------------------------------------------------------------------------------
@@ -3654,7 +3654,7 @@ public:
         VerifyCKKSScheme(__func__);
         VerifyCKKSRealDataType(__func__);
         SetParamsFromCKKSCryptocontext(params);
-        return GetScheme()->EvalCKKStoFHEWSetup(params);
+        return m_scheme->EvalCKKStoFHEWSetup(params);
     }
 
     /**
@@ -3670,7 +3670,7 @@ public:
         if (!lwesk)
             OPENFHE_THROW("FHEW private key passed to EvalCKKStoFHEWKeyGen is null");
 
-        auto evalKeys = GetScheme()->EvalCKKStoFHEWKeyGen(keyPair, lwesk);
+        auto evalKeys = m_scheme->EvalCKKStoFHEWKeyGen(keyPair, lwesk);
         CryptoContextImpl<Element>::InsertEvalAutomorphismKey(evalKeys, keyPair.secretKey->GetKeyTag());
     }
 
@@ -3684,7 +3684,7 @@ public:
     void EvalCKKStoFHEWPrecompute(double scale = 1.0) {
         VerifyCKKSScheme(__func__);
         VerifyCKKSRealDataType(__func__);
-        GetScheme()->EvalCKKStoFHEWPrecompute(*this, scale);
+        m_scheme->EvalCKKStoFHEWPrecompute(*this, scale);
     }
 
     /**
@@ -3701,7 +3701,7 @@ public:
         if (ciphertext == nullptr)
             OPENFHE_THROW("ciphertext passed to EvalCKKStoFHEW is empty");
 
-        return GetScheme()->EvalCKKStoFHEW(ciphertext, numCtxts);
+        return m_scheme->EvalCKKStoFHEW(ciphertext, numCtxts);
     }
 
     /**
@@ -3715,7 +3715,7 @@ public:
                              uint32_t logQ = 25) {
         VerifyCKKSScheme(__func__);
         VerifyCKKSRealDataType(__func__);
-        GetScheme()->EvalFHEWtoCKKSSetup(*this, ccLWE, numSlotsCKKS, logQ);
+        m_scheme->EvalFHEWtoCKKSSetup(*this, ccLWE, numSlotsCKKS, logQ);
     }
 
     /**
@@ -3734,7 +3734,7 @@ public:
         VerifyCKKSRealDataType(__func__);
         ValidateKey(keyPair.secretKey);
 
-        auto evalKeys = GetScheme()->EvalFHEWtoCKKSKeyGen(keyPair, lwesk, numSlots, numCtxts, dim1, L);
+        auto evalKeys = m_scheme->EvalFHEWtoCKKSKeyGen(keyPair, lwesk, numSlots, numCtxts, dim1, L);
         CryptoContextImpl<Element>::InsertEvalAutomorphismKey(evalKeys, keyPair.secretKey->GetKeyTag());
     }
 
@@ -3755,7 +3755,7 @@ public:
                                        double pmax = 2.0, uint32_t dim1 = 0) const {
         VerifyCKKSScheme(__func__);
         VerifyCKKSRealDataType(__func__);
-        return GetScheme()->EvalFHEWtoCKKS(LWECiphertexts, numCtxts, numSlots, p, pmin, pmax, dim1);
+        return m_scheme->EvalFHEWtoCKKS(LWECiphertexts, numCtxts, numSlots, p, pmin, pmax, dim1);
     }
 
     /**
@@ -3764,7 +3764,7 @@ public:
     * @param params  Scheme switching parameter object to populate.
     */
     void SetParamsFromCKKSCryptocontext(SchSwchParams& params) {
-        const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersCKKSRNS>(GetCryptoParameters());
+        const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersCKKSRNS>(m_params);
         if (!cryptoParams)
             OPENFHE_THROW("Invalid crypto parameters: expected CryptoParametersCKKSRNS");
         params.SetInitialCKKSModulus(cryptoParams->GetElementParams()->GetParams()[0]->GetModulus());
@@ -3787,7 +3787,7 @@ public:
         VerifyCKKSScheme(__func__);
         VerifyCKKSRealDataType(__func__);
         SetParamsFromCKKSCryptocontext(params);
-        return GetScheme()->EvalSchemeSwitchingSetup(params);
+        return m_scheme->EvalSchemeSwitchingSetup(params);
     }
 
     /**
@@ -3801,7 +3801,7 @@ public:
         VerifyCKKSRealDataType(__func__);
         ValidateKey(keyPair.secretKey);
 
-        auto evalKeys = GetScheme()->EvalSchemeSwitchingKeyGen(keyPair, lwesk);
+        auto evalKeys = m_scheme->EvalSchemeSwitchingKeyGen(keyPair, lwesk);
         CryptoContextImpl<Element>::InsertEvalAutomorphismKey(evalKeys, keyPair.secretKey->GetKeyTag());
     }
 
@@ -3816,7 +3816,7 @@ public:
     void EvalCompareSwitchPrecompute(uint32_t pLWE = 0, double scaleSign = 1.0, bool unit = false) {
         VerifyCKKSScheme(__func__);
         VerifyCKKSRealDataType(__func__);
-        GetScheme()->EvalCompareSwitchPrecompute(*this, pLWE, scaleSign, unit);
+        m_scheme->EvalCompareSwitchPrecompute(*this, pLWE, scaleSign, unit);
     }
 
     /**
@@ -3839,7 +3839,7 @@ public:
         VerifyCKKSRealDataType(__func__);
         ValidateCiphertext(ciphertext1);
         ValidateCiphertext(ciphertext2);
-        return GetScheme()->EvalCompareSchemeSwitching(ciphertext1, ciphertext2, numCtxts, numSlots, pLWE, scaleSign,
+        return m_scheme->EvalCompareSchemeSwitching(ciphertext1, ciphertext2, numCtxts, numSlots, pLWE, scaleSign,
                                                        unit);
     }
 
@@ -3864,7 +3864,7 @@ public:
         VerifyCKKSScheme(__func__);
         VerifyCKKSRealDataType(__func__);
         ValidateCiphertext(ciphertext);
-        return GetScheme()->EvalMinSchemeSwitching(ciphertext, publicKey, numValues, numSlots, pLWE, scaleSign);
+        return m_scheme->EvalMinSchemeSwitching(ciphertext, publicKey, numValues, numSlots, pLWE, scaleSign);
     }
 
     /**
@@ -3885,7 +3885,7 @@ public:
         VerifyCKKSScheme(__func__);
         VerifyCKKSRealDataType(__func__);
         ValidateCiphertext(ciphertext);
-        return GetScheme()->EvalMinSchemeSwitchingAlt(ciphertext, publicKey, numValues, numSlots, pLWE, scaleSign);
+        return m_scheme->EvalMinSchemeSwitchingAlt(ciphertext, publicKey, numValues, numSlots, pLWE, scaleSign);
     }
 
     /**
@@ -3907,7 +3907,7 @@ public:
         VerifyCKKSScheme(__func__);
         VerifyCKKSRealDataType(__func__);
         ValidateCiphertext(ciphertext);
-        return GetScheme()->EvalMaxSchemeSwitching(ciphertext, publicKey, numValues, numSlots, pLWE, scaleSign);
+        return m_scheme->EvalMaxSchemeSwitching(ciphertext, publicKey, numValues, numSlots, pLWE, scaleSign);
     }
 
     /**
@@ -3928,7 +3928,7 @@ public:
         VerifyCKKSScheme(__func__);
         VerifyCKKSRealDataType(__func__);
         ValidateCiphertext(ciphertext);
-        return GetScheme()->EvalMaxSchemeSwitchingAlt(ciphertext, publicKey, numValues, numSlots, pLWE, scaleSign);
+        return m_scheme->EvalMaxSchemeSwitchingAlt(ciphertext, publicKey, numValues, numSlots, pLWE, scaleSign);
     }
 
     /**
@@ -3936,7 +3936,7 @@ public:
     * @return BinFHE context.
     */
     std::shared_ptr<lbcrypto::BinFHEContext> GetBinCCForSchemeSwitch() const {
-        return GetScheme()->GetBinCCForSchemeSwitch();
+        return m_scheme->GetBinCCForSchemeSwitch();
     }
 
     /**
@@ -3944,7 +3944,7 @@ public:
     * @param ccLWE BinFHE context.
     */
     void SetBinCCForSchemeSwitch(std::shared_ptr<lbcrypto::BinFHEContext> ccLWE) {
-        GetScheme()->SetBinCCForSchemeSwitch(ccLWE);
+        m_scheme->SetBinCCForSchemeSwitch(ccLWE);
     }
 
     /**
@@ -3952,7 +3952,7 @@ public:
     * @return Switching key ciphertext.
     */
     Ciphertext<Element> GetSwkFC() const {
-        return GetScheme()->GetSwkFC();
+        return m_scheme->GetSwkFC();
     }
 
     /**
@@ -3960,7 +3960,7 @@ public:
     * @param FHEWtoCKKSswk Switching key ciphertext.
     */
     void SetSwkFC(Ciphertext<Element> FHEWtoCKKSswk) {
-        GetScheme()->SetSwkFC(FHEWtoCKKSswk);
+        m_scheme->SetSwkFC(FHEWtoCKKSswk);
     }
 
     /**

--- a/src/pke/include/schemebase/rlwe-cryptoparameters.h
+++ b/src/pke/include/schemebase/rlwe-cryptoparameters.h
@@ -591,9 +591,9 @@ protected:
     void PrintParameters(std::ostream& os) const override {
         CryptoParametersBase<Element>::PrintParameters(os);
 
-        os << "Distrib parm " << GetDistributionParameter() << ", Assurance measure " << GetAssuranceMeasure()
-           << ", Noise scale " << GetNoiseScale() << ", Digit Size " << GetDigitSize() << ", SecretKeyDist "
-           << GetSecretKeyDist() << ", Standard security level " << GetStdLevel() << std::endl;
+        os << "Distrib parm " << m_distributionParameter << ", Assurance measure " << m_assuranceMeasure
+           << ", Noise scale " << m_noiseScale << ", Digit Size " << m_digitSize << ", SecretKeyDist "
+           << m_secretKeyDist << ", Standard security level " << m_stdLevel << std::endl;
     }
 };
 

--- a/src/pke/lib/cryptocontext.cpp
+++ b/src/pke/lib/cryptocontext.cpp
@@ -89,7 +89,7 @@ void CryptoContextImpl<Element>::EvalMultKeyGen(const PrivateKey<Element>& key) 
     if (CryptoContextImpl<Element>::s_evalMultKeyMap.find(key->GetKeyTag()) ==
         CryptoContextImpl<Element>::s_evalMultKeyMap.end()) {
         // the key is not found in the map, so the key has to be generated
-        CryptoContextImpl<Element>::s_evalMultKeyMap[key->GetKeyTag()] = {GetScheme()->EvalMultKeyGen(key)};
+        CryptoContextImpl<Element>::s_evalMultKeyMap[key->GetKeyTag()] = {m_scheme->EvalMultKeyGen(key)};
     }
 }
 
@@ -99,7 +99,7 @@ void CryptoContextImpl<Element>::EvalMultKeysGen(const PrivateKey<Element>& key)
     if (CryptoContextImpl<Element>::s_evalMultKeyMap.find(key->GetKeyTag()) ==
         CryptoContextImpl<Element>::s_evalMultKeyMap.end()) {
         // the key is not found in the map, so the key has to be generated
-        CryptoContextImpl<Element>::s_evalMultKeyMap[key->GetKeyTag()] = GetScheme()->EvalMultKeysGen(key);
+        CryptoContextImpl<Element>::s_evalMultKeyMap[key->GetKeyTag()] = m_scheme->EvalMultKeysGen(key);
     }
 }
 
@@ -146,7 +146,7 @@ void CryptoContextImpl<Element>::InsertEvalMultKey(const std::vector<EvalKey<Ele
 template <typename Element>
 void CryptoContextImpl<Element>::EvalSumKeyGen(const PrivateKey<Element> privateKey) {
     ValidateKey(privateKey);
-    auto&& evalKeys = GetScheme()->EvalSumKeyGen(privateKey);
+    auto&& evalKeys = m_scheme->EvalSumKeyGen(privateKey);
     CryptoContextImpl<Element>::InsertEvalAutomorphismKey(evalKeys, privateKey->GetKeyTag());
 }
 
@@ -155,7 +155,7 @@ std::shared_ptr<std::map<uint32_t, EvalKey<Element>>> CryptoContextImpl<Element>
     const PrivateKey<Element> privateKey, uint32_t rowSize, uint32_t subringDim) {
     ValidateKey(privateKey);
     std::vector<uint32_t> indices;
-    auto&& evalKeys = GetScheme()->EvalSumRowsKeyGen(privateKey, rowSize, subringDim, indices);
+    auto&& evalKeys = m_scheme->EvalSumRowsKeyGen(privateKey, rowSize, subringDim, indices);
     CryptoContextImpl<Element>::InsertEvalAutomorphismKey(evalKeys, privateKey->GetKeyTag());
     return CryptoContextImpl<Element>::GetPartialEvalAutomorphismKeyMapPtr(privateKey->GetKeyTag(), indices);
 }
@@ -172,7 +172,7 @@ std::shared_ptr<std::map<uint32_t, EvalKey<Element>>> CryptoContextImpl<Element>
     const PrivateKey<Element> privateKey) {
     ValidateKey(privateKey);
     std::vector<uint32_t> indices;
-    auto&& evalKeys = GetScheme()->EvalSumColsKeyGen(privateKey, indices);
+    auto&& evalKeys = m_scheme->EvalSumColsKeyGen(privateKey, indices);
     CryptoContextImpl<Element>::InsertEvalAutomorphismKey(evalKeys, privateKey->GetKeyTag());
     return CryptoContextImpl<Element>::GetPartialEvalAutomorphismKeyMapPtr(privateKey->GetKeyTag(), indices);
 }
@@ -271,7 +271,7 @@ template <typename Element>
 void CryptoContextImpl<Element>::EvalAtIndexKeyGen(const PrivateKey<Element> privateKey,
                                                    const std::vector<int32_t>& indexList) {
     ValidateKey(privateKey);
-    auto&& evalKeys = GetScheme()->EvalAtIndexKeyGen(privateKey, indexList);
+    auto&& evalKeys = m_scheme->EvalAtIndexKeyGen(privateKey, indexList);
     CryptoContextImpl<Element>::InsertEvalAutomorphismKey(evalKeys, privateKey->GetKeyTag());
 }
 
@@ -373,7 +373,7 @@ Ciphertext<Element> CryptoContextImpl<Element>::EvalSum(ConstCiphertext<Element>
                                                         uint32_t batchSize) const {
     ValidateCiphertext(ciphertext);
     auto&& evalSumKeys = CryptoContextImpl<Element>::GetEvalAutomorphismKeyMap(ciphertext->GetKeyTag());
-    return GetScheme()->EvalSum(ciphertext, batchSize, evalSumKeys);
+    return m_scheme->EvalSum(ciphertext, batchSize, evalSumKeys);
 }
 
 template <typename Element>
@@ -381,7 +381,7 @@ Ciphertext<Element> CryptoContextImpl<Element>::EvalSumRows(ConstCiphertext<Elem
                                                             const std::map<uint32_t, EvalKey<Element>>& evalSumKeys,
                                                             uint32_t subringDim) const {
     ValidateCiphertext(ciphertext);
-    return GetScheme()->EvalSumRows(ciphertext, numRows, evalSumKeys, subringDim);
+    return m_scheme->EvalSumRows(ciphertext, numRows, evalSumKeys, subringDim);
 }
 
 template <typename Element>
@@ -390,7 +390,7 @@ Ciphertext<Element> CryptoContextImpl<Element>::EvalSumCols(
     const std::map<uint32_t, EvalKey<Element>>& evalSumKeysRight) const {
     ValidateCiphertext(ciphertext);
     auto&& evalSumKeys = CryptoContextImpl<Element>::GetEvalAutomorphismKeyMap(ciphertext->GetKeyTag());
-    return GetScheme()->EvalSumCols(ciphertext, numCols, evalSumKeys, evalSumKeysRight);
+    return m_scheme->EvalSumCols(ciphertext, numCols, evalSumKeys, evalSumKeysRight);
 }
 
 template <typename Element>
@@ -401,7 +401,7 @@ Ciphertext<Element> CryptoContextImpl<Element>::EvalAtIndex(ConstCiphertext<Elem
     if (0 == index)
         return ciphertext->Clone();
     auto&& evalAutomorphismKeys = CryptoContextImpl<Element>::GetEvalAutomorphismKeyMap(ciphertext->GetKeyTag());
-    return GetScheme()->EvalAtIndex(ciphertext, index, evalAutomorphismKeys);
+    return m_scheme->EvalAtIndex(ciphertext, index, evalAutomorphismKeys);
 }
 
 template <typename Element>
@@ -411,7 +411,7 @@ Ciphertext<Element> CryptoContextImpl<Element>::EvalMerge(
         OPENFHE_THROW("Input ciphertext vector is empty");
     ValidateCiphertext(ciphertextVector[0]);
     auto evalAutomorphismKeys = CryptoContextImpl<Element>::GetEvalAutomorphismKeyMap(ciphertextVector[0]->GetKeyTag());
-    return GetScheme()->EvalMerge(ciphertextVector, evalAutomorphismKeys);
+    return m_scheme->EvalMerge(ciphertextVector, evalAutomorphismKeys);
 }
 
 template <typename Element>
@@ -423,7 +423,7 @@ Ciphertext<Element> CryptoContextImpl<Element>::EvalInnerProduct(ConstCiphertext
         OPENFHE_THROW("Information was not generated with this crypto context");
     auto& evalSumKeys = CryptoContextImpl<Element>::GetEvalAutomorphismKeyMap(ct1->GetKeyTag());
     auto& ek          = CryptoContextImpl<Element>::GetEvalMultKeyVector(ct1->GetKeyTag());
-    return GetScheme()->EvalInnerProduct(ct1, ct2, batchSize, evalSumKeys, ek[0]);
+    return m_scheme->EvalInnerProduct(ct1, ct2, batchSize, evalSumKeys, ek[0]);
 }
 
 template <typename Element>
@@ -433,7 +433,7 @@ Ciphertext<Element> CryptoContextImpl<Element>::EvalInnerProduct(ConstCiphertext
     if (ct2 == nullptr)
         OPENFHE_THROW("Information was not generated with this crypto context");
     auto& evalSumKeys = CryptoContextImpl<Element>::GetEvalAutomorphismKeyMap(ct1->GetKeyTag());
-    return GetScheme()->EvalInnerProduct(ct1, ct2, batchSize, evalSumKeys);
+    return m_scheme->EvalInnerProduct(ct1, ct2, batchSize, evalSumKeys);
 }
 
 template <typename Element>
@@ -465,10 +465,10 @@ DecryptResult CryptoContextImpl<Element>::Decrypt(ConstCiphertext<Element>& ciph
     DecryptResult result;
 
     if ((ciphertext->GetEncodingType() == CKKS_PACKED_ENCODING) && (typeid(Element) != typeid(NativePoly))) {
-        result = GetScheme()->Decrypt(ciphertext, privateKey, &decrypted->GetElement<Poly>());
+        result = m_scheme->Decrypt(ciphertext, privateKey, &decrypted->GetElement<Poly>());
     }
     else {
-        result = GetScheme()->Decrypt(ciphertext, privateKey, &decrypted->GetElement<NativePoly>());
+        result = m_scheme->Decrypt(ciphertext, privateKey, &decrypted->GetElement<NativePoly>());
     }
 
     if (result.isValid == false)  // TODO (dsuponit): why don't we throw an exception here?
@@ -485,7 +485,7 @@ DecryptResult CryptoContextImpl<Element>::Decrypt(ConstCiphertext<Element>& ciph
         decryptedCKKS->SetScalingFactor(ciphertext->GetScalingFactor());
         decryptedCKKS->SetSlots(ciphertext->GetSlots());
 
-        const auto cryptoParamsCKKS = std::dynamic_pointer_cast<CryptoParametersRNS>(this->GetCryptoParameters());
+        const auto cryptoParamsCKKS = std::dynamic_pointer_cast<CryptoParametersRNS>(m_params);
         if (!cryptoParamsCKKS)
             OPENFHE_THROW("Invalid crypto parameters: expected CryptoParametersRNS");
 
@@ -577,9 +577,9 @@ DecryptResult CryptoContextImpl<DCRTPoly>::Decrypt(ConstCiphertext<DCRTPoly>& ci
 
     if ((ciphertext->GetEncodingType() == CKKS_PACKED_ENCODING) &&
         (ciphertext->GetElements()[0].GetParams()->GetParams().size() > 1))  // more than one tower in DCRTPoly
-        result = GetScheme()->Decrypt(ciphertext, privateKey, &decrypted->GetElement<Poly>());
+        result = m_scheme->Decrypt(ciphertext, privateKey, &decrypted->GetElement<Poly>());
     else
-        result = GetScheme()->Decrypt(ciphertext, privateKey, &decrypted->GetElement<NativePoly>());
+        result = m_scheme->Decrypt(ciphertext, privateKey, &decrypted->GetElement<NativePoly>());
 
     if (result.isValid == false)
         return result;
@@ -595,7 +595,7 @@ DecryptResult CryptoContextImpl<DCRTPoly>::Decrypt(ConstCiphertext<DCRTPoly>& ci
         decryptedCKKS->SetScalingFactor(ciphertext->GetScalingFactor());
         decryptedCKKS->SetSlots(ciphertext->GetSlots());
 
-        const auto cryptoParamsCKKS = std::dynamic_pointer_cast<CryptoParametersCKKSRNS>(this->GetCryptoParameters());
+        const auto cryptoParamsCKKS = std::dynamic_pointer_cast<CryptoParametersCKKSRNS>(m_params);
         if (!cryptoParamsCKKS)
             OPENFHE_THROW("Invalid crypto parameters: expected CryptoParametersCKKSRNS");
 
@@ -633,9 +633,9 @@ DecryptResult CryptoContextImpl<DCRTPoly>::MultipartyDecryptFusion(
 
     if ((partialCiphertextVec[0]->GetEncodingType() == CKKS_PACKED_ENCODING) &&
         (partialCiphertextVec[0]->GetElements()[0].GetParams()->GetParams().size() > 1))
-        result = GetScheme()->MultipartyDecryptFusion(partialCiphertextVec, &decrypted->GetElement<Poly>());
+        result = m_scheme->MultipartyDecryptFusion(partialCiphertextVec, &decrypted->GetElement<Poly>());
     else
-        result = GetScheme()->MultipartyDecryptFusion(partialCiphertextVec, &decrypted->GetElement<NativePoly>());
+        result = m_scheme->MultipartyDecryptFusion(partialCiphertextVec, &decrypted->GetElement<NativePoly>());
 
     if (result.isValid == false)
         return result;
@@ -647,7 +647,7 @@ DecryptResult CryptoContextImpl<DCRTPoly>::MultipartyDecryptFusion(
         if (!decryptedCKKS)
             OPENFHE_THROW("Invalid plaintext encoding type: expected CKKSPackedEncoding");
         decryptedCKKS->SetSlots(partialCiphertextVec[0]->GetSlots());
-        const auto cryptoParamsCKKS = std::dynamic_pointer_cast<CryptoParametersCKKSRNS>(this->GetCryptoParameters());
+        const auto cryptoParamsCKKS = std::dynamic_pointer_cast<CryptoParametersCKKSRNS>(m_params);
         if (!cryptoParamsCKKS)
             OPENFHE_THROW("Invalid crypto parameters: expected CryptoParametersCKKSRNS");
         decryptedCKKS->Decode(partialCiphertextVec[0]->GetNoiseScaleDeg(), partialCiphertextVec[0]->GetScalingFactor(),
@@ -664,16 +664,16 @@ DecryptResult CryptoContextImpl<DCRTPoly>::MultipartyDecryptFusion(
 
 template <typename Element>
 Ciphertext<Element> CryptoContextImpl<Element>::IntMPBootAdjustScale(ConstCiphertext<Element>& ciphertext) const {
-    return GetScheme()->IntMPBootAdjustScale(ciphertext);
+    return m_scheme->IntMPBootAdjustScale(ciphertext);
 }
 
 template <typename Element>
 Ciphertext<Element> CryptoContextImpl<Element>::IntMPBootRandomElementGen(const PublicKey<Element> publicKey) const {
-    const auto cryptoParamsCKKS = std::dynamic_pointer_cast<CryptoParametersCKKSRNS>(this->GetCryptoParameters());
+    const auto cryptoParamsCKKS = std::dynamic_pointer_cast<CryptoParametersCKKSRNS>(m_params);
     if (!cryptoParamsCKKS)
         OPENFHE_THROW("Invalid crypto parameters: expected CryptoParametersCKKSRNS");
 
-    return GetScheme()->IntMPBootRandomElementGen(cryptoParamsCKKS, publicKey);
+    return m_scheme->IntMPBootRandomElementGen(cryptoParamsCKKS, publicKey);
 }
 
 template <typename Element>
@@ -682,20 +682,20 @@ Ciphertext<Element> CryptoContextImpl<Element>::IntMPBootRandomElementGen(ConstC
     if (!cryptoParamsCKKS)
         OPENFHE_THROW("Invalid crypto parameters: expected CryptoParametersCKKSRNS");
 
-    return GetScheme()->IntMPBootRandomElementGen(cryptoParamsCKKS, ciphertext);
+    return m_scheme->IntMPBootRandomElementGen(cryptoParamsCKKS, ciphertext);
 }
 
 template <typename Element>
 std::vector<Ciphertext<Element>> CryptoContextImpl<Element>::IntMPBootDecrypt(const PrivateKey<Element> privateKey,
                                                                               ConstCiphertext<Element>& ciphertext,
                                                                               ConstCiphertext<Element>& a) const {
-    return GetScheme()->IntMPBootDecrypt(privateKey, ciphertext, a);
+    return m_scheme->IntMPBootDecrypt(privateKey, ciphertext, a);
 }
 
 template <typename Element>
 std::vector<Ciphertext<Element>> CryptoContextImpl<Element>::IntMPBootAdd(
     std::vector<std::vector<Ciphertext<Element>>>& sharesPairVec) const {
-    return GetScheme()->IntMPBootAdd(sharesPairVec);
+    return m_scheme->IntMPBootAdd(sharesPairVec);
 }
 
 template <typename Element>
@@ -703,7 +703,7 @@ Ciphertext<Element> CryptoContextImpl<Element>::IntMPBootEncrypt(const PublicKey
                                                                  const std::vector<Ciphertext<Element>>& sharesPair,
                                                                  ConstCiphertext<Element>& a,
                                                                  ConstCiphertext<Element>& ciphertext) const {
-    return GetScheme()->IntMPBootEncrypt(publicKey, sharesPair, a, ciphertext);
+    return m_scheme->IntMPBootEncrypt(publicKey, sharesPair, a, ciphertext);
 }
 
 // Function for sharing and recovery of secret for Threshold FHE with aborts

--- a/src/pke/lib/scheme/ckksrns/ckksrns-cryptoparameters.cpp
+++ b/src/pke/lib/scheme/ckksrns/ckksrns-cryptoparameters.cpp
@@ -49,7 +49,7 @@ void CryptoParametersCKKSRNS::PrecomputeCRTTables(KeySwitchTechnique ksTech, Sca
     CryptoParametersRNS::PrecomputeCRTTables(ksTech, scalTech, encTech, multTech, numPartQ, auxBits, extraBits);
 
     size_t sizeQ             = GetElementParams()->GetParams().size();
-    uint32_t compositeDegree = this->GetCompositeDegree();
+    uint32_t compositeDegree = m_compositeDegree;
 
     std::vector<NativeInteger> moduliQ(sizeQ);
     std::vector<NativeInteger> rootsQ(sizeQ);


### PR DESCRIPTION
Also, moved some trivial getters from .cpp to .h files, remove some "this->" for class data and function members, added m_ to a privateKey data member in Cryptocontext, changed a few error messages, removed PrintIntegerConstants (unused function), removed duplicate returns