### PR TITLE
fix for issue1232

### DIFF
--- a/src/core/include/lattice/dgsampling-impl.h
+++ b/src/core/include/lattice/dgsampling-impl.h
@@ -91,7 +91,7 @@ void LatticeGaussSampUtility<Element>::GaussSampGq(const Element& syndrome, doub
     for (size_t i = 1; i < k; i++)
         c(i, 0) = (c(i - 1, 0) + m_digits[i]) / base;
 
-#pragma omp parallel for
+#pragma omp parallel for num_threads(OpenFHEParallelControls.GetThreadLimit(u.GetLength()))
     for (size_t j = 0; j < u.GetLength(); j++) {
         typename Element::Integer v(u.at(j));
 
@@ -167,7 +167,7 @@ void LatticeGaussSampUtility<Element>::GaussSampGqArbBase(const Element& syndrom
     for (size_t i = 1; i < k; i++)
         c(i, 0) = (c(i - 1, 0) + (int64_t)m_digits[i]) / static_cast<double>(base);
 
-#pragma omp parallel for
+#pragma omp parallel for num_threads(OpenFHEParallelControls.GetThreadLimit(u.GetLength()))
     for (size_t j = 0; j < u.GetLength(); j++) {
         typename Element::Integer v(u.at(j));
 

--- a/src/core/include/math/matrix-impl.h
+++ b/src/core/include/math/matrix-impl.h
@@ -85,7 +85,7 @@ Matrix<Element> Matrix<Element>::Mult(Matrix<Element> const& other) const {
     }
     Matrix<Element> result(allocZero, rows, other.cols);
     if (rows == 1) {
-#pragma omp parallel for
+#pragma omp parallel for num_threads(OpenFHEParallelControls.GetThreadLimit(result.cols))
         for (size_t col = 0; col < result.cols; ++col) {
             for (size_t i = 0; i < cols; ++i) {
                 result.data[0][col] += data[0][i] * other.data[i][col];
@@ -93,7 +93,7 @@ Matrix<Element> Matrix<Element>::Mult(Matrix<Element> const& other) const {
         }
     }
     else {
-#pragma omp parallel for
+#pragma omp parallel for num_threads(OpenFHEParallelControls.GetThreadLimit(result.rows))
         for (size_t row = 0; row < result.rows; ++row) {
             for (size_t i = 0; i < cols; ++i) {
                 for (size_t col = 0; col < result.cols; ++col) {
@@ -110,7 +110,7 @@ Matrix<Element>& Matrix<Element>::operator+=(Matrix<Element> const& other) {
     if (rows != other.rows || cols != other.cols) {
         OPENFHE_THROW("Addition operands have incompatible dimensions");
     }
-#pragma omp parallel for
+#pragma omp parallel for num_threads(OpenFHEParallelControls.GetThreadLimit(cols))
     for (size_t j = 0; j < cols; ++j) {
         for (size_t i = 0; i < rows; ++i) {
             data[i][j] += other.data[i][j];
@@ -124,7 +124,7 @@ Matrix<Element>& Matrix<Element>::operator-=(Matrix<Element> const& other) {
     if (rows != other.rows || cols != other.cols) {
         OPENFHE_THROW("Subtraction operands have incompatible dimensions");
     }
-#pragma omp parallel for
+#pragma omp parallel for num_threads(OpenFHEParallelControls.GetThreadLimit(cols))
     for (size_t j = 0; j < cols; ++j) {
         for (size_t i = 0; i < rows; ++i) {
             data[i][j] -= other.data[i][j];
@@ -310,7 +310,7 @@ template <class Element>
 Matrix<Element> Matrix<Element>::MultByUnityVector() const {
     Matrix<Element> result(allocZero, rows, 1);
 
-#pragma omp parallel for
+#pragma omp parallel for num_threads(OpenFHEParallelControls.GetThreadLimit(result.rows))
     for (size_t row = 0; row < result.rows; ++row) {
         for (size_t col = 0; col < cols; ++col) {
             result.data[row][0] += data[row][col];
@@ -328,7 +328,7 @@ template <class Element>
 Matrix<Element> Matrix<Element>::MultByRandomVector(std::vector<int> ranvec) const {
     Matrix<Element> result(allocZero, rows, 1);
 
-#pragma omp parallel for
+#pragma omp parallel for num_threads(OpenFHEParallelControls.GetThreadLimit(result.rows))
     for (size_t row = 0; row < result.rows; ++row) {
         for (size_t col = 0; col < cols; ++col) {
             if (ranvec[col] == 1)

--- a/src/core/include/math/matrix.h
+++ b/src/core/include/math/matrix.h
@@ -256,7 +256,8 @@ public:
 
         auto params = g(0, 0).GetParams()->GetParams();
 
-        uint64_t digitCount = (uint64_t)std::ceil(std::log2(params[0]->GetModulus().ConvertToDouble()) / std::log2(base));
+        uint64_t digitCount =
+            (uint64_t)std::ceil(std::log2(params[0]->GetModulus().ConvertToDouble()) / std::log2(base));
 
         for (size_t k = 0; k < digitCount; k++) {
             for (size_t i = 0; i < params.size(); i++) {
@@ -333,7 +334,7 @@ public:
    */
     Matrix<Element> ScalarMult(Element const& other) const {
         Matrix<Element> result(*this);
-#pragma omp parallel for
+#pragma omp parallel for num_threads(OpenFHEParallelControls.GetThreadLimit(result.cols))
         for (size_t col = 0; col < result.cols; ++col) {
             for (size_t row = 0; row < result.rows; ++row) {
                 result.data[row][col] = result.data[row][col] * other;
@@ -450,7 +451,7 @@ public:
             OPENFHE_THROW("Addition operands have incompatible dimensions");
         }
         Matrix<Element> result(*this);
-#pragma omp parallel for
+#pragma omp parallel for num_threads(OpenFHEParallelControls.GetThreadLimit(cols))
         for (size_t j = 0; j < cols; ++j) {
             for (size_t i = 0; i < rows; ++i) {
                 result.data[i][j] += other.data[i][j];
@@ -488,7 +489,7 @@ public:
             OPENFHE_THROW("Subtraction operands have incompatible dimensions");
         }
         Matrix<Element> result(allocZero, rows, other.cols);
-#pragma omp parallel for
+#pragma omp parallel for num_threads(OpenFHEParallelControls.GetThreadLimit(cols))
         for (size_t j = 0; j < cols; ++j) {
             for (size_t i = 0; i < rows; ++i) {
                 result.data[i][j] = data[i][j] - other.data[i][j];

--- a/src/core/include/math/matrixstrassen-impl.h
+++ b/src/core/include/math/matrixstrassen-impl.h
@@ -147,7 +147,7 @@ MatrixStrassen<Element>& MatrixStrassen<Element>::operator+=(MatrixStrassen<Elem
     if (rows != other.rows || cols != other.cols) {
         OPENFHE_THROW("Addition operands have incompatible dimensions");
     }
-#pragma omp parallel for
+#pragma omp parallel for num_threads(OpenFHEParallelControls.GetThreadLimit(cols))
     for (size_t j = 0; j < cols; ++j) {
         for (size_t i = 0; i < rows; ++i) {
             data[i][j] += other.data[i][j];
@@ -161,7 +161,7 @@ inline MatrixStrassen<Element>& MatrixStrassen<Element>::operator-=(MatrixStrass
     if (rows != other.rows || cols != other.cols) {
         OPENFHE_THROW("Subtraction operands have incompatible dimensions");
     }
-#pragma omp parallel for
+#pragma omp parallel for num_threads(OpenFHEParallelControls.GetThreadLimit(cols))
     for (size_t j = 0; j < cols; ++j) {
         for (size_t i = 0; i < rows; ++i) {
             data[i][j] -= other.data[i][j];
@@ -624,7 +624,7 @@ template <class Element>
 MatrixStrassen<Element> MatrixStrassen<Element>::Mult(MatrixStrassen<Element> const& other, int nrec, int pad) const {
     int allrows = rows;
 
-    NUM_THREADS = ParallelControls().GetMachineThreads();
+    NUM_THREADS = OpenFHEParallelControls.GetNumThreads();
 
     if (pad == -1) {
         // int allcols = cols;
@@ -773,7 +773,8 @@ void MatrixStrassen<Element>::multiplyInternalCAPS(it_lineardata_t A, it_lineard
 template <class Element>
 void MatrixStrassen<Element>::addMatricesCAPS(int numEntries, it_lineardata_t C, it_lineardata_t A,
                                               it_lineardata_t B) const {
-#pragma omp parallel for schedule(static, (numEntries + NUM_THREADS - 1) / NUM_THREADS)
+#pragma omp parallel for schedule(static, (numEntries + NUM_THREADS - 1) / NUM_THREADS) \
+    num_threads(OpenFHEParallelControls.GetThreadLimit(numEntries))
     for (int i = 0; i < numEntries; i++) {
         smartAdditionCAPS(C + i, A + i, B + i);
     }
@@ -782,7 +783,8 @@ void MatrixStrassen<Element>::addMatricesCAPS(int numEntries, it_lineardata_t C,
 template <class Element>
 void MatrixStrassen<Element>::subMatricesCAPS(int numEntries, it_lineardata_t C, it_lineardata_t A,
                                               it_lineardata_t B) const {
-#pragma omp parallel for schedule(static, (numEntries + NUM_THREADS - 1) / NUM_THREADS)
+#pragma omp parallel for schedule(static, (numEntries + NUM_THREADS - 1) / NUM_THREADS) \
+    num_threads(OpenFHEParallelControls.GetThreadLimit(numEntries))
     for (int i = 0; i < numEntries; i++) {
         smartSubtractionCAPS(C + i, A + i, B + i);
     }
@@ -840,7 +842,8 @@ void MatrixStrassen<Element>::tripleSubMatricesCAPS(int numEntries, it_lineardat
                                                     it_lineardata_t S12, it_lineardata_t T2, it_lineardata_t S21,
                                                     it_lineardata_t S22, it_lineardata_t T3, it_lineardata_t S31,
                                                     it_lineardata_t S32) const {
-#pragma omp parallel for schedule(static, (numEntries + NUM_THREADS - 1) / NUM_THREADS)
+#pragma omp parallel for schedule(static, (numEntries + NUM_THREADS - 1) / NUM_THREADS) \
+    num_threads(OpenFHEParallelControls.GetThreadLimit(numEntries))
     for (int i = 0; i < numEntries; i++) {
         smartSubtractionCAPS(T1 + i, S11 + i, S12 + i);
 
@@ -855,7 +858,8 @@ void MatrixStrassen<Element>::tripleAddMatricesCAPS(int numEntries, it_lineardat
                                                     it_lineardata_t S12, it_lineardata_t T2, it_lineardata_t S21,
                                                     it_lineardata_t S22, it_lineardata_t T3, it_lineardata_t S31,
                                                     it_lineardata_t S32) const {
-#pragma omp parallel for schedule(static, (numEntries + NUM_THREADS - 1) / NUM_THREADS)
+#pragma omp parallel for schedule(static, (numEntries + NUM_THREADS - 1) / NUM_THREADS) \
+    num_threads(OpenFHEParallelControls.GetThreadLimit(numEntries))
     for (int i = 0; i < numEntries; i++) {
         smartAdditionCAPS(T1 + i, S11 + i, S12 + i);
 
@@ -869,7 +873,8 @@ template <class Element>
 void MatrixStrassen<Element>::addSubMatricesCAPS(int numEntries, it_lineardata_t T1, it_lineardata_t S11,
                                                  it_lineardata_t S12, it_lineardata_t T2, it_lineardata_t S21,
                                                  it_lineardata_t S22) const {
-#pragma omp parallel for schedule(static, (numEntries + NUM_THREADS - 1) / NUM_THREADS)
+#pragma omp parallel for schedule(static, (numEntries + NUM_THREADS - 1) / NUM_THREADS) \
+    num_threads(OpenFHEParallelControls.GetThreadLimit(numEntries))
     for (int i = 0; i < numEntries; i++) {
         smartAdditionCAPS(T1 + i, S11 + i, S12 + i);
 
@@ -967,7 +972,7 @@ void MatrixStrassen<Element>::strassenDFSCAPS(it_lineardata_t A, it_lineardata_t
 template <class Element>
 void MatrixStrassen<Element>::block_multiplyCAPS(it_lineardata_t A, it_lineardata_t B, it_lineardata_t C,
                                                  MatDescriptor d, it_lineardata_t work) const {
-#pragma omp parallel for
+#pragma omp parallel for num_threads(OpenFHEParallelControls.GetThreadLimit(d.lda))
     for (int32_t row = 0; row < d.lda; row++) {
         Element Aval;
         Element Bval;
@@ -1164,7 +1169,7 @@ void MatrixStrassen<Element>::getData(const data_t& Adata, const data_t& Bdata, 
     printf("Cdata[3][0] = %d\n", static_cast<int>(*Cdata[3][0]));
     printf("row = %d inner = %d col = %d\n", row, inner, col);
 
-#pragma omp parallel for
+#pragma omp parallel for num_threads(OpenFHEParallelControls.GetThreadLimit(row))
     for (int i = 0; i < row; i++) {
         for (int k = 0; k < inner; k++) {
             for (int j = 0; j < col; j++) {
@@ -1183,7 +1188,7 @@ template <class Element>
 MatrixStrassen<Element> MatrixStrassen<Element>::MultByUnityVector() const {
     MatrixStrassen<Element> result(allocZero, rows, 1);
 
-#pragma omp parallel for
+#pragma omp parallel for num_threads(OpenFHEParallelControls.GetThreadLimit(result.rows))
     for (int32_t row = 0; row < result.rows; ++row) {
         for (int32_t col = 0; col < cols; ++col) {
             *result.data[row][0] += *data[row][col];
@@ -1201,7 +1206,7 @@ MatrixStrassen<Element> MatrixStrassen<Element>::MultByUnityVector() const {
 template <class Element>
 MatrixStrassen<Element> MatrixStrassen<Element>::MultByRandomVector(std::vector<int> ranvec) const {
     MatrixStrassen<Element> result(allocZero, rows, 1);
-#pragma omp parallel for
+#pragma omp parallel for num_threads(OpenFHEParallelControls.GetThreadLimit(result.rows))
     for (int32_t row = 0; row < result.rows; ++row) {
         for (int32_t col = 0; col < cols; ++col) {
             if (ranvec[col] == 1)

--- a/src/core/include/math/matrixstrassen.h
+++ b/src/core/include/math/matrixstrassen.h
@@ -186,7 +186,7 @@ public:
    */
     inline MatrixStrassen<Element> ScalarMult(Element const& other) const {
         MatrixStrassen<Element> result(*this);
-#pragma omp parallel for
+#pragma omp parallel for num_threads(OpenFHEParallelControls.GetThreadLimit(result.cols))
         for (int32_t col = 0; col < result.cols; ++col) {
             for (int32_t row = 0; row < result.rows; ++row) {
                 *result.data[row][col] = *result.data[row][col] * other;
@@ -302,7 +302,7 @@ public:
             OPENFHE_THROW("Addition operands have incompatible dimensions");
         }
         MatrixStrassen<Element> result(*this);
-#pragma omp parallel for
+#pragma omp parallel for num_threads(OpenFHEParallelControls.GetThreadLimit(cols))
         for (int32_t j = 0; j < cols; ++j) {
             for (int32_t i = 0; i < rows; ++i) {
                 *result.data[i][j] += *other.data[i][j];
@@ -341,7 +341,7 @@ public:
             OPENFHE_THROW("Subtraction operands have incompatible dimensions");
         }
         MatrixStrassen<Element> result(allocZero, rows, other.cols);
-#pragma omp parallel for
+#pragma omp parallel for num_threads(OpenFHEParallelControls.GetThreadLimit(cols))
         for (int32_t j = 0; j < cols; ++j) {
             for (int32_t i = 0; i < rows; ++i) {
                 *result.data[i][j] = *data[i][j] - *other.data[i][j];

--- a/src/core/include/utils/parallel.h
+++ b/src/core/include/utils/parallel.h
@@ -37,6 +37,7 @@
 #define SRC_CORE_LIB_UTILS_PARALLEL_H_
 
 #ifdef PARALLEL
+    #include <atomic>
     #include <omp.h>
 #endif
 
@@ -44,38 +45,31 @@ namespace lbcrypto {
 
 class ParallelControls {
 public:
-    // @Brief CTOR, enables parallel operations as default
-    // Cache the number of machine threads the system reports (can be
-    // overridden by environment variables)
-    // enable on startup by default
+    // @Brief CTOR, latches the number of machine threads the system reports
+    // (can be overridden by environment variables) and allows all of them by default.
     ParallelControls() {
 #ifdef PARALLEL
         machineThreads = omp_get_max_threads();
-        Enable();
-            // omp_set_dynamic(0);
-            // omp_set_nested(0);
-            // omp_set_max_active_levels(1);
+        threadLimit.store(machineThreads, std::memory_order_relaxed);
 #endif
     }
 
     // @Brief Enable() enables parallel operation
-    void Enable() const {
-#ifdef PARALLEL
-        omp_set_num_threads(machineThreads);
-#endif
+    void Enable() {
+        SetNumThreads(machineThreads);
     }
 
     // @Brief Disable() disables parallel operation
-    void Disable() const {
-#ifdef PARALLEL
-        omp_set_num_threads(1);
-#endif
+    void Disable() {
+        SetNumThreads(1);
     }
 
+    // @Brief returns the number of threads latched at construction
     int GetMachineThreads() const {
         return machineThreads;
     }
 
+    // @Brief returns the number of processors available to the process
     static int GetNumProcs() {
 #ifdef PARALLEL
         return omp_get_num_procs();
@@ -85,60 +79,56 @@ public:
     }
 
     // @Brief returns current number of threads that are usable
-    // @return int # threads
     int GetNumThreads() const {
 #ifdef PARALLEL
-        int nthreads = 1;
-        int tid      = 1;
-            // Fork a team of threads giving them their own copies of variables
-            // so we can see how many threads we have to work with
-    #pragma omp parallel private(tid)
-        {
-            /* Obtain thread number */
-            tid = omp_get_thread_num();
-
-            /* Only main thread does this */
-            if (tid == 0) {
-                nthreads = omp_get_num_threads();
-            }
-        }
-        return nthreads;
+        return threadLimit.load(std::memory_order_relaxed);
 #else
         return 1;
 #endif
     }
 
-    // @Brief returns min of int n and machineThreads
+    // @Brief returns min of int n and the current thread limit
     int GetThreadLimit(int n) const {
 #ifdef PARALLEL
-        return n > machineThreads ? machineThreads : n;
+        int lim = threadLimit.load(std::memory_order_relaxed);
+        return n > lim ? lim : n;
 #else
         return 1;
 #endif
     }
 
-    // @Brief sets number of threads to use (limited by system value)
+    // @Brief sets number of threads to use (clamped to [1, machineThreads])
     void SetNumThreads(int nthreads) {
 #ifdef PARALLEL
-        // set number of thread, but limit to the system set number of machine threads...
-        omp_set_num_threads(nthreads > machineThreads ? machineThreads : nthreads);
+        if (nthreads < 1)
+            nthreads = 1;
+        else if (nthreads > machineThreads)
+            nthreads = machineThreads;
+        threadLimit.store(nthreads, std::memory_order_relaxed);
+        omp_set_num_threads(nthreads);
 #endif
     }
 
+    // @Brief caps unit tests at half the processors; restored by UnitTestStop()
     void UnitTestStart() {
 #ifdef PARALLEL
-        int nthreads = omp_get_max_threads() >> 1;
-        omp_set_num_threads(nthreads > machineThreads ? machineThreads : nthreads);
+        savedLimit = threadLimit.load(std::memory_order_relaxed);
+        SetNumThreads(GetNumProcs() / 2);
 #endif
     }
 
+    // @Brief restores the thread limit saved by UnitTestStart()
     void UnitTestStop() {
 #ifdef PARALLEL
-        omp_set_num_threads(machineThreads);
+        SetNumThreads(savedLimit);
 #endif
     }
 
 private:
+#ifdef PARALLEL
+    std::atomic<int> threadLimit{1};
+    int savedLimit{1};
+#endif
     int machineThreads{1};
 };
 

--- a/src/pke/lib/scheme/ckksrns/ckksrns-schemeswitching.cpp
+++ b/src/pke/lib/scheme/ckksrns/ckksrns-schemeswitching.cpp
@@ -41,6 +41,7 @@
 #include "scheme/ckksrns/ckksrns-fhe.h"
 #include "scheme/ckksrns/ckksrns-schemeswitching.h"
 #include "scheme/ckksrns/gen-cryptocontext-ckksrns.h"
+#include "utils/parallel.h"
 
 #include <algorithm>
 #include <cmath>
@@ -464,7 +465,7 @@ std::vector<std::vector<std::complex<double>>> EvalLTRectPrecomputeSwitch(
             A_slices[i] = std::vector<std::vector<std::complex<double>>>(A.begin() + i * A[0].size(),
                                                                          A.begin() + (i + 1) * A[0].size());
         }
-#pragma omp parallel for
+#pragma omp parallel for num_threads(OpenFHEParallelControls.GetThreadLimit(gStep))
         for (uint32_t j = 0; j < gStep; j++) {
             for (uint32_t i = 0; i < bStep; i++) {
                 if (bStep * j + i < n) {


### PR DESCRIPTION
Fixes #1232.

## Problem

`OpenFHEParallelControls::SetNumThreads(n)` is silently ignored by the library's
parallel hot regions. Every hot region is emitted as
`#pragma omp parallel for num_threads(GetThreadLimit(size))`, and per the OpenMP
spec an explicit `num_threads(...)` clause overrides the nthreads ICV that
`omp_set_num_threads()` sets. Since `GetThreadLimit()` compares only against a
thread count latched once at library load, there is no in-process way to cap the
library. Related defects in `parallel.h`:

- Thread limits are per-thread, not process-global — the nthreads ICV is
  thread-local, so a cap set on one thread never applies to regions entered from
  another (e.g. FHE work on a worker pool). This is also why clamping by a live
  `omp_get_max_threads()` inside `GetThreadLimit()` would be insufficient.
- `UnitTestStart()` halves the wrong base — it reads the current mutable ICV, so
  repeated calls compound (16 → 8 → 4) and any prior cap skews it; its throttle
  is itself bypassed by the `GetThreadLimit` regions.
- `UnitTestStop()` unconditionally restores `machineThreads`, stomping any cap
  the application had set.
- `omp_set_num_threads(0)` is reachable (via `SetNumThreads(0)`, or
  `UnitTestStart()` with one thread available); the spec requires a positive
  argument.
- Several parallel regions (matrix, matrixstrassen, dgsampling, CKKS scheme
  switching) have no `num_threads` clause at all, so they follow only the
  thread-local ICV.

## Changes

`src/core/include/utils/parallel.h`:
- New `std::atomic<int> threadLimit` holds the process-global cap;
  `GetThreadLimit()` mins against it (relaxed load, ~0.3 ns — measured). A cached
  member is preferred over reading the live ICV because the ICV is per-thread:
  after `omp_set_num_threads(2)` on one thread, another thread still reads the
  machine default.
- `SetNumThreads()` clamps to `[1, machineThreads]`, stores the cap, and still
  sets the ICV for clause-less regions.
- `Enable()`/`Disable()` route through `SetNumThreads()` so they actually govern
  the hot regions.
- `UnitTestStart()` uses `GetNumProcs()/2` (stable hardware base, immune to
  `OMP_NUM_THREADS` over/undersubscription) and saves the current cap;
  `UnitTestStop()` restores it.
- The constructor no longer calls `Enable()`; constructing a `ParallelControls`
  has no side effects on global OpenMP state.
- `GetNumThreads()` is now a relaxed atomic load.

Added `num_threads(OpenFHEParallelControls.GetThreadLimit(<trip count>))` to the
27 clause-less regions in `matrix.h`, `matrix-impl.h`, `matrixstrassen.h`,
`matrixstrassen-impl.h`, `dgsampling-impl.h`, and
`ckksrns-schemeswitching.cpp`, so all regions obey the same process-global cap.
The Strassen `NUM_THREADS` latch now reads
`OpenFHEParallelControls.GetNumThreads()` so its `schedule` chunk math matches
the capped team size.