### PR TITLE
Fix to the 128-bit CKKS complex encoding

### DIFF
--- a/src/pke/lib/encoding/ckkspackedencoding.cpp
+++ b/src/pke/lib/encoding/ckkspackedencoding.cpp
@@ -164,7 +164,10 @@ bool CKKSPackedEncoding::Encode() {
             re = re64 >> (-pRemaining);
         }
         else {
-            int128_t pPowRemaining = ((int128_t)1) << pRemaining;
+            if (pRemaining > 126)
+                OPENFHE_THROW("Invalid CKKS scaling shift");
+
+            int128_t pPowRemaining = static_cast<int128_t>(1) << pRemaining;
             re                     = pPowRemaining * re64;
         }
 
@@ -175,7 +178,10 @@ bool CKKSPackedEncoding::Encode() {
             im = im64 >> (-pRemaining);
         }
         else {
-            int128_t pPowRemaining = (static_cast<int64_t>(1)) << pRemaining;
+            if (pRemaining > 126)
+                OPENFHE_THROW("Invalid CKKS scaling shift");
+
+            int128_t pPowRemaining = static_cast<int128_t>(1) << pRemaining;
             im                     = pPowRemaining * im64;
         }
 

--- a/src/pke/lib/scheme/ckksrns/ckksrns-fhe.cpp
+++ b/src/pke/lib/scheme/ckksrns/ckksrns-fhe.cpp
@@ -2665,7 +2665,10 @@ Plaintext FHECKKSRNS::MakeAuxPlaintext(const CryptoContextImpl<DCRTPoly>& cc, co
             re = re64 >> (-pRemaining);
         }
         else {
-            int128_t pPowRemaining = ((int128_t)1) << pRemaining;
+            if (pRemaining > 126)
+                OPENFHE_THROW("Invalid CKKS scaling shift");
+
+            int128_t pPowRemaining = static_cast<int128_t>(1) << pRemaining;
             re                     = pPowRemaining * re64;
         }
 
@@ -2676,6 +2679,9 @@ Plaintext FHECKKSRNS::MakeAuxPlaintext(const CryptoContextImpl<DCRTPoly>& cc, co
             im = im64 >> (-pRemaining);
         }
         else {
+            if (pRemaining > 126)
+                OPENFHE_THROW("Invalid CKKS scaling shift");
+
             int128_t pPowRemaining = static_cast<int128_t>(1) << pRemaining;
             im                     = pPowRemaining * im64;
         }


### PR DESCRIPTION
1. Fixed the shift for 128-bit CKKS encoding (the integer type was int64_t instead of int128_t which was not enough for shifting)
2. Added a check for the left-shift range