### PR TITLE
Fix UB signed shifts in SignedDigitDecompose and accelerate gadget decomposition

### DIFF
--- a/src/binfhe/lib/rgsw-acc.cpp
+++ b/src/binfhe/lib/rgsw-acc.cpp
@@ -52,6 +52,11 @@
 
 namespace lbcrypto {
 
+static inline NativeInteger::SignedNativeInt SignExtend(NativeInteger::SignedNativeInt d,
+                                                        NativeInteger::SignedNativeInt bits) {
+    return static_cast<NativeInteger::SignedNativeInt>(static_cast<NativeInteger::Integer>(d) << bits) >> bits;
+}
+
 void RingGSWAccumulator::SignedDigitDecompose(const std::shared_ptr<RingGSWCryptoParams>& params,
                                               const std::vector<NativePoly>& input,
                                               std::vector<NativePoly>& output) const {
@@ -69,20 +74,20 @@ void RingGSWAccumulator::SignedDigitDecompose(const std::shared_ptr<RingGSWCrypt
         auto t1{input[1][k].ConvertToInt<BasicInteger>()};
         auto d1{static_cast<NativeInteger::SignedNativeInt>(t1 < QHalf ? t1 : t1 - Q_int)};
 
-        auto r0{(d0 << gBitsMaxBits) >> gBitsMaxBits};
+        auto r0{SignExtend(d0, gBitsMaxBits)};
         d0 = (d0 - r0) >> gBits;
 
-        auto r1{(d1 << gBitsMaxBits) >> gBitsMaxBits};
+        auto r1{SignExtend(d1, gBitsMaxBits)};
         d1 = (d1 - r1) >> gBits;
 
         for (uint32_t d{0}; d < digitsG2; d += 2) {
-            r0 = (d0 << gBitsMaxBits) >> gBitsMaxBits;
+            r0 = SignExtend(d0, gBitsMaxBits);
             d0 = (d0 - r0) >> gBits;
             if (r0 < 0)
                 r0 += Q_int;
             output[d + 0][k] += r0;
 
-            r1 = (d1 << gBitsMaxBits) >> gBitsMaxBits;
+            r1 = SignExtend(d1, gBitsMaxBits);
             d1 = (d1 - r1) >> gBits;
             if (r1 < 0)
                 r1 += Q_int;
@@ -106,11 +111,11 @@ void RingGSWAccumulator::SignedDigitDecompose(const std::shared_ptr<RingGSWCrypt
         auto t0{input[k].ConvertToInt<BasicInteger>()};
         auto d0{static_cast<NativeInteger::SignedNativeInt>(t0 < QHalf ? t0 : t0 - Q_int)};
 
-        auto r0{(d0 << gBitsMaxBits) >> gBitsMaxBits};
+        auto r0{SignExtend(d0, gBitsMaxBits)};
         d0 = (d0 - r0) >> gBits;
 
         for (uint32_t d{0}; d < digitsG; ++d) {
-            r0 = (d0 << gBitsMaxBits) >> gBitsMaxBits;
+            r0 = SignExtend(d0, gBitsMaxBits);
             d0 = (d0 - r0) >> gBits;
             if (r0 < 0)
                 r0 += Q_int;

--- a/src/binfhe/lib/rgsw-acc.cpp
+++ b/src/binfhe/lib/rgsw-acc.cpp
@@ -52,50 +52,43 @@
 
 namespace lbcrypto {
 
-static inline NativeInteger::SignedNativeInt SignExtend(NativeInteger::SignedNativeInt d,
-                                                        NativeInteger::SignedNativeInt bits) {
-    return static_cast<NativeInteger::SignedNativeInt>(static_cast<NativeInteger::Integer>(d) << bits) >> bits;
-}
-
 void RingGSWAccumulator::SignedDigitDecompose(const std::shared_ptr<RingGSWCryptoParams>& params,
                                               const std::vector<NativePoly>& input,
                                               std::vector<NativePoly>& output) const {
-    auto QHalf{params->GetQ().ConvertToInt<BasicInteger>() >> 1};
-    auto Q_int{params->GetQ().ConvertToInt<NativeInteger::SignedNativeInt>()};
-    auto gBits{static_cast<NativeInteger::SignedNativeInt>(__builtin_ctz(params->GetBaseG()))};
-    auto gBitsMaxBits{static_cast<NativeInteger::SignedNativeInt>(NativeInteger::MaxBits() - gBits)};
-    auto gHalf{static_cast<NativeInteger::SignedNativeInt>(params->GetBaseG() >> 1)};
+    auto Q{params->GetQ().ConvertToInt<BasicInteger>()};
+    auto QHalf{Q >> 1};
+    auto gBits{static_cast<uint32_t>(__builtin_ctz(params->GetBaseG()))};
+    auto gHalf{static_cast<BasicInteger>(params->GetBaseG() >> 1)};
+    auto gMask{static_cast<BasicInteger>(params->GetBaseG() - 1)};
+    auto QmHalf{Q - gHalf};
+    uint32_t digitsG{params->GetDigitsG()};
+    // Biasing by H (gHalf in every digit position) turns balanced-digit extraction into
+    // independent unsigned windows: digit_k(x) = (((x + H) >> k*gBits) & gMask) - gHalf.
+    // Requires digitsG*gBits < MaxBits, which holds for all supported parameter sets.
+    BasicInteger H{0};
+    for (uint32_t i{0}; i < digitsG; ++i)
+        H += gHalf << (i * gBits);
     // approximate gadget decomposition is used; the first digit is ignored
-    uint32_t digitsG2{(params->GetDigitsG() - 1) << 1};
+    uint32_t digitsG2{(digitsG - 1) << 1};
     uint32_t N{params->GetN()};
 
-    // digit-major order: carry0/carry1 hold the running quotient for every coefficient so
-    // that each inner loop is unit-stride and vectorizable
-    std::vector<NativeInteger::SignedNativeInt> carry0(N), carry1(N);
+    std::vector<BasicInteger> w0(N), w1(N);
     for (uint32_t k{0}; k < N; ++k) {
         auto t0{input[0][k].ConvertToInt<BasicInteger>()};
-        auto d0{static_cast<NativeInteger::SignedNativeInt>(t0 < QHalf ? t0 : t0 - Q_int)};
-        carry0[k] = (d0 + gHalf) >> gBits;
+        w0[k] = t0 + H - (t0 < QHalf ? 0 : Q);
         auto t1{input[1][k].ConvertToInt<BasicInteger>()};
-        auto d1{static_cast<NativeInteger::SignedNativeInt>(t1 < QHalf ? t1 : t1 - Q_int)};
-        carry1[k] = (d1 + gHalf) >> gBits;
+        w1[k] = t1 + H - (t1 < QHalf ? 0 : Q);
     }
 
     for (uint32_t d{0}; d < digitsG2; d += 2) {
+        uint32_t shift{((d >> 1) + 1) * gBits};
         auto& out0{output[d + 0]};
         auto& out1{output[d + 1]};
         for (uint32_t k{0}; k < N; ++k) {
-            auto r0{SignExtend(carry0[k], gBitsMaxBits)};
-            carry0[k] = (carry0[k] + gHalf) >> gBits;
-            if (r0 < 0)
-                r0 += Q_int;
-            out0[k] += r0;
-
-            auto r1{SignExtend(carry1[k], gBitsMaxBits)};
-            carry1[k] = (carry1[k] + gHalf) >> gBits;
-            if (r1 < 0)
-                r1 += Q_int;
-            out1[k] += r1;
+            auto r0{(w0[k] >> shift) & gMask};
+            out0[k] += (r0 < gHalf) ? r0 + QmHalf : r0 - gHalf;
+            auto r1{(w1[k] >> shift) & gMask};
+            out1[k] += (r1 < gHalf) ? r1 + QmHalf : r1 - gHalf;
         }
     }
 }
@@ -103,32 +96,32 @@ void RingGSWAccumulator::SignedDigitDecompose(const std::shared_ptr<RingGSWCrypt
 // Decompose a ring element, not ciphertext
 void RingGSWAccumulator::SignedDigitDecompose(const std::shared_ptr<RingGSWCryptoParams>& params,
                                               const NativePoly& input, std::vector<NativePoly>& output) const {
-    auto QHalf{params->GetQ().ConvertToInt<BasicInteger>() >> 1};
-    auto Q_int{params->GetQ().ConvertToInt<NativeInteger::SignedNativeInt>()};
-    auto gBits{static_cast<NativeInteger::SignedNativeInt>(__builtin_ctz(params->GetBaseG()))};
-    auto gBitsMaxBits{static_cast<NativeInteger::SignedNativeInt>(NativeInteger::MaxBits() - gBits)};
-    auto gHalf{static_cast<NativeInteger::SignedNativeInt>(params->GetBaseG() >> 1)};
-    // approximate gadget decomposition is used; the first digit is ignored
-    uint32_t digitsG{params->GetDigitsG() - 1};
+    auto Q{params->GetQ().ConvertToInt<BasicInteger>()};
+    auto QHalf{Q >> 1};
+    auto gBits{static_cast<uint32_t>(__builtin_ctz(params->GetBaseG()))};
+    auto gHalf{static_cast<BasicInteger>(params->GetBaseG() >> 1)};
+    auto gMask{static_cast<BasicInteger>(params->GetBaseG() - 1)};
+    auto QmHalf{Q - gHalf};
+    uint32_t digitsG{params->GetDigitsG()};
+    // see the ciphertext overload above for the excess-H digit-extraction identity
+    BasicInteger H{0};
+    for (uint32_t i{0}; i < digitsG; ++i)
+        H += gHalf << (i * gBits);
     uint32_t N{params->GetN()};
 
-    // digit-major order: carry holds the running quotient for every coefficient so that
-    // each inner loop is unit-stride and vectorizable
-    std::vector<NativeInteger::SignedNativeInt> carry(N);
+    std::vector<BasicInteger> w(N);
     for (uint32_t k{0}; k < N; ++k) {
         auto t0{input[k].ConvertToInt<BasicInteger>()};
-        auto d0{static_cast<NativeInteger::SignedNativeInt>(t0 < QHalf ? t0 : t0 - Q_int)};
-        carry[k] = (d0 + gHalf) >> gBits;
+        w[k] = t0 + H - (t0 < QHalf ? 0 : Q);
     }
 
-    for (uint32_t d{0}; d < digitsG; ++d) {
+    // approximate gadget decomposition is used; the first digit is ignored
+    for (uint32_t d{0}; d < digitsG - 1; ++d) {
+        uint32_t shift{(d + 1) * gBits};
         auto& out{output[d]};
         for (uint32_t k{0}; k < N; ++k) {
-            auto r0{SignExtend(carry[k], gBitsMaxBits)};
-            carry[k] = (carry[k] + gHalf) >> gBits;
-            if (r0 < 0)
-                r0 += Q_int;
-            out[k] += r0;
+            auto r0{(w[k] >> shift) & gMask};
+            out[k] += (r0 < gHalf) ? r0 + QmHalf : r0 - gHalf;
         }
     }
 }

--- a/src/binfhe/lib/rgsw-acc.cpp
+++ b/src/binfhe/lib/rgsw-acc.cpp
@@ -64,6 +64,7 @@ void RingGSWAccumulator::SignedDigitDecompose(const std::shared_ptr<RingGSWCrypt
     auto Q_int{params->GetQ().ConvertToInt<NativeInteger::SignedNativeInt>()};
     auto gBits{static_cast<NativeInteger::SignedNativeInt>(__builtin_ctz(params->GetBaseG()))};
     auto gBitsMaxBits{static_cast<NativeInteger::SignedNativeInt>(NativeInteger::MaxBits() - gBits)};
+    auto gHalf{static_cast<NativeInteger::SignedNativeInt>(params->GetBaseG() >> 1)};
     // approximate gadget decomposition is used; the first digit is ignored
     uint32_t digitsG2{(params->GetDigitsG() - 1) << 1};
     uint32_t N{params->GetN()};
@@ -74,21 +75,18 @@ void RingGSWAccumulator::SignedDigitDecompose(const std::shared_ptr<RingGSWCrypt
         auto t1{input[1][k].ConvertToInt<BasicInteger>()};
         auto d1{static_cast<NativeInteger::SignedNativeInt>(t1 < QHalf ? t1 : t1 - Q_int)};
 
-        auto r0{SignExtend(d0, gBitsMaxBits)};
-        d0 = (d0 - r0) >> gBits;
-
-        auto r1{SignExtend(d1, gBitsMaxBits)};
-        d1 = (d1 - r1) >> gBits;
+        d0 = (d0 + gHalf) >> gBits;
+        d1 = (d1 + gHalf) >> gBits;
 
         for (uint32_t d{0}; d < digitsG2; d += 2) {
-            r0 = SignExtend(d0, gBitsMaxBits);
-            d0 = (d0 - r0) >> gBits;
+            auto r0{SignExtend(d0, gBitsMaxBits)};
+            d0 = (d0 + gHalf) >> gBits;
             if (r0 < 0)
                 r0 += Q_int;
             output[d + 0][k] += r0;
 
-            r1 = SignExtend(d1, gBitsMaxBits);
-            d1 = (d1 - r1) >> gBits;
+            auto r1{SignExtend(d1, gBitsMaxBits)};
+            d1 = (d1 + gHalf) >> gBits;
             if (r1 < 0)
                 r1 += Q_int;
             output[d + 1][k] += r1;
@@ -103,6 +101,7 @@ void RingGSWAccumulator::SignedDigitDecompose(const std::shared_ptr<RingGSWCrypt
     auto Q_int{params->GetQ().ConvertToInt<NativeInteger::SignedNativeInt>()};
     auto gBits{static_cast<NativeInteger::SignedNativeInt>(__builtin_ctz(params->GetBaseG()))};
     auto gBitsMaxBits{static_cast<NativeInteger::SignedNativeInt>(NativeInteger::MaxBits() - gBits)};
+    auto gHalf{static_cast<NativeInteger::SignedNativeInt>(params->GetBaseG() >> 1)};
     // approximate gadget decomposition is used; the first digit is ignored
     uint32_t digitsG{params->GetDigitsG() - 1};
     uint32_t N{params->GetN()};
@@ -111,12 +110,11 @@ void RingGSWAccumulator::SignedDigitDecompose(const std::shared_ptr<RingGSWCrypt
         auto t0{input[k].ConvertToInt<BasicInteger>()};
         auto d0{static_cast<NativeInteger::SignedNativeInt>(t0 < QHalf ? t0 : t0 - Q_int)};
 
-        auto r0{SignExtend(d0, gBitsMaxBits)};
-        d0 = (d0 - r0) >> gBits;
+        d0 = (d0 + gHalf) >> gBits;
 
         for (uint32_t d{0}; d < digitsG; ++d) {
-            r0 = SignExtend(d0, gBitsMaxBits);
-            d0 = (d0 - r0) >> gBits;
+            auto r0{SignExtend(d0, gBitsMaxBits)};
+            d0 = (d0 + gHalf) >> gBits;
             if (r0 < 0)
                 r0 += Q_int;
             output[d][k] += r0;

--- a/src/binfhe/lib/rgsw-acc.cpp
+++ b/src/binfhe/lib/rgsw-acc.cpp
@@ -69,27 +69,33 @@ void RingGSWAccumulator::SignedDigitDecompose(const std::shared_ptr<RingGSWCrypt
     uint32_t digitsG2{(params->GetDigitsG() - 1) << 1};
     uint32_t N{params->GetN()};
 
+    // digit-major order: carry0/carry1 hold the running quotient for every coefficient so
+    // that each inner loop is unit-stride and vectorizable
+    std::vector<NativeInteger::SignedNativeInt> carry0(N), carry1(N);
     for (uint32_t k{0}; k < N; ++k) {
         auto t0{input[0][k].ConvertToInt<BasicInteger>()};
         auto d0{static_cast<NativeInteger::SignedNativeInt>(t0 < QHalf ? t0 : t0 - Q_int)};
+        carry0[k] = (d0 + gHalf) >> gBits;
         auto t1{input[1][k].ConvertToInt<BasicInteger>()};
         auto d1{static_cast<NativeInteger::SignedNativeInt>(t1 < QHalf ? t1 : t1 - Q_int)};
+        carry1[k] = (d1 + gHalf) >> gBits;
+    }
 
-        d0 = (d0 + gHalf) >> gBits;
-        d1 = (d1 + gHalf) >> gBits;
-
-        for (uint32_t d{0}; d < digitsG2; d += 2) {
-            auto r0{SignExtend(d0, gBitsMaxBits)};
-            d0 = (d0 + gHalf) >> gBits;
+    for (uint32_t d{0}; d < digitsG2; d += 2) {
+        auto& out0{output[d + 0]};
+        auto& out1{output[d + 1]};
+        for (uint32_t k{0}; k < N; ++k) {
+            auto r0{SignExtend(carry0[k], gBitsMaxBits)};
+            carry0[k] = (carry0[k] + gHalf) >> gBits;
             if (r0 < 0)
                 r0 += Q_int;
-            output[d + 0][k] += r0;
+            out0[k] += r0;
 
-            auto r1{SignExtend(d1, gBitsMaxBits)};
-            d1 = (d1 + gHalf) >> gBits;
+            auto r1{SignExtend(carry1[k], gBitsMaxBits)};
+            carry1[k] = (carry1[k] + gHalf) >> gBits;
             if (r1 < 0)
                 r1 += Q_int;
-            output[d + 1][k] += r1;
+            out1[k] += r1;
         }
     }
 }
@@ -106,18 +112,23 @@ void RingGSWAccumulator::SignedDigitDecompose(const std::shared_ptr<RingGSWCrypt
     uint32_t digitsG{params->GetDigitsG() - 1};
     uint32_t N{params->GetN()};
 
+    // digit-major order: carry holds the running quotient for every coefficient so that
+    // each inner loop is unit-stride and vectorizable
+    std::vector<NativeInteger::SignedNativeInt> carry(N);
     for (uint32_t k{0}; k < N; ++k) {
         auto t0{input[k].ConvertToInt<BasicInteger>()};
         auto d0{static_cast<NativeInteger::SignedNativeInt>(t0 < QHalf ? t0 : t0 - Q_int)};
+        carry[k] = (d0 + gHalf) >> gBits;
+    }
 
-        d0 = (d0 + gHalf) >> gBits;
-
-        for (uint32_t d{0}; d < digitsG; ++d) {
-            auto r0{SignExtend(d0, gBitsMaxBits)};
-            d0 = (d0 + gHalf) >> gBits;
+    for (uint32_t d{0}; d < digitsG; ++d) {
+        auto& out{output[d]};
+        for (uint32_t k{0}; k < N; ++k) {
+            auto r0{SignExtend(carry[k], gBitsMaxBits)};
+            carry[k] = (carry[k] + gHalf) >> gBits;
             if (r0 < 0)
                 r0 += Q_int;
-            output[d][k] += r0;
+            out[k] += r0;
         }
     }
 }


### PR DESCRIPTION
## Summary

Issue #1226 reported deterministic UBSan failures (`left shift of negative value`,
`left shift ... cannot be represented`) in both overloads of
`RingGSWAccumulator::SignedDigitDecompose`, reached by any ordinary `EvalBinGate`
call. The offending expressions were the classic `(d << k) >> k` sign-extension
idiom, deliberately written to compile to the hardware sign-extender (`shl`/`sar`)
— this is a bottleneck path, so the reconstruction-style rewrite suggested in the
issue would have traded correctness-on-paper for real overhead.

This PR fixes the UB with **zero performance cost**, and then — prompted by what we
found while validating the fix — restructures the decomposition so that the final
code contains **no sign extension and no signed shifts at all**, making the original
concern moot by construction, while running substantially faster.

## The fix (f3275042)

Perform the left shift in the unsigned type and shift back arithmetically:

```cpp
static_cast<SignedNativeInt>(static_cast<Integer>(d) << bits) >> bits
```

Unsigned left shift is well-defined; the value-preserving conversion back and the
arithmetic right shift are implementation-defined (not UB) and already relied on
elsewhere in the function. Generated code is unchanged — byte-identical bodies with
clang 18 and an identical instruction mix (same `shl`/`sar` pairs) with gcc 13 at
`-O3` — and the reporter's TOY/LMKCDEY repro runs UBSan-clean.

## The optimization (1c4674ab, 4dc0ed04, 46677383)

Verifying the fix exposed that the surrounding loop, not the shift idiom, was the
real cost. A hardware-adder analogy explains the three steps:

1. **The original loop is a ripple-carry structure.** Each digit is extracted and
   then fed back into the carry: `r = signext(d); d = (d - r) >> gBits`. Like a
   ripple adder, stage *k+1* cannot start until stage *k* completes — a 4-op
   dependency chain per digit.

2. **Decouple the carry from the digit** (1c4674ab). Since `r ≡ d (mod baseG)` with
   `r ∈ [-baseG/2, baseG/2)`, the carry has a closed form that never touches the
   digit: `d = (d + baseG/2) >> gBits`. The chain halves and digit extraction moves
   off the critical path — analogous to separating an adder's carry path from its
   sum logic.

3. **Vectorize across coefficients** (4dc0ed04). The N polynomial coefficients are
   independent chains, so interchange the loops to digit-major order and let SIMD
   process 4/8/16 coefficients per instruction — an array of cheap adders instead of
   one fast one.

4. **Full carry-lookahead** (46677383). Just as a lookahead adder computes every
   carry as a closed-form function of the primary inputs, biasing each coefficient
   once by `H` (= `baseG/2` in every digit position) makes every balanced digit an
   independent unsigned window of the biased value:

   ```
   w = t + H - (t < Q/2 ? 0 : Q)               // one add per coefficient
   digit_k = ((w >> k*gBits) & (baseG-1)) - baseG/2   // no chain, no signed ops
   ```

   The carry chain disappears entirely, along with the `SignExtend` helper and every
   signed shift in the function. Requires `digitsG*gBits < MaxBits`, which all
   supported parameter sets satisfy with ample margin (≤53 of 64 bits; ≤31 of 32 for
   `NATIVE_SIZE=32` builds).

## Correctness

Outputs are bit-identical to the original code at every step (exhaustive
differential harness over TOY/STD128-shaped parameters plus edge values
`0, ±1, Q−1, Q/2±1`). The full binfhe unit suite passes in all 8 validated build
configurations — {clang 18, gcc 14} × {`WITH_NATIVEOPT` ON/OFF} ×
{`NATIVE_SIZE` 64/32} — and the issue's reproducer is UBSan-clean from the first
commit onward.

## Performance

Measured on a dual Xeon Platinum 8360Y (Ice Lake, AVX-512), min of 4 repetitions,
single-thread pinned; 36-thread runs show the same or better ratios. Speedups are
dev → this PR:

| | NATIVE_SIZE=64 | NATIVE_SIZE=32 |
|---|---|---|
| `SignedDigitDecompose` (native-opt ON) | 2.9–5.9x | 7.2–11.0x |
| `SignedDigitDecompose` (native-opt OFF) | 1.2–1.9x | 4.1–5.4x |
| `EvalBinGate` end-to-end | 1.02–1.16x | 1.07–1.30x |

No regressions in any of the 32 measured configuration/thread-count cells.

Fixes #1226.