### PR TITLE
Use windowed shift-and-mask digit extraction in GetDigitAtIndexForBase

### DIFF
--- a/src/core/include/math/hal/intnat/ubintnat.h
+++ b/src/core/include/math/hal/intnat/ubintnat.h
@@ -1717,15 +1717,12 @@ public:
    * @return is the requested digit
    */
 
-    // TODO: * i to << i
     uint32_t GetDigitAtIndexForBase(uint32_t index, uint32_t base) const {
-        uint32_t DigitLen = std::ceil(std::log2(base));
-        uint32_t digit    = 0;
-        uint32_t newIndex = 1 + (index - 1) * DigitLen;
-        for (uint32_t i = 1; i < base; i <<= 1) {
-            digit += GetBitAtIndex(newIndex++) * i;
-        }
-        return digit;
+        auto digitLen = lbcrypto::GetMSB(base - 1);  // == ceil(log2(base))
+        uint32_t shift{(index - 1) * digitLen};
+        if (shift >= m_uintBitLength)
+            return 0;
+        return static_cast<uint32_t>((m_value >> shift) & ((uint64_t{1} << digitLen) - 1));
     }
 
     /**

--- a/src/core/lib/math/hal/intnat/mubintvecnat.cpp
+++ b/src/core/lib/math/hal/intnat/mubintvecnat.cpp
@@ -457,9 +457,14 @@ NativeVectorT<IntegerType>& NativeVectorT<IntegerType>::DivideAndRoundEq(const I
 
 template <class IntegerType>
 NativeVectorT<IntegerType> NativeVectorT<IntegerType>::GetDigitAtIndexForBase(uint32_t index, uint32_t base) const {
+    auto digitLen = lbcrypto::GetMSB(base - 1);  // == ceil(log2(base))
+    uint32_t shift{(index - 1) * digitLen};
+    if (shift >= IntegerType::MaxBits())
+        return NativeVectorT(m_data.size(), m_modulus);
     auto ans(*this);
+    const auto mask = static_cast<BasicInt>((uint64_t{1} << digitLen) - 1);
     for (size_t i = 0; i < ans.m_data.size(); ++i)
-        ans[i].m_value = static_cast<BasicInt>(ans[i].GetDigitAtIndexForBase(index, base));
+        ans[i].m_value = (ans[i].m_value >> shift) & mask;
     return ans;
 }
 


### PR DESCRIPTION
The scalar primitive recomputed a floating-point log2 on every call and
assembled each digit one bit at a time; the NativeVector overload then
invoked it per coefficient through the shared library, so nothing hoisted
or vectorized. Extract the digit as a single shift-and-mask window
instead, with the shift and mask hoisted across the vector so the loop
auto-vectorizes. Digits are unchanged everywhere the old code was
defined; windows past the word width now return 0 instead of reading
past it (previously undefined for partial top windows, e.g. a 60-bit
modulus with 13-bit digits).

BV key switching consumes this on every relinearization and rotation.
On Ice Lake (Xeon 8360Y) at 1 thread across {clang-18, gcc-14} x
{native-opt on, off}: the primitive is 46-150x faster,
NativePoly::BaseDecompose 21-150x, DCRTPoly::CRTDecompose 1.45-2.7x,
and BGV BV-mode EvalMult+relin / EvalRotate 1.22-1.90x, with no
regressions; the gains hold at 36 threads under clang (1.19-1.83x).
Verified digit-for-digit against the previous implementation and by
exact reconstruction; all core and pke unit tests pass.