### PR TITLE
Use balanced digits for BV key switching and remove decomposition copies

### DIFF
--- a/src/core/include/lattice/hal/default/dcrtpoly-impl.h
+++ b/src/core/include/lattice/hal/default/dcrtpoly-impl.h
@@ -269,13 +269,15 @@ std::vector<DCRTPolyImpl<VecType>> DCRTPolyImpl<VecType>::CRTDecompose(uint32_t 
         auto decomposed               = (*coef).m_vectors[i].BaseDecompose(baseBits, false);
         const uint32_t decomposedsize = decomposed.size();
         for (uint32_t j = 0; j < decomposedsize; ++j) {
-            DCRTPolyImpl<VecType> currentDCRTPoly(*coef);
+            DCRTPolyImpl<VecType> currentDCRTPoly((*coef).m_params, Format::COEFFICIENT, false);
             for (uint32_t k = 0; k < size; ++k) {
-                DCRTPolyImpl::PolyType tmp(decomposed[j]);
-                if (i != k)
+                if (i != k) {
+                    DCRTPolyImpl::PolyType tmp(decomposed[j]);
                     tmp.SwitchModulus((*coef).m_vectors[k].GetModulus(), (*coef).m_vectors[k].GetRootOfUnity(), 0, 0);
-                currentDCRTPoly.m_vectors[k] = std::move(tmp);
+                    currentDCRTPoly.m_vectors[k] = std::move(tmp);
+                }
             }
+            currentDCRTPoly.m_vectors[i] = std::move(decomposed[j]);
             currentDCRTPoly.SwitchFormat();
             result[j + arrWindows[i]] = std::move(currentDCRTPoly);
         }

--- a/src/core/include/lattice/hal/default/poly-impl.h
+++ b/src/core/include/lattice/hal/default/poly-impl.h
@@ -519,7 +519,6 @@ double PolyImpl<VecType>::Norm() const {
 // \log q / base } \rceil }; used as a subroutine in the relinearization
 // procedure baseBits is the number of bits in the base, i.e., base = 2^baseBits
 
-// TODO: optimize this
 template <typename VecType>
 std::vector<PolyImpl<VecType>> PolyImpl<VecType>::BaseDecompose(uint32_t baseBits, bool evalModeAnswer) const {
     uint32_t nBits = m_params->GetModulus().GetLengthForBase(2);
@@ -528,23 +527,37 @@ std::vector<PolyImpl<VecType>> PolyImpl<VecType>::BaseDecompose(uint32_t baseBit
     if (nBits % baseBits > 0)
         nWindows++;
 
-    PolyImpl<VecType> xDigit(m_params);
-
     std::vector<PolyImpl<VecType>> result;
     result.reserve(nWindows);
 
-    PolyImpl<VecType> x(*this);
-    x.SetFormat(Format::COEFFICIENT);
+    PolyImpl<VecType> xcopy;
+    if (m_format != Format::COEFFICIENT) {
+        xcopy = *this;
+        xcopy.SetFormat(Format::COEFFICIENT);
+    }
+    const PolyImpl<VecType>& x = (m_format != Format::COEFFICIENT) ? xcopy : *this;
 
-    // TP: x is same for BACKEND 2 and 6
-    for (uint32_t i = 0; i < nWindows; ++i) {
-        xDigit.SetValues(x.GetValues().GetDigitAtIndexForBase(i + 1, 1 << baseBits), x.GetFormat());
+    if constexpr (std::is_same_v<VecType, NativeVector>) {
+        for (auto&& dv : x.GetValues().BaseDecompose(baseBits)) {
+            PolyImpl<VecType> xDigit(m_params);
+            xDigit.SetValues(std::move(dv), Format::COEFFICIENT);
+            if (evalModeAnswer)
+                xDigit.SwitchFormat();
+            result.push_back(std::move(xDigit));
+        }
+    }
+    else {
+        // TP: x is same for BACKEND 2 and 6
+        for (uint32_t i = 0; i < nWindows; ++i) {
+            PolyImpl<VecType> xDigit(m_params);
+            xDigit.SetValues(x.GetValues().GetDigitAtIndexForBase(i + 1, 1 << baseBits), Format::COEFFICIENT);
 
-        // TP: xDigit is all zeros for BACKEND=6, but not for BACKEND-2
-        // *********************************************************
-        if (evalModeAnswer)
-            xDigit.SwitchFormat();
-        result.push_back(xDigit);
+            // TP: xDigit is all zeros for BACKEND=6, but not for BACKEND-2
+            // *********************************************************
+            if (evalModeAnswer)
+                xDigit.SwitchFormat();
+            result.push_back(std::move(xDigit));
+        }
     }
     return result;
 }

--- a/src/core/include/math/hal/intnat/mubintvecnat.h
+++ b/src/core/include/math/hal/intnat/mubintvecnat.h
@@ -632,6 +632,19 @@ public:
    */
     NativeVectorT GetDigitAtIndexForBase(uint32_t index, uint32_t base) const;
 
+    /**
+   * Decomposes every entry into all of its base-2^digitLen digits at once. Digits are
+   * balanced, i.e. in [-2^(digitLen-1), 2^(digitLen-1)) of the centered representative
+   * and returned mod q, which halves the digit bound of BV key switching; the top digit
+   * absorbs the remaining quotient so that the digits reconstruct the value exactly
+   * (mod q). Falls back to plain unsigned digit windows when the bias does not fit the
+   * native word (ceil(qBits/digitLen)*digitLen + 1 > MaxBits).
+   *
+   * @param digitLen is the bit width of one digit.
+   * @return one vector per digit position, least significant first.
+   */
+    std::vector<NativeVectorT> BaseDecompose(uint32_t digitLen) const;
+
     // STRINGS & STREAMS
 
     /**

--- a/src/core/lib/math/hal/intnat/mubintvecnat.cpp
+++ b/src/core/lib/math/hal/intnat/mubintvecnat.cpp
@@ -452,6 +452,65 @@ NativeVectorT<IntegerType>& NativeVectorT<IntegerType>::DivideAndRoundEq(const I
 }
 
 template <class IntegerType>
+std::vector<NativeVectorT<IntegerType>> NativeVectorT<IntegerType>::BaseDecompose(uint32_t digitLen) const {
+    const BasicInt q  = m_modulus.m_value;
+    const uint32_t nW = (m_modulus.GetMSB() + digitLen - 1) / digitLen;
+    const auto mask   = static_cast<BasicInt>((uint64_t{1} << digitLen) - 1);
+    const uint32_t n  = m_data.size();
+    std::vector<NativeVectorT> result;
+    result.reserve(nW);
+
+    if (nW * digitLen + 1 > IntegerType::MaxBits() || q <= 1) {
+        // not enough headroom for the bias: plain unsigned digit windows
+        for (uint32_t w = 0; w < nW; ++w) {
+            NativeVectorT d(n, m_modulus);
+            const uint32_t shift = w * digitLen;
+            for (uint32_t i = 0; i < n; ++i)
+                d[i].m_value = (m_data[i].m_value >> shift) & mask;
+            result.push_back(std::move(d));
+        }
+        return result;
+    }
+
+    // bias by H (gHalf in every digit position) once; every balanced digit is then an
+    // independent window: digit_w = (((x~ + H) >> w*digitLen) & mask) - h, x~ centered.
+    const BasicInt h     = BasicInt{1} << (digitLen - 1);
+    const BasicInt qHalf = q >> 1;
+    BasicInt H{0};
+    for (uint32_t i = 0; i < nW; ++i)
+        H += h << (i * digitLen);
+    std::vector<BasicInt> biased(n);
+    for (uint32_t i = 0; i < n; ++i) {
+        // borrow of (qHalf - x) is 1 exactly when x > qHalf, i.e. x is negative centered
+        const BasicInt borrow = (qHalf - m_data[i].m_value) >> (IntegerType::MaxBits() - 1);
+        biased[i]             = m_data[i].m_value + H - (q & (0 - borrow));
+    }
+
+    for (uint32_t w = 0; w < nW; ++w) {
+        NativeVectorT d(n, m_modulus);
+        const uint32_t shift = w * digitLen;
+        if (w + 1 < nW) {
+            for (uint32_t i = 0; i < n; ++i) {
+                const BasicInt v    = (biased[i] >> shift) & mask;
+                const BasicInt addq = q & ((v >> (digitLen - 1)) - 1);  // q exactly when v < h
+                d[i].m_value        = v - h + addq;
+            }
+        }
+        else {  // the top window is unmasked so it absorbs the remaining quotient (v < 3h)
+            for (uint32_t i = 0; i < n; ++i) {
+                const BasicInt v    = biased[i] >> shift;
+                BasicInt s          = v >> (digitLen - 1);  // in {0, 1, 2}
+                s                   = (s | (s >> 1)) & 0x1;
+                const BasicInt addq = q & (s - 1);
+                d[i].m_value        = v - h + addq;
+            }
+        }
+        result.push_back(std::move(d));
+    }
+    return result;
+}
+
+template <class IntegerType>
 NativeVectorT<IntegerType> NativeVectorT<IntegerType>::GetDigitAtIndexForBase(uint32_t index, uint32_t base) const {
     auto digitLen = lbcrypto::GetMSB(base - 1);  // == ceil(log2(base))
     uint32_t shift{(index - 1) * digitLen};


### PR DESCRIPTION
Implements the balanced-digit proposal for BV key switching #1241

## Balanced digits

`NativeVectorT::BaseDecompose(digitLen)` (new, bulk) decomposes every coefficient
into all of its digits at once, as **balanced digits in [-B/2, B/2)** of the
centered representative rather than unsigned digits in [0, B):

- The excess-half bias `H` (B/2 in every digit position) is added once per
  coefficient; every digit is then an independent shift-and-mask window —
  same asymptotic cost as unsigned extraction.
- The **top window is left unmasked** so it absorbs the remaining quotient
  (range [-B/2-1, B/2+1]); this keeps reconstruction exact mod q for all
  inputs, including centered values near +q/2, with no extra window.
- All predicates are computed as bit masks (digit sign = its own top bit;
  centered-lift borrow = logical shift of `qHalf - x`), so the loops
  auto-vectorize at the baseline ISA as well as under native optimizations.
- Decompositions whose bias would not fit the native word
  (`ceil(qBits/digitLen)·digitLen + 1 > MaxBits`) fall back to plain unsigned
  windows; no supported parameter set triggers the fallback.

**Key material is unchanged** — reconstruction is mod-q linear algebra, so
`PowersOfBase` and all serialized evaluation keys are identical; only the
transient digit range changes. Halving the digit bound makes the `relinBase/2`
factor in the BGV `noiseKS` estimate exact rather than charitable. Multiprecision
backends and the scalar `GetDigitAtIndexForBase` API keep unsigned semantics.

## Performance (Ice Lake 8360Y, 1 thread pinned, min of 4 reps, {clang-18, gcc-14} × {native-opt on, off})

vs dev@9ef247cf (cumulative, best/worst config):

| operation | speedup |
|---|---|
| `NativeVector` digit extraction | 56–171x |
| `NativePoly::BaseDecompose` | 26–150x |
| `DCRTPoly::CRTDecompose` | 1.38–2.44x |
| BGV BV `EvalMult`+relin | 1.18–1.61x |
| BGV BV `EvalRotate` | 1.16–1.75x |

## Noise (BGV FIXEDMANUAL depth 2, 3×45-bit towers, ring dim 8192; e_ks isolated exactly around Relinearize, mean of 8 fresh-key trials, log2 bits t-scaled)

| digitSize | noiseKS estimate | unsigned max / sd | balanced max / sd | Δmax | Δsd |
|---|---|---|---|---|---|
| 5  | 37.04 | 30.70 / 29.06 | 30.04 / 28.08 | 0.66 | 0.98 |
| 10 | 41.15 | 35.17 / 33.50 | 34.48 / 32.50 | 0.68 | 1.00 |
| 15 | 45.67 | 40.09 / 38.44 | 39.23 / 37.29 | 0.86 | 1.15 |
| 20 | 50.34 | 44.57 / 42.89 | 44.03 / 42.00 | 0.55 | 0.89 |
| 30 | 59.93 | 54.08 / 52.31 | 53.61 / 51.51 | 0.46 | 0.79 |

The estimator retains its full ~6–8-bit safety margin over measured noise in
both conventions. Equivalently, the headroom can be spent as `digitSize+1` at
unchanged noise, giving fewer windows and proportionally smaller BV keys where
a `ceil(nBits/digitSize)` boundary is crossed.

## Validation

- Digit extraction verified by exact centered-reconstruction self-tests and a
  differential check of the scalar API (unchanged) against its previous
  implementation; both run before every benchmark.
- All core (159) and pke (1892) unit tests pass on every configuration tested.