### PR TITLE
Compute CKKS/BFV rescaling with one scalar multiplication per tower (#1028)

### DIFF
--- a/src/core/include/lattice/hal/dcrtpoly-interface.h
+++ b/src/core/include/lattice/hal/dcrtpoly-interface.h
@@ -820,16 +820,12 @@ public:
 
     /**
    * @brief Drops the last element in the double-CRT representation and scales
-   * down by the last CRT modulus. The resulting DCRTPoly element will have one
-   * less tower.
-   * @param &QlQlInvModqlDivqlModq precomputed values for
-   * [Q^(l)*[Q^(l)^{-1}]_{q_l}/q_l]_{q_i}
-   * @param &QlQlInvModqlDivqlModqPrecon NTL-specific precomputations
+   * down by the last CRT modulus, computing round(x/q_l) as
+   * (x - [x]_{q_l}) * [q_l^{-1}]_{q_i}. The resulting DCRTPoly element will
+   * have one less tower.
    * @param &qlInvModq precomputed values for [q_l^{-1}]_{q_i}
-   * @param &qlInvModqPrecon NTL-specific precomputations
    */
-    virtual void DropLastElementAndScale(const std::vector<NativeInteger>& QlQlInvModqlDivqlModq,
-                                         const std::vector<NativeInteger>& qlInvModq) = 0;
+    virtual void DropLastElementAndScale(const std::vector<NativeInteger>& qlInvModq) = 0;
 
     /**
    * @brief ModReduces reduces the DCRTPoly element's composite modulus by

--- a/src/core/include/lattice/hal/dcrtpoly-interface.h
+++ b/src/core/include/lattice/hal/dcrtpoly-interface.h
@@ -822,7 +822,7 @@ public:
    * @brief Drops the last element in the double-CRT representation and scales
    * down by the last CRT modulus, computing round(x/q_l) as
    * (x - [x]_{q_l}) * [q_l^{-1}]_{q_i}. The resulting DCRTPoly element will
-   * have one less tower.
+   * have one less tower and is always in EVALUATION format.
    * @param &qlInvModq precomputed values for [q_l^{-1}]_{q_i}
    */
     virtual void DropLastElementAndScale(const std::vector<NativeInteger>& qlInvModq) = 0;

--- a/src/core/include/lattice/hal/default/dcrtpoly-impl.h
+++ b/src/core/include/lattice/hal/default/dcrtpoly-impl.h
@@ -688,9 +688,12 @@ void DCRTPolyImpl<VecType>::DropLastElements(size_t i) {
 }
 
 // used for CKKS rescaling
+// Computes round(x/q_l) as (x - [x]_{q_l}) * [q_l^{-1}]_{q_i}, where [x]_{q_l} is the
+// centered representative produced by SwitchModulus (see RS(ct) in Sec. 3.2 of
+// https://eprint.iacr.org/2018/931). The subtraction makes (x - [x]_{q_l}) exactly
+// divisible by q_l, so one scalar multiplication per tower suffices.
 template <typename VecType>
-void DCRTPolyImpl<VecType>::DropLastElementAndScale(const std::vector<NativeInteger>& QlQlInvModqlDivqlModq,
-                                                    const std::vector<NativeInteger>& qlInvModq) {
+void DCRTPolyImpl<VecType>::DropLastElementAndScale(const std::vector<NativeInteger>& qlInvModq) {
     auto lastPoly(m_vectors.back());
     lastPoly.SetFormat(Format::COEFFICIENT);
     this->DropLastElement();
@@ -700,11 +703,10 @@ void DCRTPolyImpl<VecType>::DropLastElementAndScale(const std::vector<NativeInte
     for (uint32_t i = 0; i < size; ++i) {
         auto tmp = lastPoly;
         tmp.SwitchModulus(m_vectors[i].GetModulus(), m_vectors[i].GetRootOfUnity(), 0, 0);
-        tmp *= QlQlInvModqlDivqlModq[i];
         if (m_format == Format::EVALUATION)
             tmp.SwitchFormat();
+        m_vectors[i] -= tmp;
         m_vectors[i] *= qlInvModq[i];
-        m_vectors[i] += tmp;
         if (m_format == Format::COEFFICIENT)
             m_vectors[i].SwitchFormat();
     }

--- a/src/core/include/lattice/hal/default/dcrtpoly-impl.h
+++ b/src/core/include/lattice/hal/default/dcrtpoly-impl.h
@@ -694,7 +694,7 @@ void DCRTPolyImpl<VecType>::DropLastElements(size_t i) {
 // divisible by q_l, so one scalar multiplication per tower suffices.
 template <typename VecType>
 void DCRTPolyImpl<VecType>::DropLastElementAndScale(const std::vector<NativeInteger>& qlInvModq) {
-    auto lastPoly(m_vectors.back());
+    auto lastPoly(std::move(m_vectors.back()));
     lastPoly.SetFormat(Format::COEFFICIENT);
     this->DropLastElement();
     uint32_t size(m_vectors.size());
@@ -710,6 +710,7 @@ void DCRTPolyImpl<VecType>::DropLastElementAndScale(const std::vector<NativeInte
         if (m_format == Format::COEFFICIENT)
             m_vectors[i].SwitchFormat();
     }
+    this->OverrideFormat(Format::EVALUATION);
 }
 
 /**

--- a/src/core/include/lattice/hal/default/dcrtpoly.h
+++ b/src/core/include/lattice/hal/default/dcrtpoly.h
@@ -206,8 +206,7 @@ public:
     void AddILElementOne() override;
     void DropLastElement() override;
     void DropLastElements(size_t i) override;
-    void DropLastElementAndScale(const std::vector<NativeInteger>& QlQlInvModqlDivqlModq,
-                                 const std::vector<NativeInteger>& qlInvModq) override;
+    void DropLastElementAndScale(const std::vector<NativeInteger>& qlInvModq) override;
 
     void ModReduce(const NativeInteger& t, const std::vector<NativeInteger>& tModqPrecon,
                    const NativeInteger& negtInvModq, const NativeInteger& negtInvModqPrecon,

--- a/src/core/include/math/hal/intnat/ubintnat.h
+++ b/src/core/include/math/hal/intnat/ubintnat.h
@@ -735,8 +735,8 @@ public:
    * @return is the result of the modulus addition operation.
    */
     NativeIntegerT ModAddFast(const NativeIntegerT& b, const NativeIntegerT& modulus) const {
-        auto r{m_value + b.m_value};
         auto& mv{modulus.m_value};
+        auto r{m_value + b.m_value};
         if (r >= mv)
             r -= mv;
         return {r};
@@ -909,9 +909,8 @@ public:
    * @return is the result of the modulus subtraction operation.
    */
     NativeIntegerT ModSubFast(const NativeIntegerT& b, const NativeIntegerT& modulus) const {
-        if (m_value < b.m_value)
-            return {m_value + modulus.m_value - b.m_value};
-        return {m_value - b.m_value};
+        auto mask{static_cast<NativeInt>(0) - static_cast<NativeInt>(m_value < b.m_value)};
+        return {m_value - b.m_value + (modulus.m_value & mask)};
     }
 
     /**
@@ -922,9 +921,9 @@ public:
    * @return is the result of the modulus subtraction operation.
    */
     NativeIntegerT& ModSubFastEq(const NativeIntegerT& b, const NativeIntegerT& modulus) {
-        if (m_value < b.m_value)
-            return *this = m_value + modulus.m_value - b.m_value;
-        return *this = m_value - b.m_value;
+        auto mask{static_cast<NativeInt>(0) - static_cast<NativeInt>(m_value < b.m_value)};
+        m_value = m_value - b.m_value + (modulus.m_value & mask);
+        return *this;
     }
 
     /**

--- a/src/core/lib/math/hal/intnat/mubintvecnat.cpp
+++ b/src/core/lib/math/hal/intnat/mubintvecnat.cpp
@@ -41,6 +41,46 @@
 
 namespace intnat {
 
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 12
+    #define OPENFHE_COMPARE_SELECT_LANES 1
+#endif
+
+template <typename T>
+static inline T topBitMask(T x) {
+    return static_cast<T>(0) - static_cast<T>(x >> (sizeof(T) * 8 - 1));
+}
+
+template <typename T>
+static inline T modAddLane(T a, T b, T m) {
+#if defined(OPENFHE_COMPARE_SELECT_LANES) || defined(__clang__)
+    T t = a + b;
+    return t >= m ? t - m : t;
+#else
+    T t = a + b - m;
+    return t + (m & topBitMask(t));
+#endif
+}
+
+template <typename T>
+static inline T modSubLane(T a, T b, T m) {
+#ifdef OPENFHE_COMPARE_SELECT_LANES
+    T t = a - b;
+    return a < b ? t + m : t;
+#else
+    T t = a - b;
+    return t + (m & topBitMask(t));
+#endif
+}
+
+template <typename T>
+static inline T centeredCorrectionLane(T v, T halfQ, T diff) {
+#ifdef OPENFHE_COMPARE_SELECT_LANES
+    return v > halfQ ? diff : static_cast<T>(0);
+#else
+    return diff & topBitMask(halfQ - v);
+#endif
+}
+
 template <class IntegerType>
 NativeVectorT<IntegerType>::NativeVectorT(uint32_t length, const IntegerType& modulus,
                                           std::initializer_list<std::string> rhs) noexcept
@@ -108,15 +148,34 @@ NativeVectorT<IntegerType>& NativeVectorT<IntegerType>::operator=(std::initializ
 template <class IntegerType>
 void NativeVectorT<IntegerType>::SwitchModulus(const IntegerType& modulus) {
     // TODO: #ifdef NATIVEINT_BARRET_MOD
-    IntegerType halfQ{m_modulus >> 1};
-    IntegerType diff{(m_modulus > modulus) ? (m_modulus - modulus) : (modulus - m_modulus)};
-    if (modulus > m_modulus) {
-        for (auto& v : m_data)
-            v.AddEqFast((v > halfQ) ? diff : 0);
+    const auto ov{m_modulus.m_value};
+    const auto nv{modulus.m_value};
+    const auto halfQ{ov >> 1};
+    const size_t size{m_data.size()};
+    if (nv > ov) {
+        const auto diff{nv - ov};
+        for (size_t i = 0; i < size; ++i)
+            m_data[i].m_value += centeredCorrectionLane(m_data[i].m_value, halfQ, diff);
+    }
+    else if (nv > halfQ) {
+        // new modulus within 2x of the old one: a single conditional subtract fully
+        // reduces every value (v <= halfQ < nv, and v > halfQ maps into [0, nv))
+        const auto diff{ov - nv};
+        for (size_t i = 0; i < size; ++i)
+            m_data[i].m_value -= centeredCorrectionLane(m_data[i].m_value, halfQ, diff);
     }
     else {
-        for (auto& v : m_data)
-            v.ModSubEq((v > halfQ) ? diff : 0, modulus);
+        // general shrink: values need full reduction; the subtrahend only takes the
+        // values {diff, 0}, so reduce it once instead of per element inside ModSubEq
+        const auto diffR{(ov - nv) % nv};
+        for (size_t i = 0; i < size; ++i) {
+            const auto v{m_data[i].m_value};
+            auto av{v};
+            if (av >= nv)
+                av %= nv;
+            const auto bv{(v > halfQ) ? diffR : static_cast<decltype(diffR)>(0)};
+            m_data[i].m_value = (av < bv) ? av + nv - bv : av - bv;
+        }
     }
     this->SetModulus(modulus);
 }
@@ -144,19 +203,7 @@ NativeVectorT<IntegerType>& NativeVectorT<IntegerType>::MultAccEqNoCheck(const N
 template <class IntegerType>
 NativeVectorT<IntegerType> NativeVectorT<IntegerType>::Mod(const IntegerType& modulus) const {
     auto ans(*this);
-    if (modulus.m_value == 2)
-        return ans.ModByTwoEq();
-    IntegerType halfQ{m_modulus >> 1};
-    IntegerType diff{(m_modulus > modulus) ? (m_modulus - modulus) : (modulus - m_modulus)};
-
-    if (modulus > m_modulus) {
-        for (auto& v : ans.m_data)
-            v.AddEqFast((v > halfQ) ? diff : 0);
-    }
-    else {
-        for (auto& v : ans.m_data)
-            v.ModSubEq((v > halfQ) ? diff : 0, modulus);
-    }
+    ans.ModEq(modulus);
     return ans;
 }
 
@@ -164,16 +211,25 @@ template <class IntegerType>
 NativeVectorT<IntegerType>& NativeVectorT<IntegerType>::ModEq(const IntegerType& modulus) {
     if (modulus.m_value == 2)
         return this->NativeVectorT::ModByTwoEq();
-    IntegerType halfQ{m_modulus >> 1};
-    IntegerType diff{(m_modulus > modulus) ? (m_modulus - modulus) : (modulus - m_modulus)};
-
-    if (modulus > m_modulus) {
-        for (auto& v : m_data)
-            v.AddEqFast((v > halfQ) ? diff : 0);
+    const auto ov{m_modulus.m_value};
+    const auto nv{modulus.m_value};
+    const auto halfQ{ov >> 1};
+    const size_t size{m_data.size()};
+    if (nv > ov) {
+        const auto diff{nv - ov};
+        for (size_t i = 0; i < size; ++i)
+            m_data[i].m_value += centeredCorrectionLane(m_data[i].m_value, halfQ, diff);
     }
     else {
-        for (auto& v : m_data)
-            v.ModSubEq((v > halfQ) ? diff : 0, modulus);
+        const auto diffR{(ov - nv) % nv};
+        for (size_t i = 0; i < size; ++i) {
+            const auto v{m_data[i].m_value};
+            auto av{v};
+            if (av >= nv)
+                av %= nv;
+            const auto bv{(v > halfQ) ? diffR : static_cast<decltype(diffR)>(0)};
+            m_data[i].m_value = (av < bv) ? av + nv - bv : av - bv;
+        }
     }
     return *this;
 }
@@ -181,23 +237,19 @@ NativeVectorT<IntegerType>& NativeVectorT<IntegerType>::ModEq(const IntegerType&
 template <class IntegerType>
 NativeVectorT<IntegerType> NativeVectorT<IntegerType>::ModAdd(const IntegerType& b) const {
     auto ans(*this);
-    auto mv{m_modulus};
-    auto bv{b};
-    if (bv.m_value >= mv.m_value)
-        bv.ModEq(mv);
-    for (size_t i = 0; i < ans.m_data.size(); ++i)
-        ans.m_data[i] = ans.m_data[i].ModAddFast(bv, mv);
+    ans.ModAddEq(b);
     return ans;
 }
 
 template <class IntegerType>
 NativeVectorT<IntegerType>& NativeVectorT<IntegerType>::ModAddEq(const IntegerType& b) {
-    auto mv{m_modulus};
+    auto mv{m_modulus.m_value};
     auto bv{b};
-    if (bv.m_value >= mv.m_value)
-        bv.ModEq(mv);
-    for (size_t i = 0; i < m_data.size(); ++i)
-        m_data[i] = m_data[i].ModAddFast(bv, mv);
+    if (bv.m_value >= mv)
+        bv.ModEq(m_modulus);
+    const size_t size{m_data.size()};
+    for (size_t i = 0; i < size; ++i)
+        m_data[i].m_value = modAddLane(m_data[i].m_value, bv.m_value, mv);
     return *this;
 }
 
@@ -216,12 +268,8 @@ NativeVectorT<IntegerType>& NativeVectorT<IntegerType>::ModAddAtIndexEq(size_t i
 
 template <class IntegerType>
 NativeVectorT<IntegerType> NativeVectorT<IntegerType>::ModAdd(const NativeVectorT& b) const {
-    if (m_modulus != b.m_modulus || m_data.size() != b.m_data.size())
-        OPENFHE_THROW("Called on NativeVectorT's with different parameters.");
-    auto mv{m_modulus};
     auto ans(*this);
-    for (size_t i = 0; i < ans.m_data.size(); ++i)
-        ans.m_data[i].ModAddFastEq(b[i], mv);
+    ans.ModAddEq(b);
     return ans;
 }
 
@@ -229,43 +277,36 @@ template <class IntegerType>
 NativeVectorT<IntegerType>& NativeVectorT<IntegerType>::ModAddEq(const NativeVectorT& b) {
     if (m_data.size() != b.m_data.size() || m_modulus != b.m_modulus)
         OPENFHE_THROW("Called on NativeVectorT's with different parameters.");
-    auto mv{m_modulus};
-    for (size_t i = 0; i < m_data.size(); ++i)
-        m_data[i].ModAddFastEq(b[i], mv);
+    const auto mv{m_modulus.m_value};
+    const size_t size{m_data.size()};
+    for (size_t i = 0; i < size; ++i)
+        m_data[i].m_value = modAddLane(m_data[i].m_value, b.m_data[i].m_value, mv);
     return *this;
 }
 
 template <class IntegerType>
 NativeVectorT<IntegerType> NativeVectorT<IntegerType>::ModSub(const IntegerType& b) const {
-    auto mv{m_modulus};
-    auto bv{b};
     auto ans(*this);
-    if (bv.m_value >= mv.m_value)
-        bv.ModEq(mv);
-    for (size_t i = 0; i < ans.m_data.size(); ++i)
-        ans[i].ModSubFastEq(bv, mv);
+    ans.ModSubEq(b);
     return ans;
 }
 
 template <class IntegerType>
 NativeVectorT<IntegerType>& NativeVectorT<IntegerType>::ModSubEq(const IntegerType& b) {
-    auto mv{m_modulus};
+    auto mv{m_modulus.m_value};
     auto bv{b};
-    if (bv.m_value >= mv.m_value)
-        bv.ModEq(mv);
-    for (size_t i = 0; i < m_data.size(); ++i)
-        m_data[i].ModSubFastEq(bv, mv);
+    if (bv.m_value >= mv)
+        bv.ModEq(m_modulus);
+    const size_t size{m_data.size()};
+    for (size_t i = 0; i < size; ++i)
+        m_data[i].m_value = modSubLane(m_data[i].m_value, bv.m_value, mv);
     return *this;
 }
 
 template <class IntegerType>
 NativeVectorT<IntegerType> NativeVectorT<IntegerType>::ModSub(const NativeVectorT& b) const {
-    if (m_data.size() != b.m_data.size() || m_modulus != b.m_modulus)
-        OPENFHE_THROW("Called on NativeVectorT's with different parameters.");
-    auto mv{m_modulus};
     auto ans(*this);
-    for (size_t i = 0; i < ans.m_data.size(); ++i)
-        ans[i].ModSubFastEq(b[i], mv);
+    ans.ModSubEq(b);
     return ans;
 }
 
@@ -273,8 +314,10 @@ template <class IntegerType>
 NativeVectorT<IntegerType>& NativeVectorT<IntegerType>::ModSubEq(const NativeVectorT& b) {
     if (m_data.size() != b.m_data.size() || m_modulus != b.m_modulus)
         OPENFHE_THROW("Called on NativeVectorT's with different parameters.");
-    for (size_t i = 0; i < m_data.size(); ++i)
-        m_data[i].ModSubFastEq(b[i], m_modulus);
+    const auto mv{m_modulus.m_value};
+    const size_t size{m_data.size()};
+    for (size_t i = 0; i < size; ++i)
+        m_data[i].m_value = modSubLane(m_data[i].m_value, b.m_data[i].m_value, mv);
     return *this;
 }
 

--- a/src/pke/include/schemerns/rns-cryptoparameters.h
+++ b/src/pke/include/schemerns/rns-cryptoparameters.h
@@ -306,26 +306,6 @@ public:
     /////////////////////////////////////
 
     /**
-   * Q^(l) = \prod_{j=0}^{l-1}
-   * Gets the precomputed table of [Q^(l)*[Q^(l)^{-1}]_{q_l}/q_l]_{q_i}
-   *
-   * @return the precomputed table
-   */
-    const std::vector<NativeInteger>& GetQlQlInvModqlDivqlModq(size_t i) const {
-        return m_QlQlInvModqlDivqlModq[i];
-    }
-
-    /**
-   * Q^(l) = \prod_{j=0}^{l-1}
-   * Gets the NTL precomputions for [Q^(l)*[Q^(l)^{-1}]_{q_l}/q_l]_{q_i}
-   *
-   * @return the precomputed table
-   */
-    const std::vector<NativeInteger>& GetQlQlInvModqlDivqlModqPrecon(size_t i) const {
-        return m_QlQlInvModqlDivqlModqPrecon[i];
-    }
-
-    /**
    * Gets the precomputed table of [q_i^{-1}]_{q_j}
    *
    * @return the precomputed table
@@ -1432,14 +1412,6 @@ protected:
     /////////////////////////////////////
     // CKKSrns/BFVrns DropLastElementAndScale
     /////////////////////////////////////
-
-    // Q^(l) = \prod_{j=0}^{l-1}
-    // Stores [Q^(l)*[Q^(l)^{-1}]_{q_l}/q_l]_{q_i}
-    std::vector<std::vector<NativeInteger>> m_QlQlInvModqlDivqlModq;
-
-    // Q^(l) = \prod_{j=0}^{l-1}
-    // Stores NTL precomputations for [Q^(l)*[Q^(l)^{-1}]_{q_l}/q_l]_{q_i}
-    std::vector<std::vector<NativeInteger>> m_QlQlInvModqlDivqlModqPrecon;
 
     // Stores [q_l^{-1}]_{q_i}
     std::vector<std::vector<NativeInteger>> m_qlInvModq;

--- a/src/pke/lib/scheme/bfvrns/bfvrns-cryptoparameters.cpp
+++ b/src/pke/lib/scheme/bfvrns/bfvrns-cryptoparameters.cpp
@@ -642,26 +642,16 @@ void CryptoParametersBFVRNS::PrecomputeCRTTables(KeySwitchTechnique ksTech, Scal
         // DropLastElementAndScale
         /////////////////////////////////////
 
-        // Pre-compute omega values for rescaling in RNS
-        // modulusQ holds Q^(l) = \prod_{i=0}^{i=l}(q_i).
-        m_QlQlInvModqlDivqlModq.resize(sizeQ - 1);
-        m_QlQlInvModqlDivqlModqPrecon.resize(sizeQ - 1);
+        // Pre-compute values for rescaling in RNS
         m_qlInvModq.resize(sizeQ - 1);
         m_qlInvModqPrecon.resize(sizeQ - 1);
         for (uint32_t k = 0; k < sizeQ - 1; ++k) {
             uint32_t l = sizeQ - (k + 1);
-            modulusQ = modulusQ / BigInteger(moduliQ[l]);
-            m_QlQlInvModqlDivqlModq[k].resize(l);
-            m_QlQlInvModqlDivqlModqPrecon[k].resize(l);
             m_qlInvModq[k].resize(l);
             m_qlInvModqPrecon[k].resize(l);
-            BigInteger QlInvModql = modulusQ.ModInverse(moduliQ[l]);
-            BigInteger result     = (QlInvModql * modulusQ) / BigInteger(moduliQ[l]);
             for (uint32_t i = 0; i < l; ++i) {
-                m_QlQlInvModqlDivqlModq[k][i]       = result.Mod(moduliQ[i]).ConvertToInt();
-                m_QlQlInvModqlDivqlModqPrecon[k][i] = m_QlQlInvModqlDivqlModq[k][i].PrepModMulConst(moduliQ[i]);
-                m_qlInvModq[k][i]                   = moduliQ[l].ModInverse(moduliQ[i]);
-                m_qlInvModqPrecon[k][i]             = m_qlInvModq[k][i].PrepModMulConst(moduliQ[i]);
+                m_qlInvModq[k][i]       = moduliQ[l].ModInverse(moduliQ[i]);
+                m_qlInvModqPrecon[k][i] = m_qlInvModq[k][i].PrepModMulConst(moduliQ[i]);
             }
         }
     }
@@ -691,8 +681,8 @@ void CryptoParametersBFVRNS::PrecomputeCRTTables(KeySwitchTechnique ksTech, Scal
             B = B * BigInteger(m_moduliB.back());
         }
 
-        m_numb  = m_numq;
-        m_msk   = PreviousPrime<NativeInteger>(m_moduliB[m_numq - 1], 2 * n);
+        m_numb     = m_numq;
+        m_msk      = PreviousPrime<NativeInteger>(m_moduliB[m_numq - 1], 2 * n);
         uint32_t s = m_msk.GetMSB();
 
         BigInteger Q(GetElementParams()->GetModulus());

--- a/src/pke/lib/scheme/bfvrns/bfvrns-leveledshe.cpp
+++ b/src/pke/lib/scheme/bfvrns/bfvrns-leveledshe.cpp
@@ -949,8 +949,7 @@ Ciphertext<DCRTPoly> LeveledSHEBFVRNS::Compress(ConstCiphertext<DCRTPoly>& ciphe
 
     for (size_t l = 0; l < levels; ++l) {
         for (size_t i = 0; i < cv.size(); ++i) {
-            cv[i].DropLastElementAndScale(cryptoParams->GetQlQlInvModqlDivqlModq(diffQl + l),
-                                          cryptoParams->GetqlInvModq(diffQl + l));
+            cv[i].DropLastElementAndScale(cryptoParams->GetqlInvModq(diffQl + l));
         }
     }
 

--- a/src/pke/lib/scheme/bfvrns/bfvrns-multiparty.cpp
+++ b/src/pke/lib/scheme/bfvrns/bfvrns-multiparty.cpp
@@ -152,7 +152,7 @@ DecryptResult MultipartyBFVRNS::MultipartyDecryptFusion(const std::vector<Cipher
     size_t sizeQl = b.GetNumOfElements();
 
     const auto elementParams = cryptoParams->GetElementParams();
-    size_t sizeQ = elementParams->GetParams().size();
+    size_t sizeQ             = elementParams->GetParams().size();
 
     // use RNS procedures only if the number of RNS limbs is the same as for fresh ciphertexts
     if (sizeQl == sizeQ) {
@@ -174,12 +174,11 @@ DecryptResult MultipartyBFVRNS::MultipartyDecryptFusion(const std::vector<Cipher
         }
     }
     else {
-    	// for the case when compress was called, we automatically reduce the polynomial to 1 RNS limb
+        // for the case when compress was called, we automatically reduce the polynomial to 1 RNS limb
         size_t diffQl = sizeQ - sizeQl;
         size_t levels = sizeQl - 1;
         for (size_t l = 0; l < levels; ++l) {
-			b.DropLastElementAndScale(cryptoParams->GetQlQlInvModqlDivqlModq(diffQl + l),
-										  cryptoParams->GetqlInvModq(diffQl + l));
+            b.DropLastElementAndScale(cryptoParams->GetqlInvModq(diffQl + l));
         }
 
         b.SetFormat(Format::COEFFICIENT);

--- a/src/pke/lib/scheme/bfvrns/bfvrns-pke.cpp
+++ b/src/pke/lib/scheme/bfvrns/bfvrns-pke.cpp
@@ -248,8 +248,7 @@ DecryptResult PKEBFVRNS::Decrypt(ConstCiphertext<DCRTPoly> ciphertext, const Pri
         size_t diffQl = sizeQ - sizeQl;
         size_t levels = sizeQl - 1;
         for (size_t l = 0; l < levels; ++l) {
-            b.DropLastElementAndScale(cryptoParams->GetQlQlInvModqlDivqlModq(diffQl + l),
-                                      cryptoParams->GetqlInvModq(diffQl + l));
+            b.DropLastElementAndScale(cryptoParams->GetqlInvModq(diffQl + l));
         }
 
         b.SetFormat(Format::COEFFICIENT);

--- a/src/pke/lib/scheme/ckksrns/ckksrns-cryptoparameters.cpp
+++ b/src/pke/lib/scheme/ckksrns/ckksrns-cryptoparameters.cpp
@@ -59,27 +59,16 @@ void CryptoParametersCKKSRNS::PrecomputeCRTTables(KeySwitchTechnique ksTech, Sca
         rootsQ[i]  = GetElementParams()->GetParams()[i]->GetRootOfUnity();
     }
 
-    BigInteger modulusQ = GetElementParams()->GetModulus();
     // Pre-compute values for rescaling
-    // modulusQ holds Q^(l) = \prod_{i=0}^{i=l}(q_i).
-    m_QlQlInvModqlDivqlModq.resize(sizeQ - 1);
-    m_QlQlInvModqlDivqlModqPrecon.resize(sizeQ - 1);
     m_qlInvModq.resize(sizeQ - 1);
     m_qlInvModqPrecon.resize(sizeQ - 1);
     for (size_t k = 0; k < sizeQ - 1; k++) {
         size_t l = sizeQ - (k + 1);
-        modulusQ = modulusQ / BigInteger(moduliQ[l]);
-        m_QlQlInvModqlDivqlModq[k].resize(l);
-        m_QlQlInvModqlDivqlModqPrecon[k].resize(l);
         m_qlInvModq[k].resize(l);
         m_qlInvModqPrecon[k].resize(l);
-        BigInteger QlInvModql = modulusQ.ModInverse(moduliQ[l]);
-        BigInteger result     = (QlInvModql * modulusQ) / BigInteger(moduliQ[l]);
         for (uint32_t i = 0; i < l; i++) {
-            m_QlQlInvModqlDivqlModq[k][i]       = result.Mod(moduliQ[i]).ConvertToInt();
-            m_QlQlInvModqlDivqlModqPrecon[k][i] = m_QlQlInvModqlDivqlModq[k][i].PrepModMulConst(moduliQ[i]);
-            m_qlInvModq[k][i]                   = moduliQ[l].ModInverse(moduliQ[i]);
-            m_qlInvModqPrecon[k][i]             = m_qlInvModq[k][i].PrepModMulConst(moduliQ[i]);
+            m_qlInvModq[k][i]       = moduliQ[l].ModInverse(moduliQ[i]);
+            m_qlInvModqPrecon[k][i] = m_qlInvModq[k][i].PrepModMulConst(moduliQ[i]);
         }
     }
 

--- a/src/pke/lib/scheme/ckksrns/ckksrns-leveledshe.cpp
+++ b/src/pke/lib/scheme/ckksrns/ckksrns-leveledshe.cpp
@@ -183,8 +183,7 @@ void LeveledSHECKKSRNS::ModReduceInternalInPlace(Ciphertext<DCRTPoly>& ciphertex
 
     for (size_t i = 0; i < levels; ++i) {
         for (auto& dcrtpoly : cv)
-            dcrtpoly.DropLastElementAndScale(cryptoParams->GetQlQlInvModqlDivqlModq(diffQl + i),
-                                             cryptoParams->GetqlInvModq(diffQl + i));
+            dcrtpoly.DropLastElementAndScale(cryptoParams->GetqlInvModq(diffQl + i));
         double modReduceFactor = cryptoParams->GetModReduceFactor(sizeQl - 1 - i);
         ciphertext->SetScalingFactor(ciphertext->GetScalingFactor() / modReduceFactor);
     }


### PR DESCRIPTION
## Summary

Restructures `DropLastElementAndScale` to the RS(ct) form from the full-RNS CKKS
paper (https://eprint.iacr.org/2018/931, Sec. 3.2): round(x/q_l) is computed as
(x − [x]_{q_l}) · [q_l⁻¹]_{q_i}, i.e. the same approach as BGV modulus switching
with t = 1. This needs **one scalar (Shoup) multiplication per tower instead of
two**: the old precomputed constant `QlQlInvModqlDivqlModq` equals −q_l⁻¹ mod q_i,
so the fused two-multiplication form collapses into subtract-then-scale.

The result is **bit-exact** with the previous implementation (differential test
against the old formula: 280/280 tower comparisons across all levels and both
formats), so noise behavior is provably unchanged.

## Changes

- `DropLastElementAndScale(qlInvModq)` — one multiplication per tower; the
  `QlQlInvModqlDivqlModq(+Precon)` tables and their precomputation are removed
  (CKKS + BFV). Affects CKKS ModReduce and BFV Compress/decrypt/multiparty,
  which all shared the formula.
- **Interim** supporting work in the native-int vector layer (`ubintnat.h`,
  `mubintvecnat.cpp`): the element `ModSubFast(Eq)` early-return branch
  mispredicted ~50% on uniform residues (eating the saved multiplication), so
  the element sub ops are now branchless and the vector `ModAdd(Eq)`/`ModSub(Eq)`
  and centered `SwitchModulus`/`ModEq` corrections use branchless,
  auto-vectorizable loops with per-compiler lane dispatch (gcc < 12 and the
  clang add lane use compare-selects; gcc ≥ 12 uses the top-bit mask).
  ⚠️ This lane/dispatch scheme is **temporary**: it works around current
  auto-vectorizer differences and will be reworked together with the NTT and
  transform layers under #1246.

## Performance

CKKS rescale (`ModReduceInPlace`, ring 16384, 12/24 towers; 1-thread pinned,
min of 4 reps, dev vs PR):

| machine | clang -O3 | clang native | gcc -O3 | gcc native |
|---------|-----------|--------------|---------|------------|
| icelake (Xeon 8360Y, clang18/gcc14) | 1.27x/1.28x | 1.07x/1.09x | 1.18x/1.19x | 1.16x/1.17x |
| llserver (i7-9700, clang15/gcc11)   | 1.23x/1.24x | 1.07x/1.11x | 1.07x/1.07x | 1.07x/1.07x |

## Breaking changes

- `DCRTPolyInterface::DropLastElementAndScale` signature changed — out-of-tree
  HALs (openfhe-hexl) must be updated in lockstep.

Refs #1028. Interim vector-layer work to be superseded by #1246.