### PR TITLE
Stream weighted sums in series evaluation

### DIFF
--- a/src/pke/lib/scheme/ckksrns/ckksrns-advancedshe.cpp
+++ b/src/pke/lib/scheme/ckksrns/ckksrns-advancedshe.cpp
@@ -48,14 +48,59 @@ namespace lbcrypto {
 // LINEAR WEIGHTED SUM
 //------------------------------------------------------------------------------
 
+// streamed accumulation: one scaled term live at a time instead of `limit` clones
+template <typename CtType, typename VectorDataType>
+static Ciphertext<DCRTPoly> evalStreamedLinearWSum(const std::vector<CtType>& ciphertexts,
+                                                   const VectorDataType* constants, uint32_t limit) {
+    const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersCKKSRNS>(ciphertexts[0]->GetCryptoParameters());
+
+    auto cc = ciphertexts[0]->GetCryptoContext();
+
+    if (cryptoParams->GetScalingTechnique() == FIXEDMANUAL) {
+        auto acc = cc->EvalMult(ciphertexts[0], constants[0]);
+        for (uint32_t i = 1; i < limit; ++i)
+            cc->EvalAddInPlaceNoCheck(acc, cc->EvalMult(ciphertexts[i], constants[i]));
+        cc->ModReduceInPlace(acc);
+        return acc;
+    }
+
+    // Check to see if input ciphertexts are of same level
+    // and adjust if needed to the max level among them
+    uint32_t maxLevel = ciphertexts[0]->GetLevel();
+    uint32_t maxIdx   = 0;
+    for (uint32_t i = 1; i < limit; ++i) {
+        if ((ciphertexts[i]->GetLevel() > maxLevel) ||
+            ((ciphertexts[i]->GetLevel() == maxLevel) && (ciphertexts[i]->GetNoiseScaleDeg() == 2))) {
+            maxLevel = ciphertexts[i]->GetLevel();
+            maxIdx   = i;
+        }
+    }
+
+    auto algo                = cc->GetScheme();
+    uint32_t compositeDegree = cryptoParams->GetCompositeDegree();
+    auto ctm                 = ciphertexts[maxIdx]->Clone();
+    const bool reduceAll     = (ctm->GetNoiseScaleDeg() == 2);
+
+    Ciphertext<DCRTPoly> acc;
+    for (uint32_t i = 0; i < limit; ++i) {
+        auto term = ciphertexts[i]->Clone();
+        algo->AdjustLevelsAndDepthInPlace(term, ctm);
+        if (reduceAll)
+            algo->ModReduceInternalInPlace(term, compositeDegree);
+        cc->EvalMultInPlace(term, constants[i]);
+        if (i == 0)
+            acc = std::move(term);
+        else
+            cc->EvalAddInPlaceNoCheck(acc, term);
+    }
+    cc->ModReduceInPlace(acc);
+    return acc;
+}
+
 template <typename VectorDataType>
 Ciphertext<DCRTPoly> internalEvalLinearWSum(const std::vector<ReadOnlyCiphertext<DCRTPoly>>& ciphertexts,
                                             const std::vector<VectorDataType>& constants) {
-    const uint32_t limit = ciphertexts.size();
-    std::vector<Ciphertext<DCRTPoly>> cts(limit);
-    for (uint32_t i = 0; i < limit; ++i)
-        cts[i] = ciphertexts[i]->Clone();
-    return internalEvalLinearWSumMutable(cts, constants);
+    return evalStreamedLinearWSum(ciphertexts, constants.data(), static_cast<uint32_t>(ciphertexts.size()));
 }
 
 template <typename VectorDataType>
@@ -107,52 +152,7 @@ Ciphertext<DCRTPoly> EvalPartialLinearWSum(const std::vector<Ciphertext<DCRTPoly
                                            const std::vector<VectorDataType>& constants, uint32_t limit = 0) {
     if (0 == limit)
         limit = ciphertexts.size();
-
-    const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersCKKSRNS>(ciphertexts[0]->GetCryptoParameters());
-
-    auto cc = ciphertexts[0]->GetCryptoContext();
-
-    std::vector<Ciphertext<DCRTPoly>> cts(limit);
-    if (cryptoParams->GetScalingTechnique() != FIXEDMANUAL) {
-        cts[0] = ciphertexts[0]->Clone();
-        // Check to see if input ciphertexts are of same level
-        // and adjust if needed to the max level among them
-        uint32_t maxLevel = cts[0]->GetLevel();
-        uint32_t maxIdx   = 0;
-        for (uint32_t i = 1; i < limit; ++i) {
-            cts[i] = ciphertexts[i]->Clone();
-            if ((cts[i]->GetLevel() > maxLevel) ||
-                ((cts[i]->GetLevel() == maxLevel) && (cts[i]->GetNoiseScaleDeg() == 2))) {
-                maxLevel = cts[i]->GetLevel();
-                maxIdx   = i;
-            }
-        }
-
-        auto algo = cc->GetScheme();
-        auto& ctm = cts[maxIdx];
-        for (uint32_t i = 0; i < maxIdx; ++i)
-            algo->AdjustLevelsAndDepthInPlace(cts[i], ctm);
-        for (uint32_t i = maxIdx + 1; i < limit; ++i)
-            algo->AdjustLevelsAndDepthInPlace(cts[i], ctm);
-
-        uint32_t compositeDegree = cryptoParams->GetCompositeDegree();
-        if (ctm->GetNoiseScaleDeg() == 2) {
-            for (uint32_t i = 0; i < limit; ++i)
-                algo->ModReduceInternalInPlace(cts[i], compositeDegree);
-        }
-    }
-    else {
-        for (uint32_t i = 0; i < limit; ++i)
-            cts[i] = ciphertexts[i]->Clone();
-    }
-
-    cc->EvalMultInPlace(cts[0], constants[1]);
-    for (uint32_t i = 1; i < limit; ++i) {
-        cc->EvalMultInPlace(cts[i], constants[i + 1]);
-        cc->EvalAddInPlaceNoCheck(cts[0], cts[i]);
-    }
-    cc->ModReduceInPlace(cts[0]);
-    return cts[0];
+    return evalStreamedLinearWSum(ciphertexts, constants.data() + 1, limit);
 }
 
 Ciphertext<DCRTPoly> AdvancedSHECKKSRNS::EvalLinearWSum(std::vector<ReadOnlyCiphertext<DCRTPoly>>& ciphertexts,
@@ -462,6 +462,10 @@ Ciphertext<DCRTPoly> internalEvalPolyPSWithPrecomp(const std::shared_ptr<seriesP
     f2.resize(2 * k2m2k + k + 1);
     f2.back() = 1;
 
+    // Serialize tree if k*2^{m-1} < 128
+    if (k * (1U << (m - 1)) < 128)
+        return powers[0]->GetCryptoContext()->EvalSub(InnerEvalPolyPS(powers[0], f2, k, m, powers, powers2), power2km1);
+
     Ciphertext<DCRTPoly> result;
 #pragma omp parallel num_threads(OpenFHEParallelControls.GetThreadLimit(6 * m + 2))
     {
@@ -637,6 +641,7 @@ Ciphertext<DCRTPoly> InnerEvalChebyshevPS(ConstCiphertext<DCRTPoly>& x, const st
 
     Ciphertext<DCRTPoly> cu, qu, su;
 
+#pragma omp task shared(qu)
     {
         // Evaluate q and s2 at u.
         // If their degrees are larger than k, then recursively apply the Paterson-Stockmeyer algorithm.
@@ -665,6 +670,7 @@ Ciphertext<DCRTPoly> InnerEvalChebyshevPS(ConstCiphertext<DCRTPoly>& x, const st
         }
     }
 
+#pragma omp task shared(su)
     {
         // Add x^{k(2^{m-1} - 1)} to s
         auto& s2 = divcs->r;
@@ -716,6 +722,8 @@ Ciphertext<DCRTPoly> InnerEvalChebyshevPS(ConstCiphertext<DCRTPoly>& x, const st
     }
 
     cu = cu ? cc->EvalAdd(T2[m - 1], cu) : cc->EvalAdd(T2[m - 1], divcs->q.front() / 2.0);
+
+#pragma omp taskwait
 
     auto result = cc->EvalMult(cu, qu);
     cc->ModReduceInPlace(result);
@@ -821,7 +829,17 @@ Ciphertext<DCRTPoly> internalEvalChebyshevSeriesPSWithPrecomp(const std::shared_
     f2.resize(2 * k2m2k + k + 1);
     f2.back() = 1;
 
-    return T[0]->GetCryptoContext()->EvalSub(InnerEvalChebyshevPS(T[0], f2, k, m, T, T2), T2km1);
+    // Serialize tree if k*2^{m-1} < 128
+    if (k * (1U << (m - 1)) < 128)
+        return T[0]->GetCryptoContext()->EvalSub(InnerEvalChebyshevPS(T[0], f2, k, m, T, T2), T2km1);
+
+    Ciphertext<DCRTPoly> result;
+#pragma omp parallel num_threads(OpenFHEParallelControls.GetThreadLimit(6 * m + 2))
+    {
+#pragma omp single
+        result = T[0]->GetCryptoContext()->EvalSub(InnerEvalChebyshevPS(T[0], f2, k, m, T, T2), T2km1);
+    }
+    return result;
 }
 
 std::shared_ptr<seriesPowers<DCRTPoly>> AdvancedSHECKKSRNS::EvalChebyPolys(ConstCiphertext<DCRTPoly>& x,


### PR DESCRIPTION
## Summary

Series evaluation (Paterson–Stockmeyer, both power and Chebyshev basis) built its leaf weighted
sums by cloning every referenced power ciphertext up front — up to k+1 ≈ 131 clones held live per
call. The clones existed to satisfy a real constraint — `AdjustLevelsAndDepthInPlace` and the
in-place accumulation require mutable ciphertexts while the inputs are read-only — but
materializing all of them up front made transient memory scale as
(series length × thread count × ciphertext size): under the `EvalPoly` OpenMP task tree these
calls execute on every thread concurrently, reaching ~90–100 GB for a degree-16383
functional-bootstrapping LUT at ring 2^17 on 36 threads, which OOM-kills 128 GB machines. This PR
removes that scaling and, with the memory barrier gone, also brings task parallelism to the
Chebyshev PS path.

## Changes

1. **Streamed weighted sums.** The inputs to these functions are read-only
   (`ReadOnlyCiphertext`, and the powers table shared across the whole PS tree), but the
   implementation needs mutable ciphertexts — `AdjustLevelsAndDepthInPlace` takes non-const
   references, and the scalar multiply/accumulate is done in place. The original code satisfied
   this by cloning *all* referenced ciphertexts up front and operating on the copies, which is
   what made peak memory scale with the series length. The mutability requirement is unchanged;
   the fix is to materialize only one mutable copy at a time: `EvalPartialLinearWSum` and
   `internalEvalLinearWSum` now share a single helper (`evalStreamedLinearWSum`) that
   clones/scales the current term and folds it into an accumulator, in both scaling branches —
   peak footprint per call drops from ~(k+1) ciphertexts to 2. For the non-`FIXEDMANUAL` branch,
   per-term adjustment against a single cloned max-level reference is equivalent to the previous
   adjust-all-then-sum: `AdjustLevelsAndDepthInPlace` mutates only the argument that is behind,
   and the reference (max level, noise-scale-degree-2 preferred on ties) never is.
   `internalEvalLinearWSumMutable` is intentionally unchanged — its contract is that the caller
   donates mutable ciphertexts, so it already has no clones to remove.
2. **Task-parallel Chebyshev PS.** `InnerEvalChebyshevPS` gets the same OpenMP task structure
   `InnerEvalPolyPS` already had (previously its recursion was fully serial).
3. **Work-based serialization gate.** Both PS callers take a serial early-return when
   `k*2^(m-1) < 128` (≈ series degree 256). Inside tasks the tower-level loops of ciphertext
   operations serialize, so small trees are faster on the serial path with full tower
   parallelism — this keeps EvalMod (degrees 44–118) on exactly its previous execution path. The
   crossover was measured empirically at 36 threads (serial wins at `k*2^(m-1)` ≤ 64, tasks win
   at ≥ 144).

## Results

Measured on a 2×36-core Xeon, 125 GB RAM, clang-18, `-march=native`; A/B against the parent
commit.

- Functional bootstrapping BENCH suite (`UnitTestFBT.cpp`): previously OOM-killed at test 22 of
  66 (>127 GB); now all 66 tests pass at full threads with a 41 GB suite-wide peak. The failing
  test alone: 232 s / 38 GB at 36 threads.
- `EvalLinearWSum`: 1.3–2.9× faster, 13–114× lower peak (e.g. 128 ciphertexts at ring 2^16:
  4.2 GB → 36 MB).
- `EvalChebyshevSeries` deg 495/2047: 1.4–2.8× at 36 threads (streaming + task tree); deg ≤ 59
  unchanged by the gate.
- `EvalPoly`: deg 27–59 1.15–1.43× (gate), deg 255–8191 1.03–1.19× with 8–20× lower peaks
  (deg 8191 at ring 2^15: 16.8 GB → 1.5 GB at 36 threads).
- Standard CKKS bootstrapping: neutral by design and by measurement — a 7-config sweep
  (ring 2^16/2^17, packing densities, UNIFORM/SPARSE_TERNARY/SPARSE_ENCAPSULATED) shows 1.00×
  time and 1.00× peak at 1 thread on every config, 36-thread times within the run-noise band,
  identical rotation-key counts.