### PR TITLE
Support per-dimension gadget bases in FHEW bootstrapping

### DIFF
--- a/src/binfhe/include/binfhe-constants.h
+++ b/src/binfhe/include/binfhe-constants.h
@@ -87,12 +87,13 @@ enum BINFHE_PARAMSET {
     STD256Q_LMKCDEY,      // STD256Q optimized for LMKCDEY                                   : 2^(-80)
     STD256Q_3_LMKCDEY,    // STD256Q_LMKCDEY for 3 binary inputs                             : 2^(-70)
     STD256Q_4_LMKCDEY,    // STD256Q_LMKCDEY for 4 binary inputs                             : 2^(-50)
-    LPF_STD128,           // STD128 configured with lower probability of failures            : 2^(-135)
-    LPF_STD128Q,          // STD128Q configured with lower probability of failures           : 2^(-130)
-    LPF_STD128_LMKCDEY,   // LPF_STD128 optimized for LMKCDEY                                : 2^(-150)
-    LPF_STD128Q_LMKCDEY,  // LPF_STD128Q optimized for LMKCDEY                               : 2^(-150)
-    SIGNED_MOD_TEST       // special parameter set for confirming the signed modular         : 2^(-45)
+    LPF_STD128,           // STD128 configured with lower probability of failures            : 2^(-128)
+    LPF_STD128Q,          // STD128Q configured with lower probability of failures           : 2^(-128)
+    LPF_STD128_LMKCDEY,   // LPF_STD128 optimized for LMKCDEY                                : 2^(-128)
+    LPF_STD128Q_LMKCDEY,  // LPF_STD128Q optimized for LMKCDEY                               : 2^(-128)
+    SIGNED_MOD_TEST,      // special parameter set for confirming the signed modular         : 2^(-45)
                           // reduction in the accumulator updates works correctly
+    TOY_MULTI_BASE        // no security; multiple gadget bases for testing                  : not evaluated
 };
 // clang-format on
 std::ostream& operator<<(std::ostream& s, BINFHE_PARAMSET f);

--- a/src/binfhe/include/binfhecontext.h
+++ b/src/binfhe/include/binfhecontext.h
@@ -77,6 +77,9 @@ struct BinFHEContextParams {
     SecretKeyDist keyDist;
 
     double stdDev;
+
+    // number of LWE secret-key coefficients assigned to each gadget base, in ascending base order
+    std::map<uint32_t, uint32_t> gadgetBaseMap;
 };
 
 /**

--- a/src/binfhe/include/lwe-cryptoparameters.h
+++ b/src/binfhe/include/lwe-cryptoparameters.h
@@ -35,6 +35,7 @@
 #include "binfhe-constants.h"
 #include "math/discretegaussiangenerator.h"
 #include "math/math-hal.h"
+#include "math/nbtheory.h"
 #include "utils/serializable.h"
 
 #include <string>
@@ -62,9 +63,8 @@ public:
    * @param baseKS the base used for key switching
    * @param keyDist the key distribution
    */
-    explicit LWECryptoParams(uint32_t n, uint32_t N, NativeInteger q, NativeInteger Q,
-                             NativeInteger q_KS, double std, uint32_t baseKS,
-                             SecretKeyDist keyDist = UNIFORM_TERNARY)
+    explicit LWECryptoParams(uint32_t n, uint32_t N, NativeInteger q, NativeInteger Q, NativeInteger q_KS, double std,
+                             uint32_t baseKS, SecretKeyDist keyDist = UNIFORM_TERNARY)
         : m_q(q), m_Q(Q), m_qKS(q_KS), m_n(n), m_N(N), m_baseKS(baseKS), m_keyDist(keyDist) {
         if (m_n == 0)
             OPENFHE_THROW("m_n (lattice parameter) can not be zero");
@@ -97,8 +97,8 @@ public:
     }
 
     LWECryptoParams& operator=(const LWECryptoParams& rhs) {
-        m_q      = rhs.m_q;
-        m_Q      = rhs.m_Q;
+        m_q = rhs.m_q;
+        m_Q = rhs.m_Q;
         // m_qKS    = rhs.m_qKS;
         m_n      = rhs.m_n;
         m_N      = rhs.m_N;
@@ -130,6 +130,10 @@ public:
 
     uint32_t GetBaseKS() const {
         return m_baseKS;
+    }
+
+    uint32_t GetDigitCountKS() const {
+        return GetDigitCount(m_qKS.ConvertToInt(), m_baseKS);
     }
 
     const DiscreteGaussianGeneratorImpl<NativeVector>& GetDgg() const {

--- a/src/binfhe/include/rgsw-acc-cggi.h
+++ b/src/binfhe/include/rgsw-acc-cggi.h
@@ -75,10 +75,11 @@ private:
    * @param params a shared pointer to RingGSW scheme parameters
    * @param skNTT secret key polynomial in the EVALUATION representation
    * @param m a plaintext
+   * @param index LWE secret-key coefficient index
    * @return a shared pointer to the resulting keys
    */
     RingGSWEvalKey KeyGenCGGI(const std::shared_ptr<RingGSWCryptoParams>& params, const NativePoly& skNTT,
-                              LWEPlaintext m) const;
+                              LWEPlaintext m, uint32_t index) const;
 
     /**
    * CGGI Accumulation as described in https://eprint.iacr.org/2020/086
@@ -88,9 +89,10 @@ private:
    * @param ek1, ek2 evaluation keys for Ring GSW
    * @param a a value to add to the accumulator
    * @param acc previous value of the accumulator
+   * @param index LWE secret-key coefficient index
    */
     void AddToAccCGGI(const std::shared_ptr<RingGSWCryptoParams>& params, ConstRingGSWEvalKey& ek1,
-                      ConstRingGSWEvalKey& ek2, NativeInteger a, RLWECiphertext& acc) const;
+                      ConstRingGSWEvalKey& ek2, NativeInteger a, RLWECiphertext& acc, uint32_t index) const;
 };
 
 }  // namespace lbcrypto

--- a/src/binfhe/include/rgsw-acc-dm.h
+++ b/src/binfhe/include/rgsw-acc-dm.h
@@ -78,8 +78,8 @@ private:
    * @param index LWE secret-key coefficient index
    * @return a shared pointer to the resulting keys
    */
-    RingGSWEvalKey KeyGenDM(const std::shared_ptr<RingGSWCryptoParams>& params, const NativePoly& skNTT,
-                            LWEPlaintext m, uint32_t index) const;
+    RingGSWEvalKey KeyGenDM(const std::shared_ptr<RingGSWCryptoParams>& params, const NativePoly& skNTT, LWEPlaintext m,
+                            uint32_t index) const;
 
     /**
    * DM Accumulation as described in https://eprint.iacr.org/2020/086
@@ -90,8 +90,8 @@ private:
    * @param index LWE secret-key coefficient index
    * @return
    */
-    void AddToAccDM(const std::shared_ptr<RingGSWCryptoParams>& params, ConstRingGSWEvalKey& ek,
-                    RLWECiphertext& acc, uint32_t index) const;
+    void AddToAccDM(const std::shared_ptr<RingGSWCryptoParams>& params, ConstRingGSWEvalKey& ek, RLWECiphertext& acc,
+                    uint32_t index) const;
 };
 
 }  // namespace lbcrypto

--- a/src/binfhe/include/rgsw-acc-dm.h
+++ b/src/binfhe/include/rgsw-acc-dm.h
@@ -75,10 +75,11 @@ private:
    * @param params a shared pointer to RingGSW scheme parameters
    * @param skNTT secret key polynomial in the EVALUATION representation
    * @param m a plaintext
+   * @param index LWE secret-key coefficient index
    * @return a shared pointer to the resulting keys
    */
     RingGSWEvalKey KeyGenDM(const std::shared_ptr<RingGSWCryptoParams>& params, const NativePoly& skNTT,
-                            LWEPlaintext m) const;
+                            LWEPlaintext m, uint32_t index) const;
 
     /**
    * DM Accumulation as described in https://eprint.iacr.org/2020/086
@@ -86,10 +87,11 @@ private:
    * @param params a shared pointer to RingGSW scheme parameters
    * @param ek evaluation key for Ring GSW
    * @param acc previous value of the accumulator
+   * @param index LWE secret-key coefficient index
    * @return
    */
     void AddToAccDM(const std::shared_ptr<RingGSWCryptoParams>& params, ConstRingGSWEvalKey& ek,
-                    RLWECiphertext& acc) const;
+                    RLWECiphertext& acc, uint32_t index) const;
 };
 
 }  // namespace lbcrypto

--- a/src/binfhe/include/rgsw-acc-lmkcdey.h
+++ b/src/binfhe/include/rgsw-acc-lmkcdey.h
@@ -75,10 +75,11 @@ private:
    * @param params a shared pointer to RingGSW scheme parameters
    * @param skNTT secret key polynomial in the EVALUATION representation
    * @param m a plaintext
+   * @param index LWE secret-key coefficient index
    * @return a shared pointer to the resulting keys
    */
     RingGSWEvalKey KeyGenLMKCDEY(const std::shared_ptr<RingGSWCryptoParams>& params, const NativePoly& skNTT,
-                                 LWEPlaintext m) const;
+                                 LWEPlaintext m, uint32_t index) const;
 
     /**
    * Automorphism keys generation for internal Ring GSW as described in https://eprint.iacr.org/2022/198
@@ -97,10 +98,11 @@ private:
    * @param params a shared pointer to RingGSW scheme parameters
    * @param ek evaluation key for Ring GSW
    * @param acc previous value of the accumulator
+   * @param index LWE secret-key coefficient index
    * @return
    */
     void AddToAccLMKCDEY(const std::shared_ptr<RingGSWCryptoParams>& params, ConstRingGSWEvalKey& ek,
-                         RLWECiphertext& acc) const;
+                         RLWECiphertext& acc, uint32_t index) const;
 
     /**
    * LMKCDEY Accumulation automorphism evaluation as described in https://eprint.iacr.org/2022/198

--- a/src/binfhe/include/rgsw-acc.h
+++ b/src/binfhe/include/rgsw-acc.h
@@ -37,7 +37,6 @@
 #include "rlwe-ciphertext.h"
 
 #include <memory>
-#include <optional>
 #include <vector>
 
 namespace lbcrypto {
@@ -86,8 +85,14 @@ public:
    * @param index optional LWE secret-key coefficient index
    */
     void SignedDigitDecompose(const std::shared_ptr<RingGSWCryptoParams>& params, const std::vector<NativePoly>& input,
-                              std::vector<NativePoly>& output,
-                              std::optional<uint32_t> index = std::nullopt) const;
+                              std::vector<NativePoly>& output) const;
+
+    void SignedDigitDecompose(const std::shared_ptr<RingGSWCryptoParams>& params, const std::vector<NativePoly>& input,
+                              std::vector<NativePoly>& output, uint32_t index) const;
+
+    void SignedDigitDecomposeImpl(const std::shared_ptr<RingGSWCryptoParams>& params,
+                                  const std::vector<NativePoly>& input, std::vector<NativePoly>& output,
+                                  const RingGSWCryptoParams::BaseGParams& bp) const;
 
     /**
    * The signed digit decomposition which takes a ring element input and outputs a vector of its digits, i.e.,

--- a/src/binfhe/include/rgsw-acc.h
+++ b/src/binfhe/include/rgsw-acc.h
@@ -37,6 +37,7 @@
 #include "rlwe-ciphertext.h"
 
 #include <memory>
+#include <optional>
 #include <vector>
 
 namespace lbcrypto {
@@ -77,14 +78,16 @@ public:
 
     /**
    * The signed digit decomposition which takes an RLWE ciphertext input and outputs a vector of its digits, i.e., an
-   * RLWE' ciphertext
+   * RLWE' ciphertext. The current gadget base is used when no coefficient index is provided.
    *
    * @param params a shared pointer to RingGSW scheme parameters
    * @param input input RLWE ciphertext
    * @param output output RLWE' ciphertext
+   * @param index optional LWE secret-key coefficient index
    */
     void SignedDigitDecompose(const std::shared_ptr<RingGSWCryptoParams>& params, const std::vector<NativePoly>& input,
-                              std::vector<NativePoly>& output) const;
+                              std::vector<NativePoly>& output,
+                              std::optional<uint32_t> index = std::nullopt) const;
 
     /**
    * The signed digit decomposition which takes a ring element input and outputs a vector of its digits, i.e.,

--- a/src/binfhe/include/rgsw-cryptoparameters.h
+++ b/src/binfhe/include/rgsw-cryptoparameters.h
@@ -85,12 +85,11 @@ public:
           m_method(method),
           m_keyDist(keyDist),
           m_numAutoKeys(numAutoKeys) {
-        if (!IsPowerOfTwo(baseG))
+        if (baseG <= 1 || !IsPowerOfTwo(baseG))
             OPENFHE_THROW("Gadget base should be a power of two.");
         if ((method == LMKCDEY) && (numAutoKeys == 0))
             OPENFHE_THROW("numAutoKeys should be greater than 0.");
-        auto logQ{std::log(m_Q.ConvertToDouble())};
-        m_digitsG = static_cast<uint32_t>(std::ceil(logQ / std::log(static_cast<double>(m_baseG))));
+        m_digitsG = DigitsForBase(m_Q, m_baseG);
         m_dgg.SetStd(std);
         PreCompute(signEval);
     }
@@ -134,11 +133,18 @@ public:
         }
         if ((method == LMKCDEY) && (numAutoKeys == 0))
             OPENFHE_THROW("numAutoKeys should be greater than 0.");
-        auto logQ{std::log(m_Q.ConvertToDouble())};
-        m_digitsG = static_cast<uint32_t>(std::ceil(logQ / std::log(static_cast<double>(m_baseG))));
+        m_digitsG = DigitsForBase(m_Q, m_baseG);
         m_dgg.SetStd(std);
         PreCompute(signEval);
     }
+
+    // gadget parameters for one LWE index: the base, its digit count, and its gadget powers
+    struct BaseGParams {
+        uint32_t baseG{0};
+        uint32_t digitsG{0};
+        uint32_t gBits{0};
+        const std::vector<NativeInteger>* gpow{nullptr};
+    };
 
     /**
    * Performs precomputations based on the supplied parameters
@@ -157,27 +163,36 @@ public:
         return m_q;
     }
 
-    uint32_t GetBaseG(std::optional<uint32_t> index = std::nullopt) const {
-        if (!index.has_value() || m_baseG_map.empty())
-            return m_baseG;
-
-        uint32_t count{0};
-        for (const auto& [baseG, baseGCount] : m_baseG_map) {
-            count += baseGCount;
-            if (*index < count)
-                return baseG;
-        }
-
-        OPENFHE_THROW("Gadget base map does not cover the LWE dimension.");
+    uint32_t GetBaseG() const {
+        return m_baseG;
     }
 
-    uint32_t GetDigitsG(std::optional<uint32_t> index = std::nullopt) const {
-        if (!index.has_value() || m_baseG_map.empty())
-            return m_digitsG;
+    uint32_t GetDigitsG() const {
+        return m_digitsG;
+    }
 
-        auto baseG{GetBaseG(index)};
-        return static_cast<uint32_t>(
-            std::ceil(std::log(m_Q.ConvertToDouble()) / std::log(static_cast<double>(baseG))));
+    // Per-LWE-index gadget parameters. PreCompute() expands the base map into one entry per index.
+    // Returned by value, and built from the live members when no base map is in use:
+    // Change_BaseG() mutates m_baseG/m_digitsG/m_Gpower after PreCompute(), and the
+    // large-precision path depends on those switches taking effect.
+    BaseGParams GetDefaultBaseGParams() const {
+        return {m_baseG, m_digitsG, lbcrypto::GetMSB(m_baseG) - 1, &m_Gpower};
+    }
+
+    BaseGParams GetBaseGParams(uint32_t index) const {
+        if (m_baseGByIndex.empty())
+            return GetDefaultBaseGParams();
+        if (index >= m_baseGByIndex.size())
+            OPENFHE_THROW("Gadget base map does not cover the LWE dimension.");
+        return m_baseGByIndex[index];
+    }
+
+    uint32_t GetBaseG(uint32_t index) const {
+        return GetBaseGParams(index).baseG;
+    }
+
+    uint32_t GetDigitsG(uint32_t index) const {
+        return GetBaseGParams(index).digitsG;
     }
 
     uint32_t GetBaseR() const {
@@ -205,6 +220,11 @@ public:
         if (it == m_Gpower_map.end())
             OPENFHE_THROW("No GPower found for the requested gadget base.");
         return it->second;
+    }
+
+    const std::vector<NativeInteger>& GetGPowerByIndex(uint32_t index) const {
+        const auto* gpow = GetBaseGParams(index).gpow;
+        return (gpow == nullptr) ? m_Gpower : *gpow;
     }
 
     const std::vector<int32_t>& GetLogGen() const {
@@ -291,14 +311,19 @@ public:
 
     void Change_BaseG(uint32_t BaseG) {
         if (m_baseG != BaseG) {
-            m_baseG  = BaseG;
-            m_Gpower = m_Gpower_map[m_baseG];
-            m_digitsG =
-                static_cast<uint32_t>(std::ceil(std::log(m_Q.ConvertToDouble()) / std::log(static_cast<double>(m_baseG))));
+            m_baseG   = BaseG;
+            m_Gpower  = m_Gpower_map[m_baseG];
+            m_digitsG = DigitsForBase(m_Q, m_baseG);
         }
     }
 
 private:
+    // ceil(log_baseG(Q)) for a power-of-two baseG, computed exactly
+    static uint32_t DigitsForBase(const NativeInteger& Q, uint32_t baseG) {
+        const uint32_t gBits{lbcrypto::GetMSB(baseG) - 1};
+        return (lbcrypto::GetMSB(Q.ConvertToInt() - 1) + gBits - 1) / gBits;
+    }
+
     // modulus for the RingGSW/RingLWE scheme
     NativeInteger m_Q;
 
@@ -313,6 +338,9 @@ private:
 
     // number of LWE secret-key coefficients assigned to each gadget base, in ascending base order
     std::map<uint32_t, uint32_t> m_baseG_map;
+
+    // m_baseG_map expanded to one entry per LWE index, filled by PreCompute()
+    std::vector<BaseGParams> m_baseGByIndex;
 
     // base used for the refreshing key (used only for DM bootstrapping)
     uint32_t m_baseR;

--- a/src/binfhe/include/rgsw-cryptoparameters.h
+++ b/src/binfhe/include/rgsw-cryptoparameters.h
@@ -195,6 +195,13 @@ public:
         return GetBaseGParams(index).digitsG;
     }
 
+    // the per-index table is built from a map that never sees the LWE dimension, so the two can
+    // only be reconciled by a caller that holds both; do it before entering a parallel region
+    void VerifyBaseGCoverage(uint32_t n) const {
+        if (!m_baseGByIndex.empty() && m_baseGByIndex.size() != n)
+            OPENFHE_THROW("Gadget base map does not cover the LWE dimension.");
+    }
+
     uint32_t GetBaseR() const {
         return m_baseR;
     }

--- a/src/binfhe/include/rgsw-cryptoparameters.h
+++ b/src/binfhe/include/rgsw-cryptoparameters.h
@@ -44,7 +44,6 @@
 
 #include <map>
 #include <memory>
-#include <optional>
 #include <string>
 #include <utility>
 #include <vector>

--- a/src/binfhe/include/rgsw-cryptoparameters.h
+++ b/src/binfhe/include/rgsw-cryptoparameters.h
@@ -318,8 +318,13 @@ public:
 
     void Change_BaseG(uint32_t BaseG) {
         if (m_baseG != BaseG) {
+            if (!m_baseGByIndex.empty())
+                OPENFHE_THROW("Change_BaseG is not supported with per-dimension gadget bases");
+            auto it = m_Gpower_map.find(BaseG);
+            if (it == m_Gpower_map.end())
+                OPENFHE_THROW("No gadget powers precomputed for base " + std::to_string(BaseG));
             m_baseG   = BaseG;
-            m_Gpower  = m_Gpower_map[m_baseG];
+            m_Gpower  = it->second;
             m_digitsG = DigitsForBase(m_Q, m_baseG);
         }
     }

--- a/src/binfhe/include/rgsw-cryptoparameters.h
+++ b/src/binfhe/include/rgsw-cryptoparameters.h
@@ -44,6 +44,7 @@
 
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -95,6 +96,51 @@ public:
     }
 
     /**
+   * Constructor for using multiple gadget bases in bootstrapping
+   *
+   * @param N ring dimension for RingGSW/RLWE used in bootstrapping
+   * @param Q modulus for RingGSW/RLWE used in bootstrapping
+   * @param q ciphertext modulus for additive LWE
+   * @param baseG the default gadget base, also used for automorphism keys
+   * @param baseGMap number of LWE secret-key coefficients assigned to each gadget base
+   * @param baseR the base for the refreshing key
+   * @param method bootstrapping method (DM or CGGI or LMKCDEY)
+   * @param std standard deviation
+   * @param keyDist secret key distribution
+   * @param signEval flag if sign evaluation is needed
+   * @param numAutoKeys number of automorphism keys in LMKCDEY bootstrapping
+   */
+    explicit RingGSWCryptoParams(uint32_t N, NativeInteger Q, NativeInteger q, uint32_t baseG,
+                                 const std::map<uint32_t, uint32_t>& baseGMap, uint32_t baseR, BINFHE_METHOD method,
+                                 double std, SecretKeyDist keyDist = UNIFORM_TERNARY, bool signEval = false,
+                                 uint32_t numAutoKeys = 10)
+        : m_Q(Q),
+          m_q(q),
+          m_N(N),
+          m_baseG(baseG),
+          m_baseG_map(baseGMap),
+          m_baseR(baseR),
+          m_polyParams{std::make_shared<ILNativeParams>(2 * N, Q)},
+          m_method(method),
+          m_keyDist(keyDist),
+          m_numAutoKeys(numAutoKeys) {
+        if (baseGMap.empty())
+            OPENFHE_THROW("Gadget base map should not be empty.");
+        if (!IsPowerOfTwo(baseG))
+            OPENFHE_THROW("Gadget base should be a power of two.");
+        for (const auto& [baseG, count] : baseGMap) {
+            if (count == 0 || baseG <= 1 || !IsPowerOfTwo(baseG))
+                OPENFHE_THROW("Gadget base should be a power of two and its count should be greater than zero.");
+        }
+        if ((method == LMKCDEY) && (numAutoKeys == 0))
+            OPENFHE_THROW("numAutoKeys should be greater than 0.");
+        auto logQ{std::log(m_Q.ConvertToDouble())};
+        m_digitsG = static_cast<uint32_t>(std::ceil(logQ / std::log(static_cast<double>(m_baseG))));
+        m_dgg.SetStd(std);
+        PreCompute(signEval);
+    }
+
+    /**
    * Performs precomputations based on the supplied parameters
    */
     void PreCompute(bool signEval = false);
@@ -111,12 +157,27 @@ public:
         return m_q;
     }
 
-    uint32_t GetBaseG() const {
-        return m_baseG;
+    uint32_t GetBaseG(std::optional<uint32_t> index = std::nullopt) const {
+        if (!index.has_value() || m_baseG_map.empty())
+            return m_baseG;
+
+        uint32_t count{0};
+        for (const auto& [baseG, baseGCount] : m_baseG_map) {
+            count += baseGCount;
+            if (*index < count)
+                return baseG;
+        }
+
+        OPENFHE_THROW("Gadget base map does not cover the LWE dimension.");
     }
 
-    uint32_t GetDigitsG() const {
-        return m_digitsG;
+    uint32_t GetDigitsG(std::optional<uint32_t> index = std::nullopt) const {
+        if (!index.has_value() || m_baseG_map.empty())
+            return m_digitsG;
+
+        auto baseG{GetBaseG(index)};
+        return static_cast<uint32_t>(
+            std::ceil(std::log(m_Q.ConvertToDouble()) / std::log(static_cast<double>(baseG))));
     }
 
     uint32_t GetBaseR() const {
@@ -137,6 +198,13 @@ public:
 
     const std::vector<NativeInteger>& GetGPower() const {
         return m_Gpower;
+    }
+
+    const std::vector<NativeInteger>& GetGPower(uint32_t baseG) const {
+        auto it = m_Gpower_map.find(baseG);
+        if (it == m_Gpower_map.end())
+            OPENFHE_THROW("No GPower found for the requested gadget base.");
+        return it->second;
     }
 
     const std::vector<int32_t>& GetLogGen() const {
@@ -168,7 +236,8 @@ public:
     }
 
     bool operator==(const RingGSWCryptoParams& other) const {
-        return m_N == other.m_N && m_Q == other.m_Q && m_baseR == other.m_baseR && m_baseG == other.m_baseG;
+        return m_N == other.m_N && m_Q == other.m_Q && m_baseR == other.m_baseR && m_baseG == other.m_baseG &&
+               m_baseG_map == other.m_baseG_map;
     }
 
     bool operator!=(const RingGSWCryptoParams& other) const {
@@ -187,6 +256,7 @@ public:
         ar(::cereal::make_nvp("bdigitsG", m_digitsG));
         ar(::cereal::make_nvp("bparams", m_polyParams));
         ar(::cereal::make_nvp("numAutoKeys", m_numAutoKeys));
+        ar(::cereal::make_nvp("baseGMap", m_baseG_map));
     }
 
     template <class Archive>
@@ -207,7 +277,7 @@ public:
         ar(::cereal::make_nvp("bdigitsG", m_digitsG));
         ar(::cereal::make_nvp("bparams", m_polyParams));
         ar(::cereal::make_nvp("numAutoKeys", m_numAutoKeys));
-
+        ar(::cereal::make_nvp("baseGMap", m_baseG_map));
         PreCompute();
     }
 
@@ -241,10 +311,13 @@ private:
     // gadget base used in bootstrapping
     uint32_t m_baseG;
 
+    // number of LWE secret-key coefficients assigned to each gadget base, in ascending base order
+    std::map<uint32_t, uint32_t> m_baseG_map;
+
     // base used for the refreshing key (used only for DM bootstrapping)
     uint32_t m_baseR;
 
-    // number of digits in decomposing integers mod Q
+    // number of digits in decomposing integers mod Q for given baseG
     uint32_t m_digitsG;
 
     // powers of m_baseR (used only for DM bootstrapping)
@@ -264,7 +337,7 @@ private:
     // Error distribution generator
     DiscreteGaussianGeneratorImpl<NativeVector> m_dgg;
 
-    // A map of vectors of powers of baseG for sign evaluation
+    // A map of vectors of powers for each gadget base
     std::map<uint32_t, std::vector<NativeInteger>> m_Gpower_map;
 
     // Parameters for polynomials in RingGSW/RingLWE

--- a/src/binfhe/include/rgsw-cryptoparameters.h
+++ b/src/binfhe/include/rgsw-cryptoparameters.h
@@ -318,10 +318,8 @@ public:
     }
 
 private:
-    // ceil(log_baseG(Q)) for a power-of-two baseG, computed exactly
     static uint32_t DigitsForBase(const NativeInteger& Q, uint32_t baseG) {
-        const uint32_t gBits{lbcrypto::GetMSB(baseG) - 1};
-        return (lbcrypto::GetMSB(Q.ConvertToInt() - 1) + gBits - 1) / gBits;
+        return lbcrypto::GetDigitCount(Q.ConvertToInt(), baseG);
     }
 
     // modulus for the RingGSW/RingLWE scheme

--- a/src/binfhe/include/rgsw-cryptoparameters.h
+++ b/src/binfhe/include/rgsw-cryptoparameters.h
@@ -150,6 +150,9 @@ public:
    */
     void PreCompute(bool signEval = false);
 
+    // gadget powers baseG^i mod Q, computed once per base and cached in m_Gpower_map
+    const std::vector<NativeInteger>& PrecomputeGPower(uint32_t baseG);
+
     uint32_t GetN() const {
         return m_N;
     }
@@ -319,11 +322,8 @@ public:
         if (m_baseG != BaseG) {
             if (!m_baseGByIndex.empty())
                 OPENFHE_THROW("Change_BaseG is not supported with per-dimension gadget bases");
-            auto it = m_Gpower_map.find(BaseG);
-            if (it == m_Gpower_map.end())
-                OPENFHE_THROW("No gadget powers precomputed for base " + std::to_string(BaseG));
             m_baseG   = BaseG;
-            m_Gpower  = it->second;
+            m_Gpower  = PrecomputeGPower(BaseG);
             m_digitsG = DigitsForBase(m_Q, m_baseG);
         }
     }

--- a/src/binfhe/lib/binfhe-base-scheme.cpp
+++ b/src/binfhe/lib/binfhe-base-scheme.cpp
@@ -426,14 +426,12 @@ LWECiphertext BinFHEScheme::EvalSign(const std::shared_ptr<BinFHECryptoParams>& 
     while (mod > q) {
         cttmp = EvalFloor(params, curEK, cttmp, beta);
         // round Q to 2betaQ/q
-        //  mod   = mod / q * 2 * beta;
         mod   = (mod << 1) * beta / q;
         cttmp = LWEscheme->ModSwitch(mod, cttmp);
 
         // if dynamic
         if (EKs.size() == 3) {
-            // TODO: use GetMSB()?
-            uint32_t binLog = static_cast<uint32_t>(std::ceil(GetMSB(mod.ConvertToInt()) - 1));
+            uint32_t binLog = GetMSB(mod.ConvertToInt()) - 1;
             uint32_t base{0};
             if (binLog <= static_cast<uint32_t>(17))
                 base = static_cast<uint32_t>(1) << 27;
@@ -445,7 +443,7 @@ LWECiphertext BinFHEScheme::EvalSign(const std::shared_ptr<BinFHECryptoParams>& 
 
                 auto search = EKs.find(base);
                 if (search == EKs.end())
-                    OPENFHE_THROW("No key [" + std::to_string(curBase) + "] found in the map");
+                    OPENFHE_THROW("No key [" + std::to_string(base) + "] found in the map");
                 curEK = search->second;
             }
         }
@@ -503,12 +501,12 @@ std::vector<LWECiphertext> BinFHEScheme::EvalDecomp(const std::shared_ptr<BinFHE
 
         // Floor the input sequentially to obtain the most significant bit
         cttmp = EvalFloor(params, curEK, cttmp, beta);
-        mod   = mod / q * 2 * beta;
         // round Q to 2betaQ/q
+        mod   = (mod << 1) * beta / q;
         cttmp = LWEscheme->ModSwitch(mod, cttmp);
 
         if (EKs.size() == 3) {  // if dynamic
-            uint32_t binLog = static_cast<uint32_t>(std::ceil(std::log2(mod.ConvertToInt())));
+            uint32_t binLog = GetMSB(mod.ConvertToInt()) - 1;
             uint32_t base   = 0;
             if (binLog <= static_cast<uint32_t>(17))
                 base = static_cast<uint32_t>(1) << 27;
@@ -520,7 +518,7 @@ std::vector<LWECiphertext> BinFHEScheme::EvalDecomp(const std::shared_ptr<BinFHE
 
                 auto search = EKs.find(base);
                 if (search == EKs.end())
-                    OPENFHE_THROW("No key [" + std::to_string(curBase) + "] found in the map");
+                    OPENFHE_THROW("No key [" + std::to_string(base) + "] found in the map");
                 curEK = search->second;
             }
         }

--- a/src/binfhe/lib/binfhe-constants-impl.cpp
+++ b/src/binfhe/lib/binfhe-constants-impl.cpp
@@ -41,6 +41,9 @@ std::ostream& operator<<(std::ostream& s, BINFHE_PARAMSET f) {
         case TOY:
             s << "TOY";
             break;
+        case TOY_MULTI_BASE:
+            s << "TOY_MULTI_BASE";
+            break;
         case MEDIUM:
             s << "MEDIUM";
             break;
@@ -267,6 +270,7 @@ void isMethodCompatible(BINFHE_METHOD m, BINFHE_PARAMSET p) {
     if (m == LMKCDEY) {
         switch (p) {
             case TOY:
+            case TOY_MULTI_BASE:
             case MEDIUM:
             case STD128_LMKCDEY:
             case STD128_3_LMKCDEY:
@@ -296,6 +300,7 @@ void isMethodCompatible(BINFHE_METHOD m, BINFHE_PARAMSET p) {
     else if (m == AP || m == GINX) {
         switch (p) {
             case TOY:
+            case TOY_MULTI_BASE:
             case MEDIUM:
             case STD128_AP:
             case STD128:

--- a/src/binfhe/lib/binfhecontext.cpp
+++ b/src/binfhe/lib/binfhecontext.cpp
@@ -35,6 +35,7 @@
 
 #include "binfhecontext.h"
 
+#include <map>
 #include <string>
 #include <unordered_map>
 

--- a/src/binfhe/lib/binfhecontext.cpp
+++ b/src/binfhe/lib/binfhecontext.cpp
@@ -307,15 +307,14 @@ void BinFHEContext::BTKeyGen(ConstLWEPrivateKey& sk, KEYGEN_MODE keygenMode) {
     auto&& RGSWParams = m_params->GetRingGSWParams();
     auto temp         = RGSWParams->GetBaseG();
 
+    // the map is keyed by gadget base alone, but what it caches is only valid for the secret
+    // key it was generated from; take a cached entry only when this call just regenerated it
     if (m_timeOptimization) {
         for (auto&& [k, v] : RGSWParams->GetGPowerMap()) {
             RGSWParams->Change_BaseG(k);
             m_BTKey_map[k] = m_binfhescheme->KeyGen(m_params, sk, keygenMode);
         }
         RGSWParams->Change_BaseG(temp);
-    }
-
-    if (m_BTKey_map.size() != 0) {
         m_BTKey = m_BTKey_map[temp];
     }
     else {

--- a/src/binfhe/lib/binfhecontext.cpp
+++ b/src/binfhe/lib/binfhecontext.cpp
@@ -111,51 +111,52 @@ void BinFHEContext::GenerateBinFHEContext(BINFHE_PARAMSET s, BINFHE_METHOD metho
 
     // clang-format off
     static const std::unordered_map<BINFHE_PARAMSET, BinFHEContextParams> paramsMap{
-    //  { BINFHE_PARAMSET      { bits, cycOrder, latParam, modq,   modKS, Bks,        Bg, Brk, autoKeys,         keyDist, stdDev } },
-        { TOY,                 {   27,     1024,       64,  512,   PRIME,  25,       512,  23,        9, UNIFORM_TERNARY,   3.19 } },
-        { MEDIUM,              {   28,     2048,      422, 1024,   16384, 128,      1024,  32,       10, UNIFORM_TERNARY,   3.19 } },
-        { STD128_AP,           {   27,     2048,      559, 2048,   32768,  32,       512,  64,       10, UNIFORM_TERNARY,   3.19 } },
-        { STD128,              {   27,     2048,      556, 2048,   32768,  32,       128,  64,       10, UNIFORM_TERNARY,   3.19 } },
-        { STD128_3,            {   27,     2048,      595, 2048,   65536,  64,       128,  64,       10, UNIFORM_TERNARY,   3.19 } },
-        { STD128_4,            {   27,     2048,      635, 2048,  131072,  64,        32,  64,       10, UNIFORM_TERNARY,   3.19 } },
-        { STD128Q,             {   25,     2048,      601, 2048,   32768,  32,        16,  64,       10, UNIFORM_TERNARY,   3.19 } },
-        { STD128Q_3,           {   25,     2048,      641, 2048,   65536,  64,        16,  64,       10, UNIFORM_TERNARY,   3.19 } },
-        { STD128Q_4,           {   50,     4096,      683, 4096,  131072,  64,    131072,  64,       10, UNIFORM_TERNARY,   3.19 } },
-        { STD192,              {   37,     4096,      821, 2048,   32768,  32,      8192,  64,       10, UNIFORM_TERNARY,   3.19 } },
-        { STD192_3,            {   37,     4096,      876, 2048,   65536,  64,      8192,  64,       10, UNIFORM_TERNARY,   3.19 } },
-        { STD192_4,            {   37,     4096,      932, 4096,  131072,  64,      8192,  64,       10, UNIFORM_TERNARY,   3.19 } },
-        { STD192Q,             {   34,     4096,      890, 2048,   32768,  32,      4096,  64,       10, UNIFORM_TERNARY,   3.19 } },
-        { STD192Q_3,           {   34,     4096,      948, 2048,   65536,  64,      4096,  64,       10, UNIFORM_TERNARY,   3.19 } },
-        { STD192Q_4,           {   34,     4096,     1009, 4096,  131072,  64,      4096,  64,       10, UNIFORM_TERNARY,   3.19 } },
-        { STD256,              {   29,     4096,     1299, 2048,  262144,  64,      1024,  64,       10, UNIFORM_TERNARY,   3.19 } },
-        { STD256_3,            {   29,     4096,     1241, 2048,  131072,  64,       256,  64,       10, UNIFORM_TERNARY,   3.19 } },
-        { STD256_4,            {   29,     4096,     1218, 4096,  131072,  64,        32,  64,       10, UNIFORM_TERNARY,   3.19 } },
-        { STD256Q,             {   26,     4096,     1242, 2048,   65536,  64,        64,  64,       10, UNIFORM_TERNARY,   3.19 } },
-        { STD256Q_3,           {   26,     4096,     1319, 4096,  131072,  64,        32,  64,       10, UNIFORM_TERNARY,   3.19 } },
-        { STD256Q_4,           {   26,     4096,     1319, 4096,  131072,  64,        16,  64,       10, UNIFORM_TERNARY,   3.19 } },
-        { STD128_LMKCDEY,      {   27,     2048,      581, 1024,   32768,  32,       512,  32,       10, UNIFORM_TERNARY,   3.19 } },
-        { STD128_3_LMKCDEY,    {   27,     2048,      595, 2048,   65536,  64,       128,  64,       10, UNIFORM_TERNARY,   3.19 } },
-        { STD128_4_LMKCDEY,    {   27,     2048,      635, 2048,  131072,  64,        64,  64,       10, UNIFORM_TERNARY,   3.19 } },
-        { STD128Q_LMKCDEY,     {   25,     2048,      640, 1024,   32768,  32,       128,  32,       10, UNIFORM_TERNARY,   3.19 } },
-        { STD128Q_3_LMKCDEY,   {   25,     2048,      641, 2048,   65536,  64,        16,  64,       10, UNIFORM_TERNARY,   3.19 } },
-        { STD128Q_4_LMKCDEY,   {   25,     2048,      685, 2048,  131072,  64,        16,  64,       10, UNIFORM_TERNARY,   3.19 } },
-        { STD192_LMKCDEY,      {   39,     4096,      716, 4096,   32768,  32,   1048576,  64,       10,        GAUSSIAN,   3.19 } },
-        { STD192_3_LMKCDEY,    {   37,     4096,      876, 2048,   65536,  64,      1024,  64,       10, UNIFORM_TERNARY,   3.19 } },
-        { STD192_4_LMKCDEY,    {   37,     4096,      932, 4096,  131072,  64,      1024,  64,       10, UNIFORM_TERNARY,   3.19 } },
-        { STD192Q_LMKCDEY,     {   36,     4096,      778, 4096,   32768,  32,      4096,  64,       10,        GAUSSIAN,   3.19 } },
-        { STD192Q_3_LMKCDEY,   {   34,     4096,      948, 2048,   65536,  64,      4096,  64,       10, UNIFORM_TERNARY,   3.19 } },
-        { STD192Q_4_LMKCDEY,   {   34,     4096,     1009, 4096,  131072,  64,      4096,  64,       10, UNIFORM_TERNARY,   3.19 } },
-        { STD256_LMKCDEY,      {   29,     4096,     1079, 2048,   32768,  32,      1024,  64,       10, UNIFORM_TERNARY,   3.19 } },
-        { STD256_3_LMKCDEY,    {   29,     4096,     1218, 2048,  131072,  64,       256,  64,       10, UNIFORM_TERNARY,   3.19 } },
-        { STD256_4_LMKCDEY,    {   29,     4096,     1218, 4096,  131072,  64,       256,  64,       10, UNIFORM_TERNARY,   3.19 } },
-        { STD256Q_LMKCDEY,     {   26,     4096,     1242, 2048,   65536,  64,       128,  64,       10, UNIFORM_TERNARY,   3.19 } },
-        { STD256Q_3_LMKCDEY,   {   26,     4096,     1319, 4096,  131072,  64,        64,  64,       10, UNIFORM_TERNARY,   3.19 } },
-        { STD256Q_4_LMKCDEY,   {   26,     4096,     1319, 4096,  131072,  64,        32,  64,       10, UNIFORM_TERNARY,   3.19 } },
-        { LPF_STD128,          {   27,     2048,      556, 2048,   32768,  32,       128,  64,       10, UNIFORM_TERNARY,   3.19 } },
-        { LPF_STD128Q,         {   25,     2048,      601, 2048,   32768,  32,        16,  64,       10, UNIFORM_TERNARY,   3.19 } },
-        { LPF_STD128_LMKCDEY,  {   27,     2048,      556, 2048,   32768,  32,       128,  64,       10, UNIFORM_TERNARY,   3.19 } },
-        { LPF_STD128Q_LMKCDEY, {   25,     2048,      601, 2048,   32768,  32,        16,  64,       10, UNIFORM_TERNARY,   3.19 } },
-        { SIGNED_MOD_TEST,     {   28,     2048,      512, 1024,   PRIME,  25,       128,  23,       10, UNIFORM_TERNARY,   3.19 } },
+    //  { BINFHE_PARAMSET      { bits, cycOrder, latParam, modq,   modKS, Bks,        Bg, Brk, autoKeys,         keyDist, stdDev, gadgetBaseMap } },
+        { TOY,                 {   27,     1024,       64,  512,   PRIME,  25,       512,  23,        9, UNIFORM_TERNARY,   3.19, {{512, 64}} } },
+        { TOY_MULTI_BASE,      {   27,     1024,       64,  512,   PRIME,  25,       512,  23,        9, UNIFORM_TERNARY,   3.19, {{128, 32}, {512, 32}} } },
+        { MEDIUM,              {   28,     2048,      422, 1024,   16384, 128,      1024,  32,       10, UNIFORM_TERNARY,   3.19, {{1024, 422}} } },
+        { STD128_AP,           {   27,     2048,      559, 2048,   32768,  32,       512,  64,       10, UNIFORM_TERNARY,   3.19, {{512, 559}} } },
+        { STD128,              {   27,     2048,      556, 2048,   32768,  32,       128,  64,       10, UNIFORM_TERNARY,   3.19, {{128, 556}} } },
+        { STD128_3,            {   27,     2048,      595, 2048,   65536,  64,       128,  64,       10, UNIFORM_TERNARY,   3.19, {{128, 595}} } },
+        { STD128_4,            {   27,     2048,      635, 2048,  131072,  64,        32,  64,       10, UNIFORM_TERNARY,   3.19, {{32, 635}} } },
+        { STD128Q,             {   25,     2048,      601, 2048,   32768,  32,        16,  64,       10, UNIFORM_TERNARY,   3.19, {{16, 601}} } },
+        { STD128Q_3,           {   25,     2048,      641, 2048,   65536,  64,        16,  64,       10, UNIFORM_TERNARY,   3.19, {{16, 641}} } },
+        { STD128Q_4,           {   50,     4096,      683, 4096,  131072,  64,    131072,  64,       10, UNIFORM_TERNARY,   3.19, {{131072, 683}} } },
+        { STD192,              {   37,     4096,      821, 2048,   32768,  32,      8192,  64,       10, UNIFORM_TERNARY,   3.19, {{8192, 821}} } },
+        { STD192_3,            {   37,     4096,      876, 2048,   65536,  64,      8192,  64,       10, UNIFORM_TERNARY,   3.19, {{8192, 876}} } },
+        { STD192_4,            {   37,     4096,      932, 4096,  131072,  64,      8192,  64,       10, UNIFORM_TERNARY,   3.19, {{8192, 932}} } },
+        { STD192Q,             {   34,     4096,      890, 2048,   32768,  32,      4096,  64,       10, UNIFORM_TERNARY,   3.19, {{4096, 890}} } },
+        { STD192Q_3,           {   34,     4096,      948, 2048,   65536,  64,      4096,  64,       10, UNIFORM_TERNARY,   3.19, {{4096, 948}} } },
+        { STD192Q_4,           {   34,     4096,     1009, 4096,  131072,  64,      4096,  64,       10, UNIFORM_TERNARY,   3.19, {{4096, 1009}} } },
+        { STD256,              {   29,     4096,     1299, 2048,  262144,  64,      1024,  64,       10, UNIFORM_TERNARY,   3.19, {{1024, 1299}} } },
+        { STD256_3,            {   29,     4096,     1241, 2048,  131072,  64,       256,  64,       10, UNIFORM_TERNARY,   3.19, {{256, 1241}} } },
+        { STD256_4,            {   29,     4096,     1218, 4096,  131072,  64,        32,  64,       10, UNIFORM_TERNARY,   3.19, {{32, 1218}} } },
+        { STD256Q,             {   26,     4096,     1242, 2048,   65536,  64,        64,  64,       10, UNIFORM_TERNARY,   3.19, {{64, 1242}} } },
+        { STD256Q_3,           {   26,     4096,     1319, 4096,  131072,  64,        32,  64,       10, UNIFORM_TERNARY,   3.19, {{32, 1319}} } },
+        { STD256Q_4,           {   26,     4096,     1319, 4096,  131072,  64,        16,  64,       10, UNIFORM_TERNARY,   3.19, {{16, 1319}} } },
+        { STD128_LMKCDEY,      {   27,     2048,      581, 1024,   32768,  32,       512,  32,       10, UNIFORM_TERNARY,   3.19, {{512, 581}} } },
+        { STD128_3_LMKCDEY,    {   27,     2048,      595, 2048,   65536,  64,       128,  64,       10, UNIFORM_TERNARY,   3.19, {{128, 595}} } },
+        { STD128_4_LMKCDEY,    {   27,     2048,      635, 2048,  131072,  64,        64,  64,       10, UNIFORM_TERNARY,   3.19, {{64, 635}} } },
+        { STD128Q_LMKCDEY,     {   25,     2048,      640, 1024,   32768,  32,       128,  32,       10, UNIFORM_TERNARY,   3.19, {{128, 640}} } },
+        { STD128Q_3_LMKCDEY,   {   25,     2048,      641, 2048,   65536,  64,        16,  64,       10, UNIFORM_TERNARY,   3.19, {{16, 641}} } },
+        { STD128Q_4_LMKCDEY,   {   25,     2048,      685, 2048,  131072,  64,        16,  64,       10, UNIFORM_TERNARY,   3.19, {{16, 685}} } },
+        { STD192_LMKCDEY,      {   39,     4096,      716, 4096,   32768,  32,   1048576,  64,       10,        GAUSSIAN,   3.19, {{1048576, 716}} } },
+        { STD192_3_LMKCDEY,    {   37,     4096,      876, 2048,   65536,  64,      1024,  64,       10, UNIFORM_TERNARY,   3.19, {{1024, 876}} } },
+        { STD192_4_LMKCDEY,    {   37,     4096,      932, 4096,  131072,  64,      1024,  64,       10, UNIFORM_TERNARY,   3.19, {{1024, 932}} } },
+        { STD192Q_LMKCDEY,     {   36,     4096,      778, 4096,   32768,  32,      4096,  64,       10,        GAUSSIAN,   3.19, {{4096, 778}} } },
+        { STD192Q_3_LMKCDEY,   {   34,     4096,      948, 2048,   65536,  64,      4096,  64,       10, UNIFORM_TERNARY,   3.19, {{4096, 948}} } },
+        { STD192Q_4_LMKCDEY,   {   34,     4096,     1009, 4096,  131072,  64,      4096,  64,       10, UNIFORM_TERNARY,   3.19, {{4096, 1009}} } },
+        { STD256_LMKCDEY,      {   29,     4096,     1079, 2048,   32768,  32,      1024,  64,       10, UNIFORM_TERNARY,   3.19, {{1024, 1079}} } },
+        { STD256_3_LMKCDEY,    {   29,     4096,     1218, 2048,  131072,  64,       256,  64,       10, UNIFORM_TERNARY,   3.19, {{256, 1218}} } },
+        { STD256_4_LMKCDEY,    {   29,     4096,     1218, 4096,  131072,  64,       256,  64,       10, UNIFORM_TERNARY,   3.19, {{256, 1218}} } },
+        { STD256Q_LMKCDEY,     {   26,     4096,     1242, 2048,   65536,  64,       128,  64,       10, UNIFORM_TERNARY,   3.19, {{128, 1242}} } },
+        { STD256Q_3_LMKCDEY,   {   26,     4096,     1319, 4096,  131072,  64,        64,  64,       10, UNIFORM_TERNARY,   3.19, {{64, 1319}} } },
+        { STD256Q_4_LMKCDEY,   {   26,     4096,     1319, 4096,  131072,  64,        32,  64,       10, UNIFORM_TERNARY,   3.19, {{32, 1319}} } },
+        { LPF_STD128,          {   27,     2048,      556, 2048,   32768,  32,       128,  64,       10, UNIFORM_TERNARY,   3.19, {{128, 547}, {512, 9}} } },
+        { LPF_STD128Q,         {   25,     2048,      601, 2048,   32768,  32,        16,  64,       10, UNIFORM_TERNARY,   3.19, {{16, 581}, {32, 20}} } },
+        { LPF_STD128_LMKCDEY,  {   27,     2048,      556, 2048,   32768,  32,       128,  64,       10, UNIFORM_TERNARY,   3.19, {{128, 392}, {512, 164}} } },
+        { LPF_STD128Q_LMKCDEY, {   25,     2048,      601, 2048,   32768,  32,        16,  64,       10, UNIFORM_TERNARY,   3.19, {{16, 567}, {32, 34}} } },
+        { SIGNED_MOD_TEST,     {   28,     2048,      512, 1024,   PRIME,  25,       128,  23,       10, UNIFORM_TERNARY,   3.19, {{128, 512}} } },
     };
     // clang-format on
 
@@ -171,7 +172,7 @@ void BinFHEContext::GenerateBinFHEContext(BINFHE_PARAMSET s, BINFHE_METHOD metho
                                                        (params.modKS == PRIME ? Q : params.modKS), params.stdDev,
                                                        params.baseKS, params.keyDist);
     auto rgswparams =
-        std::make_shared<RingGSWCryptoParams>(ringDim, Q, params.mod, params.gadgetBase, params.baseRK, method,
+        std::make_shared<RingGSWCryptoParams>(ringDim, Q, params.mod, params.gadgetBase, params.gadgetBaseMap, params.baseRK, method,
                                               params.stdDev, params.keyDist, false, params.numAutoKeys);
     m_params = std::make_shared<BinFHECryptoParams>(lweparams, rgswparams);
 
@@ -186,9 +187,23 @@ void BinFHEContext::GenerateBinFHEContext(const BinFHEContextParams& params, BIN
     auto lweparams = std::make_shared<LWECryptoParams>(params.latticeParam, ringDim, params.mod, Q,
                                                        (params.modKS == PRIME ? Q : params.modKS), params.stdDev,
                                                        params.baseKS, params.keyDist);
-    auto rgswparams =
-        std::make_shared<RingGSWCryptoParams>(ringDim, Q, params.mod, params.gadgetBase, params.baseRK, method,
-                                              params.stdDev, params.keyDist, false, params.numAutoKeys);
+    std::shared_ptr<RingGSWCryptoParams> rgswparams;
+    if (params.gadgetBaseMap.empty()) {
+        rgswparams = std::make_shared<RingGSWCryptoParams>(ringDim, Q, params.mod, params.gadgetBase,
+                                                           params.baseRK, method, params.stdDev, params.keyDist,
+                                                           false, params.numAutoKeys);
+    }
+    else {
+        uint32_t count{0};
+        for (const auto& item : params.gadgetBaseMap)
+            count += item.second;
+        if (count != params.latticeParam)
+            OPENFHE_THROW("Gadget base map should cover the LWE dimension.");
+
+        rgswparams = std::make_shared<RingGSWCryptoParams>(
+            ringDim, Q, params.mod, params.gadgetBase, params.gadgetBaseMap, params.baseRK, method, params.stdDev,
+            params.keyDist, false, params.numAutoKeys);
+    }
     m_params       = std::make_shared<BinFHECryptoParams>(lweparams, rgswparams);
     m_binfhescheme = std::make_shared<BinFHEScheme>(method);
 }

--- a/src/binfhe/lib/binfhecontext.cpp
+++ b/src/binfhe/lib/binfhecontext.cpp
@@ -42,9 +42,18 @@ static constexpr double STD_DEV = 3.19;
 
 namespace lbcrypto {
 
-void BinFHEContext::GenerateBinFHEContext(uint32_t n, uint32_t N, NativeInteger q, NativeInteger Q,
-                                          double std, uint32_t baseKS, uint32_t baseG, uint32_t baseR,
-                                          SecretKeyDist keyDist, BINFHE_METHOD method, uint32_t numAutoKeys) {
+// RingGSWCryptoParams never sees the LWE dimension, so the map and n meet only here
+static void VerifyGadgetBaseMapCoverage(const std::map<uint32_t, uint32_t>& baseGMap, uint32_t n) {
+    uint32_t count{0};
+    for (const auto& item : baseGMap)
+        count += item.second;
+    if (count != n)
+        OPENFHE_THROW("Gadget base map should cover the LWE dimension.");
+}
+
+void BinFHEContext::GenerateBinFHEContext(uint32_t n, uint32_t N, NativeInteger q, NativeInteger Q, double std,
+                                          uint32_t baseKS, uint32_t baseG, uint32_t baseR, SecretKeyDist keyDist,
+                                          BINFHE_METHOD method, uint32_t numAutoKeys) {
     auto lweparams = std::make_shared<LWECryptoParams>(n, N, q, Q, Q, std, baseKS);
     auto rgswparams =
         std::make_shared<RingGSWCryptoParams>(N, Q, q, baseG, baseR, method, std, keyDist, true, numAutoKeys);
@@ -171,10 +180,12 @@ void BinFHEContext::GenerateBinFHEContext(BINFHE_PARAMSET s, BINFHE_METHOD metho
     auto lweparams = std::make_shared<LWECryptoParams>(params.latticeParam, ringDim, params.mod, Q,
                                                        (params.modKS == PRIME ? Q : params.modKS), params.stdDev,
                                                        params.baseKS, params.keyDist);
-    auto rgswparams =
-        std::make_shared<RingGSWCryptoParams>(ringDim, Q, params.mod, params.gadgetBase, params.gadgetBaseMap, params.baseRK, method,
-                                              params.stdDev, params.keyDist, false, params.numAutoKeys);
-    m_params = std::make_shared<BinFHECryptoParams>(lweparams, rgswparams);
+    VerifyGadgetBaseMapCoverage(params.gadgetBaseMap, params.latticeParam);
+
+    auto rgswparams = std::make_shared<RingGSWCryptoParams>(ringDim, Q, params.mod, params.gadgetBase,
+                                                            params.gadgetBaseMap, params.baseRK, method, params.stdDev,
+                                                            params.keyDist, false, params.numAutoKeys);
+    m_params        = std::make_shared<BinFHECryptoParams>(lweparams, rgswparams);
 
     m_binfhescheme = std::make_shared<BinFHEScheme>(method);
 }
@@ -189,20 +200,16 @@ void BinFHEContext::GenerateBinFHEContext(const BinFHEContextParams& params, BIN
                                                        params.baseKS, params.keyDist);
     std::shared_ptr<RingGSWCryptoParams> rgswparams;
     if (params.gadgetBaseMap.empty()) {
-        rgswparams = std::make_shared<RingGSWCryptoParams>(ringDim, Q, params.mod, params.gadgetBase,
-                                                           params.baseRK, method, params.stdDev, params.keyDist,
-                                                           false, params.numAutoKeys);
+        rgswparams =
+            std::make_shared<RingGSWCryptoParams>(ringDim, Q, params.mod, params.gadgetBase, params.baseRK, method,
+                                                  params.stdDev, params.keyDist, false, params.numAutoKeys);
     }
     else {
-        uint32_t count{0};
-        for (const auto& item : params.gadgetBaseMap)
-            count += item.second;
-        if (count != params.latticeParam)
-            OPENFHE_THROW("Gadget base map should cover the LWE dimension.");
+        VerifyGadgetBaseMapCoverage(params.gadgetBaseMap, params.latticeParam);
 
-        rgswparams = std::make_shared<RingGSWCryptoParams>(
-            ringDim, Q, params.mod, params.gadgetBase, params.gadgetBaseMap, params.baseRK, method, params.stdDev,
-            params.keyDist, false, params.numAutoKeys);
+        rgswparams = std::make_shared<RingGSWCryptoParams>(ringDim, Q, params.mod, params.gadgetBase,
+                                                           params.gadgetBaseMap, params.baseRK, method, params.stdDev,
+                                                           params.keyDist, false, params.numAutoKeys);
     }
     m_params       = std::make_shared<BinFHECryptoParams>(lweparams, rgswparams);
     m_binfhescheme = std::make_shared<BinFHEScheme>(method);

--- a/src/binfhe/lib/lwe-pke.cpp
+++ b/src/binfhe/lib/lwe-pke.cpp
@@ -253,7 +253,7 @@ LWESwitchingKey LWEEncryptionScheme::KeySwitchGen(const std::shared_ptr<LWECrypt
     NativeInteger qKS(params->GetqKS());
     NativeInteger baseKS(params->GetBaseKS());
     NativeInteger value{1};
-    const uint32_t digitCount = std::ceil(std::log(qKS.ConvertToDouble()) / std::log(baseKS.ConvertToDouble()));
+    const uint32_t digitCount = params->GetDigitCountKS();
     std::vector<NativeInteger> digitsKS(digitCount);
     for (uint32_t i = 0; i < digitCount; ++i) {
         digitsKS[i] = value;
@@ -335,7 +335,7 @@ LWECiphertext LWEEncryptionScheme::KeySwitch(const std::shared_ptr<LWECryptoPara
 
     NativeInteger Q(params->GetqKS());
     NativeInteger::Integer baseKS(params->GetBaseKS());
-    const uint32_t digitCount = std::ceil(std::log(Q.ConvertToDouble()) / std::log(static_cast<double>(baseKS)));
+    const uint32_t digitCount = params->GetDigitCountKS();
 
     NativeVector a(n, Q);
     NativeInteger b(ctQN->GetB());

--- a/src/binfhe/lib/rgsw-acc-cggi.cpp
+++ b/src/binfhe/lib/rgsw-acc-cggi.cpp
@@ -51,8 +51,8 @@ RingGSWACCKey RingGSWAccumulatorCGGI::KeyGenAcc(const std::shared_ptr<RingGSWCry
 #pragma omp parallel for num_threads(OpenFHEParallelControls.GetThreadLimit(n))
     for (uint32_t i = 0; i < n; ++i) {
         auto s  = sv[i].ConvertToInt();
-        ek00[i] = KeyGenCGGI(params, skNTT, s == 1 ? 1 : 0);
-        ek01[i] = KeyGenCGGI(params, skNTT, s == neg ? 1 : 0);
+        ek00[i] = KeyGenCGGI(params, skNTT, s == 1 ? 1 : 0, i);
+        ek01[i] = KeyGenCGGI(params, skNTT, s == neg ? 1 : 0, i);
     }
     return ek;
 }
@@ -64,21 +64,21 @@ void RingGSWAccumulatorCGGI::EvalAcc(const std::shared_ptr<RingGSWCryptoParams>&
     auto MbyMod{NativeInteger(2 * params->GetN()) / mod};
     for (uint32_t i = 0; i < n; ++i) {
         // handles -a*E(1) and handles -a*E(-1) = a*E(1)
-        AddToAccCGGI(params, (*ek)[0][0][i], (*ek)[0][1][i], NativeInteger(0).ModSubFast(a[i], mod) * MbyMod, acc);
+        AddToAccCGGI(params, (*ek)[0][0][i], (*ek)[0][1][i], NativeInteger(0).ModSubFast(a[i], mod) * MbyMod, acc, i);
     }
 }
 
 // Encryption for the CGGI variant, as described in https://eprint.iacr.org/2020/086
 RingGSWEvalKey RingGSWAccumulatorCGGI::KeyGenCGGI(const std::shared_ptr<RingGSWCryptoParams>& params,
-                                                  const NativePoly& skNTT, LWEPlaintext m) const {
-    const auto& Gpow       = params->GetGPower();
+                                                  const NativePoly& skNTT, LWEPlaintext m, uint32_t index) const {
     const auto& polyParams = params->GetPolyParams();
 
     DiscreteUniformGeneratorImpl<NativeVector> dug;
     NativeInteger Q{params->GetQ()};
 
     // approximate gadget decomposition is used; the first digit is ignored
-    uint32_t digitsG2{(params->GetDigitsG() - 1) << 1};
+    uint32_t digitsG2{(params->GetDigitsG(index) - 1) << 1};
+    const auto& Gpow{params->GetGPower(params->GetBaseG(index))};
 
     RingGSWEvalKeyImpl result(digitsG2, 2);
     NativePoly tmp;
@@ -101,16 +101,16 @@ RingGSWEvalKey RingGSWAccumulatorCGGI::KeyGenCGGI(const std::shared_ptr<RingGSWC
 // We optimize the algorithm by multiplying the monomial after the external product
 // This reduces the number of polynomial multiplications which further reduces the runtime
 void RingGSWAccumulatorCGGI::AddToAccCGGI(const std::shared_ptr<RingGSWCryptoParams>& params, ConstRingGSWEvalKey& ek1,
-                                          ConstRingGSWEvalKey& ek2, NativeInteger a, RLWECiphertext& acc) const {
+                                          ConstRingGSWEvalKey& ek2, NativeInteger a, RLWECiphertext& acc, uint32_t index) const {
     std::vector<NativePoly> ct(acc->GetElements());
     ct[0].SetFormat(Format::COEFFICIENT);
     ct[1].SetFormat(Format::COEFFICIENT);
 
     // approximate gadget decomposition is used; the first digit is ignored
-    uint32_t digitsG2{(params->GetDigitsG() - 1) << 1};
+    uint32_t digitsG2{(params->GetDigitsG(index) - 1) << 1};
     std::vector<NativePoly> dct(digitsG2, NativePoly(params->GetPolyParams(), Format::COEFFICIENT, true));
 
-    SignedDigitDecompose(params, ct, dct);
+    SignedDigitDecompose(params, ct, dct, index);
 
 #pragma omp parallel for num_threads(OpenFHEParallelControls.GetThreadLimit(digitsG2))
     for (uint32_t i = 0; i < digitsG2; ++i)

--- a/src/binfhe/lib/rgsw-acc-cggi.cpp
+++ b/src/binfhe/lib/rgsw-acc-cggi.cpp
@@ -77,8 +77,9 @@ RingGSWEvalKey RingGSWAccumulatorCGGI::KeyGenCGGI(const std::shared_ptr<RingGSWC
     NativeInteger Q{params->GetQ()};
 
     // approximate gadget decomposition is used; the first digit is ignored
-    uint32_t digitsG2{(params->GetDigitsG(index) - 1) << 1};
-    const auto& Gpow{params->GetGPower(params->GetBaseG(index))};
+    const auto& bp = params->GetBaseGParams(index);
+    uint32_t digitsG2{(bp.digitsG - 1) << 1};
+    const auto& Gpow{*bp.gpow};
 
     RingGSWEvalKeyImpl result(digitsG2, 2);
     NativePoly tmp;
@@ -101,7 +102,8 @@ RingGSWEvalKey RingGSWAccumulatorCGGI::KeyGenCGGI(const std::shared_ptr<RingGSWC
 // We optimize the algorithm by multiplying the monomial after the external product
 // This reduces the number of polynomial multiplications which further reduces the runtime
 void RingGSWAccumulatorCGGI::AddToAccCGGI(const std::shared_ptr<RingGSWCryptoParams>& params, ConstRingGSWEvalKey& ek1,
-                                          ConstRingGSWEvalKey& ek2, NativeInteger a, RLWECiphertext& acc, uint32_t index) const {
+                                          ConstRingGSWEvalKey& ek2, NativeInteger a, RLWECiphertext& acc,
+                                          uint32_t index) const {
     std::vector<NativePoly> ct(acc->GetElements());
     ct[0].SetFormat(Format::COEFFICIENT);
     ct[1].SetFormat(Format::COEFFICIENT);

--- a/src/binfhe/lib/rgsw-acc-cggi.cpp
+++ b/src/binfhe/lib/rgsw-acc-cggi.cpp
@@ -42,6 +42,7 @@ RingGSWACCKey RingGSWAccumulatorCGGI::KeyGenAcc(const std::shared_ptr<RingGSWCry
     auto sv    = LWEsk->GetElement();
     auto neg   = sv.GetModulus().ConvertToInt() - 1;
     uint32_t n = sv.GetLength();
+    params->VerifyBaseGCoverage(n);
     auto ek    = std::make_shared<RingGSWACCKeyImpl>(1, 2, n);
     auto& ek00 = (*ek)[0][0];
     auto& ek01 = (*ek)[0][1];
@@ -109,10 +110,11 @@ void RingGSWAccumulatorCGGI::AddToAccCGGI(const std::shared_ptr<RingGSWCryptoPar
     ct[1].SetFormat(Format::COEFFICIENT);
 
     // approximate gadget decomposition is used; the first digit is ignored
-    uint32_t digitsG2{(params->GetDigitsG(index) - 1) << 1};
+    const auto& bp = params->GetBaseGParams(index);
+    uint32_t digitsG2{(bp.digitsG - 1) << 1};
     std::vector<NativePoly> dct(digitsG2, NativePoly(params->GetPolyParams(), Format::COEFFICIENT, true));
 
-    SignedDigitDecompose(params, ct, dct, index);
+    SignedDigitDecomposeImpl(params, ct, dct, bp);
 
 #pragma omp parallel for num_threads(OpenFHEParallelControls.GetThreadLimit(digitsG2))
     for (uint32_t i = 0; i < digitsG2; ++i)

--- a/src/binfhe/lib/rgsw-acc-dm.cpp
+++ b/src/binfhe/lib/rgsw-acc-dm.cpp
@@ -42,6 +42,7 @@ RingGSWACCKey RingGSWAccumulatorDM::KeyGenAcc(const std::shared_ptr<RingGSWCrypt
     auto mod{sv.GetModulus().ConvertToInt<int32_t>()};
     auto modHalf{mod >> 1};
     uint32_t n(sv.GetLength());
+    params->VerifyBaseGCoverage(n);
     int32_t baseR(params->GetBaseR());
     const auto& digitsR = params->GetDigitsR();
     RingGSWACCKey ek    = std::make_shared<RingGSWACCKeyImpl>(n, baseR, digitsR.size());
@@ -124,10 +125,11 @@ void RingGSWAccumulatorDM::AddToAccDM(const std::shared_ptr<RingGSWCryptoParams>
     ct[1].SetFormat(Format::COEFFICIENT);
 
     // approximate gadget decomposition is used; the first digit is ignored
-    uint32_t digitsG2{(params->GetDigitsG(index) - 1) << 1};
+    const auto& bp = params->GetBaseGParams(index);
+    uint32_t digitsG2{(bp.digitsG - 1) << 1};
     std::vector<NativePoly> dct(digitsG2, NativePoly(params->GetPolyParams(), Format::COEFFICIENT, true));
 
-    SignedDigitDecompose(params, ct, dct, index);
+    SignedDigitDecomposeImpl(params, ct, dct, bp);
 
 #pragma omp parallel for num_threads(OpenFHEParallelControls.GetThreadLimit(digitsG2))
     for (uint32_t j = 0; j < digitsG2; ++j)

--- a/src/binfhe/lib/rgsw-acc-dm.cpp
+++ b/src/binfhe/lib/rgsw-acc-dm.cpp
@@ -94,8 +94,9 @@ RingGSWEvalKey RingGSWAccumulatorDM::KeyGenDM(const std::shared_ptr<RingGSWCrypt
         mm -= N;
 
     // approximate gadget decomposition is used; the first digit is ignored
-    uint32_t digitsG2{(params->GetDigitsG(index) - 1) << 1};
-    const auto& Gpow{params->GetGPower(params->GetBaseG(index))};
+    const auto& bp = params->GetBaseGParams(index);
+    uint32_t digitsG2{(bp.digitsG - 1) << 1};
+    const auto& Gpow{*bp.gpow};
 
     RingGSWEvalKeyImpl result(digitsG2, 2);
     NativePoly tmp;

--- a/src/binfhe/lib/rgsw-acc-dm.cpp
+++ b/src/binfhe/lib/rgsw-acc-dm.cpp
@@ -52,7 +52,7 @@ RingGSWACCKey RingGSWAccumulatorDM::KeyGenAcc(const std::shared_ptr<RingGSWCrypt
             for (size_t k = 0; k < digitsR.size(); ++k) {
                 auto s{sv[i].ConvertToInt<int32_t>()};
                 (*ek)[i][j][k] =
-                    KeyGenDM(params, skNTT, (s > modHalf ? s - mod : s) * j * digitsR[k].ConvertToInt<int32_t>());
+                    KeyGenDM(params, skNTT, (s > modHalf ? s - mod : s) * j * digitsR[k].ConvertToInt<int32_t>(), i);
             }
         }
     }
@@ -71,7 +71,7 @@ void RingGSWAccumulatorDM::EvalAcc(const std::shared_ptr<RingGSWCryptoParams>& p
         for (size_t k = 0; k < digitsR; ++k, aI /= baseR) {
             auto a0 = (aI.Mod(baseR)).ConvertToInt<uint32_t>();
             if (a0)
-                AddToAccDM(params, (*ek)[i][a0][k], acc);
+                AddToAccDM(params, (*ek)[i][a0][k], acc, i);
         }
     }
 }
@@ -79,8 +79,7 @@ void RingGSWAccumulatorDM::EvalAcc(const std::shared_ptr<RingGSWCryptoParams>& p
 // Encryption as described in Section 5 of https://eprint.iacr.org/2014/816
 // skNTT corresponds to the secret key z
 RingGSWEvalKey RingGSWAccumulatorDM::KeyGenDM(const std::shared_ptr<RingGSWCryptoParams>& params,
-                                              const NativePoly& skNTT, LWEPlaintext m) const {
-    const auto& Gpow       = params->GetGPower();
+                                              const NativePoly& skNTT, LWEPlaintext m, uint32_t index) const {
     const auto& polyParams = params->GetPolyParams();
 
     DiscreteUniformGeneratorImpl<NativeVector> dug;
@@ -95,7 +94,9 @@ RingGSWEvalKey RingGSWAccumulatorDM::KeyGenDM(const std::shared_ptr<RingGSWCrypt
         mm -= N;
 
     // approximate gadget decomposition is used; the first digit is ignored
-    uint32_t digitsG2{(params->GetDigitsG() - 1) << 1};
+    uint32_t digitsG2{(params->GetDigitsG(index) - 1) << 1};
+    const auto& Gpow{params->GetGPower(params->GetBaseG(index))};
+
     RingGSWEvalKeyImpl result(digitsG2, 2);
     NativePoly tmp;
     for (uint32_t i = 0; i < digitsG2; ++i) {
@@ -116,16 +117,16 @@ RingGSWEvalKey RingGSWAccumulatorDM::KeyGenDM(const std::shared_ptr<RingGSWCrypt
 
 // AP Accumulation as described in https://eprint.iacr.org/2020/086
 void RingGSWAccumulatorDM::AddToAccDM(const std::shared_ptr<RingGSWCryptoParams>& params, ConstRingGSWEvalKey& ek,
-                                      RLWECiphertext& acc) const {
+                                      RLWECiphertext& acc, uint32_t index) const {
     std::vector<NativePoly> ct(acc->GetElements());
     ct[0].SetFormat(Format::COEFFICIENT);
     ct[1].SetFormat(Format::COEFFICIENT);
 
     // approximate gadget decomposition is used; the first digit is ignored
-    uint32_t digitsG2{(params->GetDigitsG() - 1) << 1};
+    uint32_t digitsG2{(params->GetDigitsG(index) - 1) << 1};
     std::vector<NativePoly> dct(digitsG2, NativePoly(params->GetPolyParams(), Format::COEFFICIENT, true));
 
-    SignedDigitDecompose(params, ct, dct);
+    SignedDigitDecompose(params, ct, dct, index);
 
 #pragma omp parallel for num_threads(OpenFHEParallelControls.GetThreadLimit(digitsG2))
     for (uint32_t j = 0; j < digitsG2; ++j)

--- a/src/binfhe/lib/rgsw-acc-lmkcdey.cpp
+++ b/src/binfhe/lib/rgsw-acc-lmkcdey.cpp
@@ -51,7 +51,7 @@ RingGSWACCKey RingGSWAccumulatorLMKCDEY::KeyGenAcc(const std::shared_ptr<RingGSW
 #pragma omp parallel for num_threads(OpenFHEParallelControls.GetThreadLimit(n))
     for (size_t i = 0; i < n; ++i) {
         auto s{sv[i].ConvertToInt<int32_t>()};
-        (*ek)[0][0][i] = KeyGenLMKCDEY(params, skNTT, s > modHalf ? s - mod : s);
+        (*ek)[0][0][i] = KeyGenLMKCDEY(params, skNTT, s > modHalf ? s - mod : s, i);
     }
 
     NativeInteger gen = NativeInteger(5);
@@ -101,7 +101,7 @@ void RingGSWAccumulatorLMKCDEY::EvalAcc(const std::shared_ptr<RingGSWCryptoParam
             }
             auto& indexVec = it->second;
             for (size_t j = 0; j < indexVec.size(); j++) {
-                AddToAccLMKCDEY(params, (*ek)[0][0][indexVec[j]], acc);
+                AddToAccLMKCDEY(params, (*ek)[0][0][indexVec[j]], acc, indexVec[j]);
             }
         }
         nSkips++;
@@ -117,7 +117,7 @@ void RingGSWAccumulatorLMKCDEY::EvalAcc(const std::shared_ptr<RingGSWCryptoParam
     if (itM != permuteMap.end()) {
         auto& indexVec = itM->second;
         for (size_t j = 0; j < indexVec.size(); j++) {
-            AddToAccLMKCDEY(params, (*ek)[0][0][indexVec[j]], acc);
+            AddToAccLMKCDEY(params, (*ek)[0][0][indexVec[j]], acc, indexVec[j]);
         }
     }
 
@@ -133,7 +133,7 @@ void RingGSWAccumulatorLMKCDEY::EvalAcc(const std::shared_ptr<RingGSWCryptoParam
 
             auto& indexVec = it->second;
             for (size_t j = 0; j < indexVec.size(); j++) {
-                AddToAccLMKCDEY(params, (*ek)[0][0][indexVec[j]], acc);
+                AddToAccLMKCDEY(params, (*ek)[0][0][indexVec[j]], acc, indexVec[j]);
             }
         }
         nSkips++;
@@ -149,7 +149,7 @@ void RingGSWAccumulatorLMKCDEY::EvalAcc(const std::shared_ptr<RingGSWCryptoParam
     if (it0 != permuteMap.end()) {
         auto& indexVec = it0->second;
         for (size_t j = 0; j < indexVec.size(); j++) {
-            AddToAccLMKCDEY(params, (*ek)[0][0][indexVec[j]], acc);
+            AddToAccLMKCDEY(params, (*ek)[0][0][indexVec[j]], acc, indexVec[j]);
         }
     }
 }
@@ -158,9 +158,8 @@ void RingGSWAccumulatorLMKCDEY::EvalAcc(const std::shared_ptr<RingGSWCryptoParam
 // Same as KeyGenAP, but only for X^{s_i}
 // skNTT corresponds to the secret key z
 RingGSWEvalKey RingGSWAccumulatorLMKCDEY::KeyGenLMKCDEY(const std::shared_ptr<RingGSWCryptoParams>& params,
-                                                        const NativePoly& skNTT, LWEPlaintext m) const {
+                                                        const NativePoly& skNTT, LWEPlaintext m, uint32_t index) const {
     auto polyParams = params->GetPolyParams();
-    auto Gpow       = params->GetGPower();
 
     DiscreteUniformGeneratorImpl<NativeVector> dug;
     NativeInteger Q{params->GetQ()};
@@ -176,7 +175,9 @@ RingGSWEvalKey RingGSWAccumulatorLMKCDEY::KeyGenLMKCDEY(const std::shared_ptr<Ri
     }
 
     // approximate gadget decomposition is used; the first digit is ignored
-    uint32_t digitsG2{(params->GetDigitsG() - 1) << 1};
+    uint32_t digitsG2{(params->GetDigitsG(index) - 1) << 1};
+    const auto& Gpow{params->GetGPower(params->GetBaseG(index))};
+
     RingGSWEvalKeyImpl result(digitsG2, 2);
     NativePoly tmp;
     for (uint32_t i = 0; i < digitsG2; ++i) {
@@ -199,7 +200,7 @@ RingGSWEvalKey RingGSWAccumulatorLMKCDEY::KeyGenLMKCDEY(const std::shared_ptr<Ri
 RingGSWEvalKey RingGSWAccumulatorLMKCDEY::KeyGenAuto(const std::shared_ptr<RingGSWCryptoParams>& params,
                                                      const NativePoly& skNTT, LWEPlaintext k) const {
     auto polyParams{params->GetPolyParams()};
-    auto Gpow{params->GetGPower()};
+    const auto& Gpow{params->GetGPower()};
     auto skAuto{skNTT.AutomorphismTransform(k)};
 
     // approximate gadget decomposition is used; the first digit is ignored
@@ -217,17 +218,17 @@ RingGSWEvalKey RingGSWAccumulatorLMKCDEY::KeyGenAuto(const std::shared_ptr<RingG
 // LMKCDEY Accumulation as described in https://eprint.iacr.org/2022/198
 // Same as AP, but multiplied once
 void RingGSWAccumulatorLMKCDEY::AddToAccLMKCDEY(const std::shared_ptr<RingGSWCryptoParams>& params,
-                                                ConstRingGSWEvalKey& ek, RLWECiphertext& acc) const {
+                                                ConstRingGSWEvalKey& ek, RLWECiphertext& acc, uint32_t index) const {
     std::vector<NativePoly> ct(acc->GetElements());
     ct[0].SetFormat(Format::COEFFICIENT);
     ct[1].SetFormat(Format::COEFFICIENT);
 
     // approximate gadget decomposition is used; the first digit is ignored
-    uint32_t digitsG2{(params->GetDigitsG() - 1) << 1};
+    uint32_t digitsG2{(params->GetDigitsG(index) - 1) << 1};
 
     std::vector<NativePoly> dct(digitsG2, NativePoly(params->GetPolyParams(), Format::COEFFICIENT, true));
 
-    SignedDigitDecompose(params, ct, dct);
+    SignedDigitDecompose(params, ct, dct, index);
 
     // calls digitsG2 NTTs
 #pragma omp parallel for num_threads(OpenFHEParallelControls.GetThreadLimit(digitsG2))

--- a/src/binfhe/lib/rgsw-acc-lmkcdey.cpp
+++ b/src/binfhe/lib/rgsw-acc-lmkcdey.cpp
@@ -41,6 +41,7 @@ RingGSWACCKey RingGSWAccumulatorLMKCDEY::KeyGenAcc(const std::shared_ptr<RingGSW
     auto modHalf{mod >> 1};
     uint32_t N{params->GetN()};
     size_t n{sv.GetLength()};
+    params->VerifyBaseGCoverage(static_cast<uint32_t>(n));
     uint32_t numAutoKeys{params->GetNumAutoKeys()};
 
     // dim2, 0: for RGSW(X^si), 1: for automorphism keys
@@ -225,11 +226,12 @@ void RingGSWAccumulatorLMKCDEY::AddToAccLMKCDEY(const std::shared_ptr<RingGSWCry
     ct[1].SetFormat(Format::COEFFICIENT);
 
     // approximate gadget decomposition is used; the first digit is ignored
-    uint32_t digitsG2{(params->GetDigitsG(index) - 1) << 1};
+    const auto& bp = params->GetBaseGParams(index);
+    uint32_t digitsG2{(bp.digitsG - 1) << 1};
 
     std::vector<NativePoly> dct(digitsG2, NativePoly(params->GetPolyParams(), Format::COEFFICIENT, true));
 
-    SignedDigitDecompose(params, ct, dct, index);
+    SignedDigitDecomposeImpl(params, ct, dct, bp);
 
     // calls digitsG2 NTTs
 #pragma omp parallel for num_threads(OpenFHEParallelControls.GetThreadLimit(digitsG2))

--- a/src/binfhe/lib/rgsw-acc-lmkcdey.cpp
+++ b/src/binfhe/lib/rgsw-acc-lmkcdey.cpp
@@ -175,8 +175,9 @@ RingGSWEvalKey RingGSWAccumulatorLMKCDEY::KeyGenLMKCDEY(const std::shared_ptr<Ri
     }
 
     // approximate gadget decomposition is used; the first digit is ignored
-    uint32_t digitsG2{(params->GetDigitsG(index) - 1) << 1};
-    const auto& Gpow{params->GetGPower(params->GetBaseG(index))};
+    const auto& bp = params->GetBaseGParams(index);
+    uint32_t digitsG2{(bp.digitsG - 1) << 1};
+    const auto& Gpow{*bp.gpow};
 
     RingGSWEvalKeyImpl result(digitsG2, 2);
     NativePoly tmp;

--- a/src/binfhe/lib/rgsw-acc.cpp
+++ b/src/binfhe/lib/rgsw-acc.cpp
@@ -54,14 +54,16 @@ namespace lbcrypto {
 
 void RingGSWAccumulator::SignedDigitDecompose(const std::shared_ptr<RingGSWCryptoParams>& params,
                                               const std::vector<NativePoly>& input,
-                                              std::vector<NativePoly>& output) const {
+                                              std::vector<NativePoly>& output,
+                                              std::optional<uint32_t> index) const {
     auto Q{params->GetQ().ConvertToInt<BasicInteger>()};
     auto QHalf{Q >> 1};
-    auto gBits{static_cast<uint32_t>(__builtin_ctz(params->GetBaseG()))};
-    auto gHalf{static_cast<BasicInteger>(params->GetBaseG() >> 1)};
-    auto gMask{static_cast<BasicInteger>(params->GetBaseG() - 1)};
+    auto baseG{params->GetBaseG(index)};
+    auto gBits{static_cast<uint32_t>(__builtin_ctz(baseG))};
+    auto gHalf{static_cast<BasicInteger>(baseG >> 1)};
+    auto gMask{static_cast<BasicInteger>(baseG - 1)};
     auto QmHalf{Q - gHalf};
-    uint32_t digitsG{params->GetDigitsG()};
+    uint32_t digitsG{params->GetDigitsG(index)};
     // Biasing by H (gHalf in every digit position) turns balanced-digit extraction into
     // independent unsigned windows: digit_k(x) = (((x + H) >> k*gBits) & gMask) - gHalf.
     // Requires digitsG*gBits < MaxBits, which holds for all supported parameter sets.
@@ -98,9 +100,10 @@ void RingGSWAccumulator::SignedDigitDecompose(const std::shared_ptr<RingGSWCrypt
                                               const NativePoly& input, std::vector<NativePoly>& output) const {
     auto Q{params->GetQ().ConvertToInt<BasicInteger>()};
     auto QHalf{Q >> 1};
-    auto gBits{static_cast<uint32_t>(__builtin_ctz(params->GetBaseG()))};
-    auto gHalf{static_cast<BasicInteger>(params->GetBaseG() >> 1)};
-    auto gMask{static_cast<BasicInteger>(params->GetBaseG() - 1)};
+    auto baseG{params->GetBaseG()};
+    auto gBits{static_cast<uint32_t>(__builtin_ctz(baseG))};
+    auto gHalf{static_cast<BasicInteger>(baseG >> 1)};
+    auto gMask{static_cast<BasicInteger>(baseG - 1)};
     auto QmHalf{Q - gHalf};
     uint32_t digitsG{params->GetDigitsG()};
     // see the ciphertext overload above for the excess-H digit-extraction identity

--- a/src/binfhe/lib/rgsw-acc.cpp
+++ b/src/binfhe/lib/rgsw-acc.cpp
@@ -54,16 +54,26 @@ namespace lbcrypto {
 
 void RingGSWAccumulator::SignedDigitDecompose(const std::shared_ptr<RingGSWCryptoParams>& params,
                                               const std::vector<NativePoly>& input,
-                                              std::vector<NativePoly>& output,
-                                              std::optional<uint32_t> index) const {
+                                              std::vector<NativePoly>& output) const {
+    SignedDigitDecomposeImpl(params, input, output, params->GetDefaultBaseGParams());
+}
+
+void RingGSWAccumulator::SignedDigitDecompose(const std::shared_ptr<RingGSWCryptoParams>& params,
+                                              const std::vector<NativePoly>& input, std::vector<NativePoly>& output,
+                                              uint32_t index) const {
+    SignedDigitDecomposeImpl(params, input, output, params->GetBaseGParams(index));
+}
+
+void RingGSWAccumulator::SignedDigitDecomposeImpl(const std::shared_ptr<RingGSWCryptoParams>& params,
+                                                  const std::vector<NativePoly>& input, std::vector<NativePoly>& output,
+                                                  const RingGSWCryptoParams::BaseGParams& bp) const {
     auto Q{params->GetQ().ConvertToInt<BasicInteger>()};
     auto QHalf{Q >> 1};
-    auto baseG{params->GetBaseG(index)};
-    auto gBits{static_cast<uint32_t>(__builtin_ctz(baseG))};
-    auto gHalf{static_cast<BasicInteger>(baseG >> 1)};
-    auto gMask{static_cast<BasicInteger>(baseG - 1)};
+    auto gBits{bp.gBits};
+    auto gHalf{static_cast<BasicInteger>(bp.baseG >> 1)};
+    auto gMask{static_cast<BasicInteger>(bp.baseG - 1)};
     auto QmHalf{Q - gHalf};
-    uint32_t digitsG{params->GetDigitsG(index)};
+    uint32_t digitsG{bp.digitsG};
     // Biasing by H (gHalf in every digit position) turns balanced-digit extraction into
     // independent unsigned windows: digit_k(x) = (((x + H) >> k*gBits) & gMask) - gHalf.
     // Requires digitsG*gBits < MaxBits, which holds for all supported parameter sets.
@@ -101,7 +111,7 @@ void RingGSWAccumulator::SignedDigitDecompose(const std::shared_ptr<RingGSWCrypt
     auto Q{params->GetQ().ConvertToInt<BasicInteger>()};
     auto QHalf{Q >> 1};
     auto baseG{params->GetBaseG()};
-    auto gBits{static_cast<uint32_t>(__builtin_ctz(baseG))};
+    auto gBits{GetMSB(baseG) - 1};
     auto gHalf{static_cast<BasicInteger>(baseG >> 1)};
     auto gMask{static_cast<BasicInteger>(baseG - 1)};
     auto QmHalf{Q - gHalf};

--- a/src/binfhe/lib/rgsw-acc.cpp
+++ b/src/binfhe/lib/rgsw-acc.cpp
@@ -94,13 +94,15 @@ void RingGSWAccumulator::SignedDigitDecomposeImpl(const std::shared_ptr<RingGSWC
 
     for (uint32_t d{0}; d < digitsG2; d += 2) {
         uint32_t shift{((d >> 1) + 1) * gBits};
+        // Q/2 + H can exceed baseG^digitsG, so the top window must keep the carry out of digitsG*gBits.
+        auto mask{(d + 2 < digitsG2) ? gMask : static_cast<BasicInteger>(-1)};
         auto& out0{output[d + 0]};
         auto& out1{output[d + 1]};
         for (uint32_t k{0}; k < N; ++k) {
-            auto r0{(w0[k] >> shift) & gMask};
-            out0[k] += (r0 < gHalf) ? r0 + QmHalf : r0 - gHalf;
-            auto r1{(w1[k] >> shift) & gMask};
-            out1[k] += (r1 < gHalf) ? r1 + QmHalf : r1 - gHalf;
+            auto r0{(w0[k] >> shift) & mask};
+            out0[k] = (r0 < gHalf) ? r0 + QmHalf : r0 - gHalf;
+            auto r1{(w1[k] >> shift) & mask};
+            out1[k] = (r1 < gHalf) ? r1 + QmHalf : r1 - gHalf;
         }
     }
 }
@@ -131,10 +133,12 @@ void RingGSWAccumulator::SignedDigitDecompose(const std::shared_ptr<RingGSWCrypt
     // approximate gadget decomposition is used; the first digit is ignored
     for (uint32_t d{0}; d < digitsG - 1; ++d) {
         uint32_t shift{(d + 1) * gBits};
+        // Q/2 + H can exceed baseG^digitsG, so the top window must keep the carry out of digitsG*gBits.
+        auto mask{(d + 2 < digitsG) ? gMask : static_cast<BasicInteger>(-1)};
         auto& out{output[d]};
         for (uint32_t k{0}; k < N; ++k) {
-            auto r0{(w[k] >> shift) & gMask};
-            out[k] += (r0 < gHalf) ? r0 + QmHalf : r0 - gHalf;
+            auto r0{(w[k] >> shift) & mask};
+            out[k] = (r0 < gHalf) ? r0 + QmHalf : r0 - gHalf;
         }
     }
 }

--- a/src/binfhe/lib/rgsw-cryptoparameters.cpp
+++ b/src/binfhe/lib/rgsw-cryptoparameters.cpp
@@ -33,6 +33,21 @@
 
 namespace lbcrypto {
 
+const std::vector<NativeInteger>& RingGSWCryptoParams::PrecomputeGPower(uint32_t baseG) {
+    auto it = m_Gpower_map.find(baseG);
+    if (it != m_Gpower_map.end())
+        return it->second;
+
+    auto digitsG{DigitsForBase(m_Q, baseG)};
+    NativeInteger vTemp{1};
+    std::vector<NativeInteger> tempvec(digitsG);
+    for (uint32_t i = 0; i < digitsG; ++i) {
+        tempvec[i] = vTemp;
+        vTemp      = vTemp.ModMulFast(NativeInteger(baseG), m_Q);
+    }
+    return m_Gpower_map.emplace(baseG, std::move(tempvec)).first->second;
+}
+
 void RingGSWCryptoParams::PreCompute(bool signEval) {
     // Computes baseR^i (only for AP bootstrapping)
     if (m_method == BINFHE_METHOD::AP) {
@@ -62,23 +77,9 @@ void RingGSWCryptoParams::PreCompute(bool signEval) {
         }
     }
     else {
-        auto precomputeGPower = [&](uint32_t baseG) {
-            if (m_Gpower_map.find(baseG) != m_Gpower_map.end())
-                return;
-
-            auto digitsG{DigitsForBase(m_Q, baseG)};
-            NativeInteger vTemp{1};
-            std::vector<NativeInteger> tempvec(digitsG);
-            for (uint32_t i = 0; i < digitsG; ++i) {
-                tempvec[i] = vTemp;
-                vTemp      = vTemp.ModMulFast(NativeInteger(baseG), m_Q);
-            }
-            m_Gpower_map[baseG] = std::move(tempvec);
-        };
-
-        precomputeGPower(m_baseG);
+        PrecomputeGPower(m_baseG);
         for (const auto& item : m_baseG_map)
-            precomputeGPower(item.first);
+            PrecomputeGPower(item.first);
         m_Gpower = m_Gpower_map.at(m_baseG);
     }
 

--- a/src/binfhe/lib/rgsw-cryptoparameters.cpp
+++ b/src/binfhe/lib/rgsw-cryptoparameters.cpp
@@ -64,14 +64,26 @@ void RingGSWCryptoParams::PreCompute(bool signEval) {
                 m_Gpower = tempvec;
             m_Gpower_map[baseGlist[j]] = std::move(tempvec);
         }
-    }
-    else {
-        m_Gpower.reserve(m_digitsG);
-        NativeInteger vTemp{1};
-        for (uint32_t i = 0; i < m_digitsG; ++i) {
-            m_Gpower.push_back(vTemp);
-            vTemp = vTemp.ModMulFast(NativeInteger(m_baseG), m_Q);
-        }
+    } else {
+        auto precomputeGPower = [&](uint32_t baseG) {
+            if (m_Gpower_map.find(baseG) != m_Gpower_map.end())
+                return;
+
+            auto digitsG{static_cast<uint32_t>(
+                std::ceil(std::log(m_Q.ConvertToDouble()) / std::log(static_cast<double>(baseG))))};
+            NativeInteger vTemp{1};
+            std::vector<NativeInteger> tempvec(digitsG);
+            for (uint32_t i = 0; i < digitsG; ++i) {
+                tempvec[i] = vTemp;
+                vTemp      = vTemp.ModMulFast(NativeInteger(baseG), m_Q);
+            }
+            m_Gpower_map[baseG] = std::move(tempvec);
+        };
+
+        precomputeGPower(m_baseG);
+        for (const auto& item : m_baseG_map)
+            precomputeGPower(item.first);
+        m_Gpower = m_Gpower_map.at(m_baseG);
     }
 
     // Sets the gate constants for supported binary operations

--- a/src/binfhe/lib/rgsw-cryptoparameters.cpp
+++ b/src/binfhe/lib/rgsw-cryptoparameters.cpp
@@ -36,8 +36,7 @@ namespace lbcrypto {
 void RingGSWCryptoParams::PreCompute(bool signEval) {
     // Computes baseR^i (only for AP bootstrapping)
     if (m_method == BINFHE_METHOD::AP) {
-        auto&& logq = std::log(m_q.ConvertToDouble());
-        auto digitCountR{static_cast<size_t>(std::ceil(logq / std::log(static_cast<double>(m_baseR))))};
+        auto digitCountR{GetDigitCount(m_q.ConvertToInt(), m_baseR)};
         m_digitsR.clear();
         m_digitsR.reserve(digitCountR);
         BasicInteger value{1};

--- a/src/binfhe/lib/rgsw-cryptoparameters.cpp
+++ b/src/binfhe/lib/rgsw-cryptoparameters.cpp
@@ -47,14 +47,11 @@ void RingGSWCryptoParams::PreCompute(bool signEval) {
 
     // Computes baseG^i
     if (signEval) {
-        constexpr uint32_t baseGlist[]  = {1 << 14, 1 << 18, 1 << 27};
-        // {log(1 << 14), log(1 << 18), log(1 << 27)}
-        constexpr double logbaseGlist[] = {0x1.3687a9f1af2b1p+3, 0x1.8f40b5ed9812dp+3, 0x1.2b708872320e2p+4};
+        constexpr uint32_t baseGlist[]            = {1 << 14, 1 << 18, 1 << 27};
         constexpr NativeInteger nativebaseGlist[] = {1 << 14, 1 << 18, 1 << 27};
-        auto logQ{std::log(m_Q.ConvertToDouble())};
         for (size_t j = 0; j < 3; ++j) {
             NativeInteger vTemp{1};
-            auto tempdigits{static_cast<size_t>(std::ceil(logQ / logbaseGlist[j]))};
+            auto tempdigits{DigitsForBase(m_Q, baseGlist[j])};
             std::vector<NativeInteger> tempvec(tempdigits);
             for (size_t i = 0; i < tempdigits; ++i) {
                 tempvec[i] = vTemp;
@@ -64,13 +61,13 @@ void RingGSWCryptoParams::PreCompute(bool signEval) {
                 m_Gpower = tempvec;
             m_Gpower_map[baseGlist[j]] = std::move(tempvec);
         }
-    } else {
+    }
+    else {
         auto precomputeGPower = [&](uint32_t baseG) {
             if (m_Gpower_map.find(baseG) != m_Gpower_map.end())
                 return;
 
-            auto digitsG{static_cast<uint32_t>(
-                std::ceil(std::log(m_Q.ConvertToDouble()) / std::log(static_cast<double>(baseG))))};
+            auto digitsG{DigitsForBase(m_Q, baseG)};
             NativeInteger vTemp{1};
             std::vector<NativeInteger> tempvec(digitsG);
             for (uint32_t i = 0; i < digitsG; ++i) {
@@ -121,6 +118,23 @@ void RingGSWCryptoParams::PreCompute(bool signEval) {
             aPoly[i].ModSubFastEq(one, m_Q);  // -X^m
             aPoly.SetFormat(Format::EVALUATION);
             m_monomials.push_back(std::move(aPoly));
+        }
+    }
+
+    // expand the base map into one entry per LWE index. Digit counts are computed here,
+    // once per distinct base, instead of per call in the accumulator.
+    m_baseGByIndex.clear();
+    if (!m_baseG_map.empty()) {
+        uint32_t total{0};
+        for (const auto& [baseG, count] : m_baseG_map)
+            total += count;
+        m_baseGByIndex.reserve(total);
+        for (const auto& [baseG, count] : m_baseG_map) {
+            auto it = m_Gpower_map.find(baseG);
+            if (it == m_Gpower_map.end())
+                OPENFHE_THROW("No GPower found for the requested gadget base.");
+            m_baseGByIndex.insert(m_baseGByIndex.end(), count,
+                                  BaseGParams{baseG, DigitsForBase(m_Q, baseG), GetMSB(baseG) - 1, &it->second});
         }
     }
 

--- a/src/binfhe/unittest/UnitTestFHEW.cpp
+++ b/src/binfhe/unittest/UnitTestFHEW.cpp
@@ -168,69 +168,104 @@ static std::ostream& operator<<(std::ostream& os, const TEST_CASE_UTGENERAL_FHEW
 //===========================================================================================================
 // clang-format off
 static std::vector<TEST_CASE_UTGENERAL_FHEW> testCasesUTGENERAL_FHEW = {
-    // TestType, Descr,  ParamSet, Method,  num_of_inputs, ptmodulus, Gate, Results
-    { FHEW_AND,  "01",   TOY,      GINX,    2,              4,        AND,   {1, 0, 0, 0} },
-    { FHEW_AND,  "02",   TOY,      AP,      2,              4,        AND,   {1, 0, 0, 0} },
-    { FHEW_AND,  "03",   TOY,      LMKCDEY, 2,              4,        AND,   {1, 0, 0, 0} },
+    // TestType,          Descr, ParamSet,         Method,  num_of_inputs, ptmodulus, Gate,     Results
+    { FHEW_AND,           "01",  TOY,              GINX,    2,             4,         AND,      {1, 0, 0, 0} },
+    { FHEW_AND,           "02",  TOY,              AP,      2,             4,         AND,      {1, 0, 0, 0} },
+    { FHEW_AND,           "03",  TOY,              LMKCDEY, 2,             4,         AND,      {1, 0, 0, 0} },
+    { FHEW_AND,           "04",  TOY_MULTI_BASE,   GINX,    2,             4,         AND,      {1, 0, 0, 0} },
+    { FHEW_AND,           "05",  TOY_MULTI_BASE,   AP,      2,             4,         AND,      {1, 0, 0, 0} },
+    { FHEW_AND,           "06",  TOY_MULTI_BASE,   LMKCDEY, 2,             4,         AND,      {1, 0, 0, 0} },
     // ==========================================
-    { FHEW_NAND, "01",   TOY,      GINX,    2,              4,        NAND,  {0, 1, 1, 1} },
-    { FHEW_NAND, "02",   TOY,      AP,      2,              4,        NAND,  {0, 1, 1, 1} },
-    { FHEW_NAND, "03",   TOY,      LMKCDEY, 2,              4,        NAND,  {0, 1, 1, 1} },
+    { FHEW_NAND,          "01",  TOY,              GINX,    2,             4,         NAND,     {0, 1, 1, 1} },
+    { FHEW_NAND,          "02",  TOY,              AP,      2,             4,         NAND,     {0, 1, 1, 1} },
+    { FHEW_NAND,          "03",  TOY,              LMKCDEY, 2,             4,         NAND,     {0, 1, 1, 1} },
+    { FHEW_NAND,          "04",  TOY_MULTI_BASE,   GINX,    2,             4,         NAND,     {0, 1, 1, 1} },
+    { FHEW_NAND,          "05",  TOY_MULTI_BASE,   AP,      2,             4,         NAND,     {0, 1, 1, 1} },
+    { FHEW_NAND,          "06",  TOY_MULTI_BASE,   LMKCDEY, 2,             4,         NAND,     {0, 1, 1, 1} },
     // ==========================================
-    { FHEW_OR,   "01",   TOY,      GINX,    2,              4,        OR,    {1, 1, 1, 0} },
-    { FHEW_OR,   "02",   TOY,      AP,      2,              4,        OR,    {1, 1, 1, 0} },
-    { FHEW_OR,   "03",   TOY,      LMKCDEY, 2,              4,        OR,    {1, 1, 1, 0} },
+    { FHEW_OR,            "01",  TOY,              GINX,    2,             4,         OR,       {1, 1, 1, 0} },
+    { FHEW_OR,            "02",  TOY,              AP,      2,             4,         OR,       {1, 1, 1, 0} },
+    { FHEW_OR,            "03",  TOY,              LMKCDEY, 2,             4,         OR,       {1, 1, 1, 0} },
+    { FHEW_OR,            "04",  TOY_MULTI_BASE,   GINX,    2,             4,         OR,       {1, 1, 1, 0} },
+    { FHEW_OR,            "05",  TOY_MULTI_BASE,   AP,      2,             4,         OR,       {1, 1, 1, 0} },
+    { FHEW_OR,            "06",  TOY_MULTI_BASE,   LMKCDEY, 2,             4,         OR,       {1, 1, 1, 0} },
     // ==========================================
-    { FHEW_NOR,  "01",   TOY,      GINX,    2,              4,        NOR,   {0, 0, 0, 1} },
-    { FHEW_NOR,  "02",   TOY,      AP,      2,              4,        NOR,   {0, 0, 0, 1} },
-    { FHEW_NOR,  "03",   TOY,      LMKCDEY, 2,              4,        NOR,   {0, 0, 0, 1} },
+    { FHEW_NOR,           "01",  TOY,              GINX,    2,             4,         NOR,      {0, 0, 0, 1} },
+    { FHEW_NOR,           "02",  TOY,              AP,      2,             4,         NOR,      {0, 0, 0, 1} },
+    { FHEW_NOR,           "03",  TOY,              LMKCDEY, 2,             4,         NOR,      {0, 0, 0, 1} },
+    { FHEW_NOR,           "04",  TOY_MULTI_BASE,   GINX,    2,             4,         NOR,      {0, 0, 0, 1} },
+    { FHEW_NOR,           "05",  TOY_MULTI_BASE,   AP,      2,             4,         NOR,      {0, 0, 0, 1} },
+    { FHEW_NOR,           "06",  TOY_MULTI_BASE,   LMKCDEY, 2,             4,         NOR,      {0, 0, 0, 1} },
     // ==========================================
-    { FHEW_XOR,  "01",   TOY,      GINX,    2,              4,        XOR,   {0, 1, 1, 0} },
-    { FHEW_XOR,  "02",   TOY,      AP,      2,              4,        XOR,   {0, 1, 1, 0} },
-    { FHEW_XOR,  "03",   TOY,      LMKCDEY, 2,              4,        XOR,   {0, 1, 1, 0} },
+    { FHEW_XOR,           "01",  TOY,              GINX,    2,             4,         XOR,      {0, 1, 1, 0} },
+    { FHEW_XOR,           "02",  TOY,              AP,      2,             4,         XOR,      {0, 1, 1, 0} },
+    { FHEW_XOR,           "03",  TOY,              LMKCDEY, 2,             4,         XOR,      {0, 1, 1, 0} },
+    { FHEW_XOR,           "04",  TOY_MULTI_BASE,   GINX,    2,             4,         XOR,      {0, 1, 1, 0} },
+    { FHEW_XOR,           "05",  TOY_MULTI_BASE,   AP,      2,             4,         XOR,      {0, 1, 1, 0} },
+    { FHEW_XOR,           "06",  TOY_MULTI_BASE,   LMKCDEY, 2,             4,         XOR,      {0, 1, 1, 0} },
     // ==========================================
-
-    { FHEW_XNOR,  "01",  TOY,      GINX,    2,              4,        XNOR,  {1, 0, 0, 1} },
-    { FHEW_XNOR,  "02",  TOY,      AP,      2,              4,        XNOR,  {1, 0, 0, 1} },
-    { FHEW_XNOR,  "03",  TOY,      LMKCDEY, 2,              4,        XNOR,  {1, 0, 0, 1} },
+    { FHEW_XNOR,          "01",  TOY,              GINX,    2,             4,         XNOR,     {1, 0, 0, 1} },
+    { FHEW_XNOR,          "02",  TOY,              AP,      2,             4,         XNOR,     {1, 0, 0, 1} },
+    { FHEW_XNOR,          "03",  TOY,              LMKCDEY, 2,             4,         XNOR,     {1, 0, 0, 1} },
+    { FHEW_XNOR,          "04",  TOY_MULTI_BASE,   GINX,    2,             4,         XNOR,     {1, 0, 0, 1} },
+    { FHEW_XNOR,          "05",  TOY_MULTI_BASE,   AP,      2,             4,         XNOR,     {1, 0, 0, 1} },
+    { FHEW_XNOR,          "06",  TOY_MULTI_BASE,   LMKCDEY, 2,             4,         XNOR,     {1, 0, 0, 1} },
     // ==========================================
-    { FHEW_AND3, "01", TOY,      GINX,         3,           6,        AND3,      {0} },
-    { FHEW_AND3, "02", TOY,      AP,           3,           6,        AND3,      {0} },
-    { FHEW_AND3, "03", TOY,      LMKCDEY,      3,           6,        AND3,      {0} },
+    { FHEW_AND3,          "01",  TOY,              GINX,    3,             6,         AND3,     {0} },
+    { FHEW_AND3,          "02",  TOY,              AP,      3,             6,         AND3,     {0} },
+    { FHEW_AND3,          "03",  TOY,              LMKCDEY, 3,             6,         AND3,     {0} },
+    { FHEW_AND3,          "04",  TOY_MULTI_BASE,   GINX,    3,             6,         AND3,     {0} },
+    { FHEW_AND3,          "05",  TOY_MULTI_BASE,   AP,      3,             6,         AND3,     {0} },
+    { FHEW_AND3,          "06",  TOY_MULTI_BASE,   LMKCDEY, 3,             6,         AND3,     {0} },
     // ==========================================
-    { FHEW_OR3, "01", TOY,      GINX,         3,            6,        OR3,      {1} },
-    { FHEW_OR3, "02", TOY,      AP,           3,            6,        OR3,      {1} },
-    { FHEW_OR3, "03", TOY,      LMKCDEY,      3,            6,        OR3,      {1} },
+    { FHEW_OR3,           "01",  TOY,              GINX,    3,             6,         OR3,      {1} },
+    { FHEW_OR3,           "02",  TOY,              AP,      3,             6,         OR3,      {1} },
+    { FHEW_OR3,           "03",  TOY,              LMKCDEY, 3,             6,         OR3,      {1} },
+    { FHEW_OR3,           "04",  TOY_MULTI_BASE,   GINX,    3,             6,         OR3,      {1} },
+    { FHEW_OR3,           "05",  TOY_MULTI_BASE,   AP,      3,             6,         OR3,      {1} },
+    { FHEW_OR3,           "06",  TOY_MULTI_BASE,   LMKCDEY, 3,             6,         OR3,      {1} },
     // ==========================================
-    { FHEW_AND4, "01", TOY,      GINX,         4,           8,        AND4,      {0} },
-    { FHEW_AND4, "02", TOY,      AP,           4,           8,        AND4,      {0} },
-    { FHEW_AND4, "03", TOY,      LMKCDEY,      4,           8,        AND4,      {0} },
+    { FHEW_AND4,          "01",  TOY,              GINX,    4,             8,         AND4,     {0} },
+    { FHEW_AND4,          "02",  TOY,              AP,      4,             8,         AND4,     {0} },
+    { FHEW_AND4,          "03",  TOY,              LMKCDEY, 4,             8,         AND4,     {0} },
+    { FHEW_AND4,          "04",  TOY_MULTI_BASE,   GINX,    4,             8,         AND4,     {0} },
+    { FHEW_AND4,          "05",  TOY_MULTI_BASE,   AP,      4,             8,         AND4,     {0} },
+    { FHEW_AND4,          "06",  TOY_MULTI_BASE,   LMKCDEY, 4,             8,         AND4,     {0} },
     // ==========================================
-    { FHEW_OR4, "01", TOY,      GINX,         4,            8,        OR4,      {1} },
-    { FHEW_OR4, "02", TOY,      AP,           4,            8,        OR4,      {1} },
-    { FHEW_OR4, "03", TOY,      LMKCDEY,      4,            8,        OR4,      {1} },
+    { FHEW_OR4,           "01",  TOY,              GINX,    4,             8,         OR4,      {1} },
+    { FHEW_OR4,           "02",  TOY,              AP,      4,             8,         OR4,      {1} },
+    { FHEW_OR4,           "03",  TOY,              LMKCDEY, 4,             8,         OR4,      {1} },
+    { FHEW_OR4,           "04",  TOY_MULTI_BASE,   GINX,    4,             8,         OR4,      {1} },
+    { FHEW_OR4,           "05",  TOY_MULTI_BASE,   AP,      4,             8,         OR4,      {1} },
+    { FHEW_OR4,           "06",  TOY_MULTI_BASE,   LMKCDEY, 4,             8,         OR4,      {1} },
     // ==========================================
-    { FHEW_MAJORITY, "01", TOY,      GINX,       3,         4,        MAJORITY,      {1} },
-    { FHEW_MAJORITY, "02", TOY,      AP,         3,         4,        MAJORITY,      {1} },
-    { FHEW_MAJORITY, "03", TOY,      LMKCDEY,    3,         4,        MAJORITY,      {1} },
+    { FHEW_MAJORITY,      "01",  TOY,              GINX,    3,             4,         MAJORITY, {1} },
+    { FHEW_MAJORITY,      "02",  TOY,              AP,      3,             4,         MAJORITY, {1} },
+    { FHEW_MAJORITY,      "03",  TOY,              LMKCDEY, 3,             4,         MAJORITY, {1} },
+    { FHEW_MAJORITY,      "04",  TOY_MULTI_BASE,   GINX,    3,             4,         MAJORITY, {1} },
+    { FHEW_MAJORITY,      "05",  TOY_MULTI_BASE,   AP,      3,             4,         MAJORITY, {1} },
+    { FHEW_MAJORITY,      "06",  TOY_MULTI_BASE,   LMKCDEY, 3,             4,         MAJORITY, {1} },
     // ==========================================
-    { FHEW_CMUX, "01", TOY,      GINX,         3,           4,        CMUX,      {1, 0} },
-    { FHEW_CMUX, "02", TOY,      AP,           3,           4,        CMUX,      {1, 0} },
-    { FHEW_CMUX, "03", TOY,      LMKCDEY,      3,           4,        CMUX,      {1, 0} },
+    { FHEW_CMUX,          "01",  TOY,              GINX,    3,             4,         CMUX,     {1, 0} },
+    { FHEW_CMUX,          "02",  TOY,              AP,      3,             4,         CMUX,     {1, 0} },
+    { FHEW_CMUX,          "03",  TOY,              LMKCDEY, 3,             4,         CMUX,     {1, 0} },
+    { FHEW_CMUX,          "04",  TOY_MULTI_BASE,   GINX,    3,             4,         CMUX,     {1, 0} },
+    { FHEW_CMUX,          "05",  TOY_MULTI_BASE,   AP,      3,             4,         CMUX,     {1, 0} },
+    { FHEW_CMUX,          "06",  TOY_MULTI_BASE,   LMKCDEY, 3,             4,         CMUX,     {1, 0} },
     // ==========================================
-    { FHEW_SIGNED_MODE, "01", SIGNED_MOD_TEST, GINX, 2,     4,        AND, {1, 0, 0, 0} },
+    { FHEW_SIGNED_MODE,   "01",  SIGNED_MOD_TEST,  GINX,    2,             4,         AND,      {1, 0, 0, 0} },
     // ==========================================
-    { FHEW_KEY_SWITCH, "01", TOY,      GINX,    2,          4,        OR, {1, 0} },  // OR is not needed; added as a random value
-    { FHEW_KEY_SWITCH, "02", TOY,      AP,      2,          4,        OR, {1, 0} },  // OR is not needed; added as a random value
-    { FHEW_KEY_SWITCH, "03", TOY,      LMKCDEY, 2,          4,        OR, {1, 0} },  // OR is not needed; added as a random value
+    { FHEW_KEY_SWITCH,    "01",  TOY,              GINX,    2,             4,         OR,       {1, 0} },  // OR is not needed; added as a random value
+    { FHEW_KEY_SWITCH,    "02",  TOY,              AP,      2,             4,         OR,       {1, 0} },  // OR is not needed; added as a random value
+    { FHEW_KEY_SWITCH,    "03",  TOY,              LMKCDEY, 2,             4,         OR,       {1, 0} },  // OR is not needed; added as a random value
     // ==========================================
-    { FHEW_MOD_SWITCH, "01", TOY,      GINX,    2,          4,        OR, {1, 0} },  // OR is not needed; added as a random value
-    { FHEW_MOD_SWITCH, "02", TOY,      AP,      2,          4,        OR, {1, 0} },  // OR is not needed; added as a random value
-    { FHEW_MOD_SWITCH, "03", TOY,      LMKCDEY, 2,          4,        OR, {1, 0} },  // OR is not needed; added as a random value
+    { FHEW_MOD_SWITCH,    "01",  TOY,              GINX,    2,             4,         OR,       {1, 0} },  // OR is not needed; added as a random value
+    { FHEW_MOD_SWITCH,    "02",  TOY,              AP,      2,             4,         OR,       {1, 0} },  // OR is not needed; added as a random value
+    { FHEW_MOD_SWITCH,    "03",  TOY,              LMKCDEY, 2,             4,         OR,       {1, 0} },  // OR is not needed; added as a random value
     // ==========================================
-    { FHEW_NOT, "01", TOY,      GINX,    2,                 4,        OR, {0, 1} },  // OR is not needed; added as a random value
-    { FHEW_NOT, "02", TOY,      AP,      2,                 4,        OR, {0, 1} },  // OR is not needed; added as a random value
-    { FHEW_NOT, "03", TOY,      LMKCDEY, 2,                 4,        OR, {0, 1} },  // OR is not needed; added as a random value
+    { FHEW_NOT,           "01",  TOY,              GINX,    2,             4,         OR,       {0, 1} },  // OR is not needed; added as a random value
+    { FHEW_NOT,           "02",  TOY,              AP,      2,             4,         OR,       {0, 1} },  // OR is not needed; added as a random value
+    { FHEW_NOT,           "03",  TOY,              LMKCDEY, 2,             4,         OR,       {0, 1} },  // OR is not needed; added as a random value
 };
 // clang-format on
 //===========================================================================================================

--- a/src/binfhe/unittest/UnitTestFHEWExtended.cpp
+++ b/src/binfhe/unittest/UnitTestFHEWExtended.cpp
@@ -56,7 +56,7 @@ TEST(UNITTestFHEWExtended, EvalBinGate2) {
     auto ct12 = cc.EvalBinGate(AND, ct_large, ct_small, true);
     EXPECT_EQ(Q, ct12->GetModulus());
 
-    auto ct2  = cc.EvalBinGate(NAND, ct11, ct12, false);
+    auto ct2 = cc.EvalBinGate(NAND, ct11, ct12, false);
     EXPECT_NE(Q, ct2->GetModulus());
     EXPECT_EQ(4, ct2->GetptModulus());
 
@@ -91,7 +91,7 @@ TEST(UNITTestFHEWExtended, EvalBinGate3) {
     EXPECT_EQ(Q, ct12->GetModulus());
     EXPECT_EQ(6, ct12->GetptModulus());
 
-    auto ct2  = cc.EvalBinGate(NAND, ct11, ct12, false);
+    auto ct2 = cc.EvalBinGate(NAND, ct11, ct12, false);
     EXPECT_NE(Q, ct2->GetModulus());
     EXPECT_EQ(4, ct2->GetptModulus());
 
@@ -126,7 +126,7 @@ TEST(UNITTestFHEWExtended, EvalBinGate4) {
     EXPECT_EQ(Q, ct12->GetModulus());
     EXPECT_EQ(8, ct12->GetptModulus());
 
-    auto ct2  = cc.EvalBinGate(NAND, ct11, ct12, false);
+    auto ct2 = cc.EvalBinGate(NAND, ct11, ct12, false);
     EXPECT_NE(Q, ct2->GetModulus());
     EXPECT_EQ(4, ct2->GetptModulus());
 
@@ -151,3 +151,46 @@ TEST(UNITTestFHEWExtended, BootStrap) {
     auto ct0 = cc.Bootstrap(cc.Encrypt(pk, 0, LARGE_DIM, 4), true);
     EXPECT_EQ(Q, ct0->GetModulus());
 }
+
+// BTKeyGen caches the bootstrapping key per gadget base, but its validity also depends on the
+// secret key. A second BTKeyGen with a different key must regenerate, not return the first key.
+TEST(UNITTestFHEWExtended, BTKeyGenRegeneratesForNewSecretKey) {
+    auto cc = BinFHEContext();
+    cc.GenerateBinFHEContext(STD128, GINX);
+
+    for (uint32_t round = 0; round < 2; ++round) {
+        auto sk = cc.KeyGen();
+        cc.BTKeyGen(sk);
+        for (uint32_t i = 0; i < 4; ++i) {
+            uint32_t b0 = i & 0x1, b1 = (i >> 1) & 0x1;
+            auto ct = cc.EvalBinGate(NAND, cc.Encrypt(sk, b0), cc.Encrypt(sk, b1));
+            LWEPlaintext result;
+            cc.Decrypt(sk, ct, &result);
+            EXPECT_EQ(static_cast<LWEPlaintext>(1 - (b0 & b1)), result)
+                << "NAND(" << b0 << "," << b1 << ") wrong for secret key " << (round + 1);
+        }
+    }
+}
+
+// The same, with the time-optimization path, which keeps one key per gadget base.
+// Excluded at NATIVE_SIZE=32 as in UnitTestFunc.cpp: the large-precision constructor sets
+// qKS = 1 << 35, which truncates to zero in a 32-bit NativeInteger.
+#if NATIVEINT != 32
+TEST(UNITTestFHEWExtended, BTKeyGenRegeneratesForNewSecretKeyTimeOptimization) {
+    auto cc = BinFHEContext();
+    cc.GenerateBinFHEContext(TOY, false, 11, 0, GINX, true);
+
+    for (uint32_t round = 0; round < 2; ++round) {
+        auto sk = cc.KeyGen();
+        cc.BTKeyGen(sk);
+        for (uint32_t i = 0; i < 4; ++i) {
+            uint32_t b0 = i & 0x1, b1 = (i >> 1) & 0x1;
+            auto ct = cc.EvalBinGate(NAND, cc.Encrypt(sk, b0), cc.Encrypt(sk, b1));
+            LWEPlaintext result;
+            cc.Decrypt(sk, ct, &result);
+            EXPECT_EQ(static_cast<LWEPlaintext>(1 - (b0 & b1)), result)
+                << "NAND(" << b0 << "," << b1 << ") wrong for secret key " << (round + 1);
+        }
+    }
+}
+#endif

--- a/src/core/include/math/matrix.h
+++ b/src/core/include/math/matrix.h
@@ -256,8 +256,7 @@ public:
 
         auto params = g(0, 0).GetParams()->GetParams();
 
-        uint64_t digitCount =
-            (uint64_t)std::ceil(std::log2(params[0]->GetModulus().ConvertToDouble()) / std::log2(base));
+        uint64_t digitCount = GetDigitCount(params[0]->GetModulus().ConvertToInt(), static_cast<uint64_t>(base));
 
         for (size_t k = 0; k < digitCount; k++) {
             for (size_t i = 0; i < params.size(); i++) {

--- a/src/core/include/math/nbtheory.h
+++ b/src/core/include/math/nbtheory.h
@@ -192,6 +192,34 @@ inline constexpr uint32_t GetMSB64(uint64_t x) {
     return GetMSB(x);
 }
 
+/**
+ * Get the number of base-`base` digits needed to represent every value below x,
+ * i.e. exact ceil(log_base(x)). Integer-only, so it is unaffected by the rounding
+ * of std::log and by the loss of precision of converting moduli above 2^53 to double.
+ *
+ * @param x the exclusive upper bound on the values to be represented.
+ * @param base the digit base, at least 2.
+ *
+ * @return the digit count.
+ */
+template <
+    typename T,
+    std::enable_if_t<std::is_integral_v<T> || std::is_same_v<T, int128_t> || std::is_same_v<T, uint128_t>, bool> = true>
+inline constexpr uint32_t GetDigitCount(T x, uint64_t base) {
+    if (base < 2)
+        OPENFHE_THROW("GetDigitCount() requires a base of at least 2");
+    if (x < 2)
+        return 0;
+    if ((base & (base - 1)) == 0) {
+        const uint32_t bits{GetMSB(base) - 1};
+        return (GetMSB(x - 1) + bits - 1) / bits;
+    }
+    uint32_t count{0};
+    for (T v{static_cast<T>(x - 1)}; v > 0; v = static_cast<T>(v / base))
+        ++count;
+    return count;
+}
+
 template <typename IntType>
 std::shared_ptr<std::vector<int64_t>> GetDigits(const IntType& u, uint64_t base, uint32_t k) {
     auto u_vec = std::make_shared<std::vector<int64_t>>(k);

--- a/src/core/include/math/nbtheory.h
+++ b/src/core/include/math/nbtheory.h
@@ -49,22 +49,11 @@
 #include "utils/inttypes.h"
 #include "utils/exception.h"
 
+#include <limits>
 #include <memory>
 #include <random>
 #include <set>
-// #include <string>
 #include <vector>
-
-#if defined(HAVE_INT128)
-namespace {  // to define local (or C-style static) functions here
-
-inline int clz_u128(uint128_t u) {
-    uint64_t hi(u >> 64), lo(u);
-    return hi ? __builtin_clzll(hi) : lo ? __builtin_clzll(lo) + 64 : 128;
-}
-
-};  // namespace
-#endif
 
 /**
  * @namespace lbcrypto
@@ -136,17 +125,17 @@ inline uint32_t ReverseBits(uint32_t num, uint32_t msb) {
     uint32_t msbb = (msb >> 3) + (msb & 0x7 ? 1 : 0);
     switch (msbb) {
         case 1:
-            return (reverse_byte((num)&0xff) >> shift_trick[msb & 0x7]);
+            return (reverse_byte((num) & 0xff) >> shift_trick[msb & 0x7]);
 
         case 2:
-            return (reverse_byte((num)&0xff) << 8 | reverse_byte((num >> 8) & 0xff)) >> shift_trick[msb & 0x7];
+            return (reverse_byte((num) & 0xff) << 8 | reverse_byte((num >> 8) & 0xff)) >> shift_trick[msb & 0x7];
 
         case 3:
-            return (reverse_byte((num)&0xff) << 16 | reverse_byte((num >> 8) & 0xff) << 8 |
+            return (reverse_byte((num) & 0xff) << 16 | reverse_byte((num >> 8) & 0xff) << 8 |
                     reverse_byte((num >> 16) & 0xff)) >>
                    shift_trick[msb & 0x7];
         case 4:
-            return (reverse_byte((num)&0xff) << 24 | reverse_byte((num >> 8) & 0xff) << 16 |
+            return (reverse_byte((num) & 0xff) << 24 | reverse_byte((num >> 8) & 0xff) << 16 |
                     reverse_byte((num >> 16) & 0xff) << 8 | reverse_byte((num >> 24) & 0xff)) >>
                    shift_trick[msb & 0x7];
         default:
@@ -175,17 +164,15 @@ inline constexpr uint32_t GetMSB(T x) {
         _BitScanReverse64(&msb, uint64_t(x));
         return msb + 1;
 #else
-        // a wrapper for GCC
-        return 64 -
-               (sizeof(unsigned long) == 8 ? __builtin_clzl(uint64_t(x)) : __builtin_clzll(uint64_t(x)));  // NOLINT
+        static_assert(std::numeric_limits<unsigned long long>::digits == 64,  // NOLINT
+                      "GetMSB assumes a 64-bit unsigned long long");
+        return 64 - static_cast<uint32_t>(__builtin_clzll(static_cast<uint64_t>(x)));
 #endif
     }
 #if defined(HAVE_INT128)
     else if constexpr (sizeof(T) == 16) {
-    #if defined(_MSC_VER)
-        static_assert(false, "MSVC doesn't support 128-bit integers");
-    #endif
-        return 128 - clz_u128(uint128_t(x));
+        auto hi{static_cast<uint64_t>(uint128_t(x) >> 64)};
+        return hi ? 64 + GetMSB(hi) : GetMSB(static_cast<uint64_t>(uint128_t(x)));
     }
 #endif
     else {

--- a/src/core/lib/lattice/trapdoor-dcrtpoly.cpp
+++ b/src/core/lib/lattice/trapdoor-dcrtpoly.cpp
@@ -57,7 +57,7 @@ std::pair<Matrix<DCRTPoly>, RLWETrapdoorPair<DCRTPoly>> RLWETrapdoorUtility<DCRT
 
     NativeInteger q = params->GetParams()[0]->GetModulus();
 
-    size_t digitCount = static_cast<size_t>(std::ceil(std::log2(q.ConvertToDouble()) / std::log2(base)));
+    size_t digitCount = GetDigitCount(q.ConvertToInt(), static_cast<uint64_t>(base));
 
     size_t k = params->GetParams().size() * digitCount;
 
@@ -97,7 +97,7 @@ std::pair<Matrix<DCRTPoly>, RLWETrapdoorPair<DCRTPoly>> RLWETrapdoorUtility<DCRT
 
     NativeInteger q = params->GetParams()[0]->GetModulus();
 
-    size_t digitCount = static_cast<size_t>(std::ceil(std::log2(q.ConvertToDouble()) / std::log2(base)));
+    size_t digitCount = GetDigitCount(q.ConvertToInt(), static_cast<uint64_t>(base));
 
     size_t k = params->GetParams().size() * digitCount;
 


### PR DESCRIPTION
Below is a brief summary of the main changes.

The existing parameter structure, which previously supported a single `baseG`, has been extended to support multiple gadget bases. A `gadgetBaseMap` and the corresponding internal `m_baseG_map` were added, while the existing `m_Gpower_map` is used to store the precomputed gadget powers for each base.

`GetBaseG()` and `GetDigitsG()` now take an LWE secret-key coefficient index and return the gadget base and the corresponding number of decomposition digits assigned to that coefficient. To support this throughout the bootstrapping path, the LWE secret-key index is propagated through key generation and accumulator updates so that the appropriate gadget base can be selected during `EvalACC`. A new constructor that takes a `gadgetBaseMap` was also added.

The named parameter sets are now initialized with their corresponding gadget base maps. In addition, the parameter sets with the `LPF_` prefix were updated using the `openfhe-lattice-estimator` so that their failure probability is approximately $2^{-128}$.

The same estimator can also be used to search for parameter sets targeting an arbitrary failure probability. The updated `LPF_` parameter sets in this PR were obtained using this parameter search.