### PR TITLE
added better exception handling for PRE mode not set

### DIFF
--- a/src/pke/include/cryptocontext.h
+++ b/src/pke/include/cryptocontext.h
@@ -346,6 +346,14 @@ protected:
         }
     }
 
+    void ValidatePREMode(CALLER_INFO_ARGS_HDR) const {
+        const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersRNS>(m_params);
+        if (cryptoParams == nullptr)
+            OPENFHE_THROW("Invalid crypto parameters: expected CryptoParametersRNS");
+        if (cryptoParams->GetKeySwitchTechnique() == HYBRID && cryptoParams->GetPREMode() == NOT_SET)
+            OPENFHE_THROW("PRE is disabled (default = NOT_SET). Enable with SetPREMode() before generating cryptocontext.");
+    }
+
     void ValidateSeriesPowers(std::shared_ptr<seriesPowers<Element>> powers, CALLER_INFO_ARGS_HDR) const {
         if (powers == nullptr) {
             std::string errorMsg(std::string("The object for powers is nullptr") + CALLER_INFO);
@@ -3109,10 +3117,7 @@ public:
     EvalKey<Element> ReKeyGen(const PrivateKey<Element> oldPrivateKey, const PublicKey<Element> newPublicKey) const {
         ValidateKey(oldPrivateKey);
         ValidateKey(newPublicKey);
-        const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersRLWE<DCRTPoly>>(GetCryptoParameters());
-        if (cryptoParams->GetPREMode() == NOT_SET)
-            OPENFHE_THROW(
-                "Set the PRE mode using SetPREMode() before using PRE. The default PRE mode is NOT_SET, which means PRE is disabled.");
+        ValidatePREMode();
         return m_scheme->ReKeyGen(oldPrivateKey, newPublicKey);
     }
 
@@ -3140,11 +3145,7 @@ public:
                                   const PublicKey<Element> publicKey = nullptr) const {
         ValidateCiphertext(ciphertext);
         ValidateKey(evalKey);
-        const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersRLWE<DCRTPoly>>(GetCryptoParameters());
-        if (cryptoParams->GetPREMode() == NOT_SET)
-            OPENFHE_THROW(
-                "Set the PRE mode using SetPREMode() before using PRE. The default PRE mode is NOT_SET, which means PRE is disabled.");
-
+        ValidatePREMode();
         return m_scheme->ReEncrypt(ciphertext, evalKey, publicKey);
     }
 

--- a/src/pke/include/cryptocontext.h
+++ b/src/pke/include/cryptocontext.h
@@ -3109,6 +3109,10 @@ public:
     EvalKey<Element> ReKeyGen(const PrivateKey<Element> oldPrivateKey, const PublicKey<Element> newPublicKey) const {
         ValidateKey(oldPrivateKey);
         ValidateKey(newPublicKey);
+        const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersRLWE<DCRTPoly>>(GetCryptoParameters());
+        if (cryptoParams->GetPREMode() == NOT_SET)
+            OPENFHE_THROW(
+                "Set the PRE mode using SetPREMode() before using PRE. The default PRE mode is NOT_SET, which means PRE is disabled.");
         return m_scheme->ReKeyGen(oldPrivateKey, newPublicKey);
     }
 
@@ -3136,6 +3140,11 @@ public:
                                   const PublicKey<Element> publicKey = nullptr) const {
         ValidateCiphertext(ciphertext);
         ValidateKey(evalKey);
+        const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersRLWE<DCRTPoly>>(GetCryptoParameters());
+        if (cryptoParams->GetPREMode() == NOT_SET)
+            OPENFHE_THROW(
+                "Set the PRE mode using SetPREMode() before using PRE. The default PRE mode is NOT_SET, which means PRE is disabled.");
+
         return m_scheme->ReEncrypt(ciphertext, evalKey, publicKey);
     }
 


### PR DESCRIPTION
The exception now tells the use to set the PRE mode to enable proxy re-encryption instead of throwing a cryptic low-level exception.