### PR TITLE
Added FIXEDAUTO/FLEXIBLEAUTO/FLEXIBLEAUTOEXT support to CKKS function…

### DIFF
--- a/src/pke/examples/CKKS_FUNCTIONAL_BOOTSTRAPING.md
+++ b/src/pke/examples/CKKS_FUNCTIONAL_BOOTSTRAPING.md
@@ -118,5 +118,8 @@ security.
 - The current multiprecision sign evaluation implementation requires that the digit bit size divides the input bit size.
 - Only sparse secrets are currently supported, with the secret key distributions SPARSE_TERNARY (larger probability of
 failure) and SPARSE_ENCAPSULATED (negligible probability of failure).
-- Only the FIXEDMANUAL mode for rescaling is supported.
+- The FIXEDMANUAL, FIXEDAUTO, FLEXIBLEAUTO, and FLEXIBLEAUTOEXT modes for rescaling are supported (for the 64-bit build).
+The FLEXIBLEAUTO and FLEXIBLEAUTOEXT modes track the exact level-specific scaling factors, which removes the
+scaling-factor drift of the FIXED* modes; hence they achieve smaller noise for the same parameters (equivalently,
+correctness can be achieved with a smaller CKKS scaling factor).
 - MULTIPARTY is not supported.

--- a/src/pke/examples/CKKS_FUNCTIONAL_BOOTSTRAPING.md
+++ b/src/pke/examples/CKKS_FUNCTIONAL_BOOTSTRAPING.md
@@ -122,4 +122,6 @@ failure) and SPARSE_ENCAPSULATED (negligible probability of failure).
 The FLEXIBLEAUTO and FLEXIBLEAUTOEXT modes track the exact level-specific scaling factors, which removes the
 scaling-factor drift of the FIXED* modes; hence they achieve smaller noise for the same parameters (equivalently,
 correctness can be achieved with a smaller CKKS scaling factor).
+Composite scaling (COMPOSITESCALINGAUTO and COMPOSITESCALINGMANUAL) is not supported yet, and neither is NORESCALE;
+`EvalFBTSetup` rejects them.
 - MULTIPARTY is not supported.

--- a/src/pke/examples/CKKS_FUNCTIONAL_BOOTSTRAPING.md
+++ b/src/pke/examples/CKKS_FUNCTIONAL_BOOTSTRAPING.md
@@ -124,4 +124,5 @@ scaling-factor drift of the FIXED* modes; hence they achieve smaller noise for t
 correctness can be achieved with a smaller CKKS scaling factor).
 Composite scaling (COMPOSITESCALINGAUTO and COMPOSITESCALINGMANUAL) is not supported yet, and neither is NORESCALE;
 `EvalFBTSetup` rejects them.
+- The 128-bit build (`NATIVE_SIZE == 128`) is not supported yet; `EvalFBTSetup` rejects it.
 - MULTIPARTY is not supported.

--- a/src/pke/examples/functional-bootstrapping-ckks.cpp
+++ b/src/pke/examples/functional-bootstrapping-ckks.cpp
@@ -145,6 +145,9 @@ void ArbitraryLUT(BigInteger QBFVInit, BigInteger PInput, BigInteger POutput, Bi
     * The SPARSE_TERNARY distribution is for testing purposes as it gives a larger probability of
     * failure but less noise, while the SPARSE_ENCAPSULATED distribution gives a smaller probability
     * of failure at a cost of slightly more noise.
+    * The supported rescaling techniques are FIXEDMANUAL, FIXEDAUTO, FLEXIBLEAUTO and FLEXIBLEAUTOEXT.
+    * The FLEXIBLEAUTO and FLEXIBLEAUTOEXT techniques track the exact level-specific scaling factors,
+    * hence they yield less noise than the FIXED* techniques for the same parameters.
     */
     uint32_t dcrtBits                       = Bigq.GetMSB() - 1;
     uint32_t firstMod                       = Bigq.GetMSB() - 1;
@@ -152,13 +155,14 @@ void ArbitraryLUT(BigInteger QBFVInit, BigInteger PInput, BigInteger POutput, Bi
     uint32_t levelsAvailableBeforeBootstrap = 0;
     uint32_t dnum                           = 3;
     SecretKeyDist secretKeyDist             = SPARSE_ENCAPSULATED;
+    ScalingTechnique scalTech               = FLEXIBLEAUTO;
     std::vector<uint32_t> lvlb              = {3, 3};
 
     CCParams<CryptoContextCKKSRNS> parameters;
     parameters.SetSecretKeyDist(secretKeyDist);
     parameters.SetSecurityLevel(HEStd_NotSet);
     parameters.SetScalingModSize(dcrtBits);
-    parameters.SetScalingTechnique(FIXEDMANUAL);
+    parameters.SetScalingTechnique(scalTech);
     parameters.SetFirstModSize(firstMod);
     parameters.SetNumLargeDigits(dnum);
     parameters.SetBatchSize(numSlotsCKKS);
@@ -178,8 +182,8 @@ void ArbitraryLUT(BigInteger QBFVInit, BigInteger PInput, BigInteger POutput, Bi
     cc->Enable(ADVANCEDSHE);
     cc->Enable(FHE);
 
-    std::cout << "CKKS scheme is using ring dimension " << cc->GetRingDimension() << " and a multiplicative depth of "
-              << depth << std::endl
+    std::cout << "CKKS scheme is using ring dimension " << cc->GetRingDimension() << ", a multiplicative depth of "
+              << depth << " and the " << scalTech << " rescaling technique" << std::endl
               << std::endl;
 
     /* 5. Compute various moduli and scaling sizes, used for scheme conversions.
@@ -302,6 +306,9 @@ void MultiValueBootstrapping(BigInteger QBFVInit, BigInteger PInput, BigInteger 
      * The SPARSE_TERNARY distribution is for testing purposes as it gives a larger probability of
      * failure but less noise, while the SPARSE_ENCAPSULATED distribution gives a smaller probability
      * of failure at a cost of slightly more noise.
+     * The supported rescaling techniques are FIXEDMANUAL, FIXEDAUTO, FLEXIBLEAUTO and FLEXIBLEAUTOEXT.
+     * The FLEXIBLEAUTO and FLEXIBLEAUTOEXT techniques track the exact level-specific scaling factors,
+     * hence they yield less noise than the FIXED* techniques for the same parameters.
      */
     uint32_t dcrtBits                       = Bigq.GetMSB() - 1;
     uint32_t firstMod                       = Bigq.GetMSB() - 1;
@@ -309,13 +316,14 @@ void MultiValueBootstrapping(BigInteger QBFVInit, BigInteger PInput, BigInteger 
     uint32_t levelsAvailableBeforeBootstrap = 0;
     uint32_t dnum                           = 3;
     SecretKeyDist secretKeyDist             = SPARSE_TERNARY;
+    ScalingTechnique scalTech               = FIXEDMANUAL;
     std::vector<uint32_t> lvlb              = {3, 3};
 
     CCParams<CryptoContextCKKSRNS> parameters;
     parameters.SetSecretKeyDist(secretKeyDist);
     parameters.SetSecurityLevel(HEStd_NotSet);
     parameters.SetScalingModSize(dcrtBits);
-    parameters.SetScalingTechnique(FIXEDMANUAL);
+    parameters.SetScalingTechnique(scalTech);
     parameters.SetFirstModSize(firstMod);
     parameters.SetNumLargeDigits(dnum);
     parameters.SetBatchSize(numSlotsCKKS);
@@ -335,8 +343,8 @@ void MultiValueBootstrapping(BigInteger QBFVInit, BigInteger PInput, BigInteger 
     cc->Enable(ADVANCEDSHE);
     cc->Enable(FHE);
 
-    std::cout << "CKKS scheme is using ring dimension " << cc->GetRingDimension() << " and a multiplicative depth of "
-              << depth << std::endl
+    std::cout << "CKKS scheme is using ring dimension " << cc->GetRingDimension() << ", a multiplicative depth of "
+              << depth << " and the " << scalTech << " rescaling technique" << std::endl
               << std::endl;
 
     /* 6. Compute various moduli and scaling sizes, used for scheme conversions.
@@ -357,10 +365,13 @@ void MultiValueBootstrapping(BigInteger QBFVInit, BigInteger PInput, BigInteger 
 
     auto mask_real = Fill<double>({1, 1, 1, 1, 0, 0, 0, 0}, numSlots);
 
+    // The mask level is counted on the full modulus chain, which has an extra modulus for FLEXIBLEAUTOEXT
+    const uint32_t extOff = (scalTech == FLEXIBLEAUTOEXT) ? 1 : 0;
+
     // Note that the corresponding plaintext mask for full packing can be just real, as real times complex multiplies both real and imaginary parts
     Plaintext ptxt_mask = cc->MakeCKKSPackedPlaintext(
         Fill<double>({1, 1, 1, 1, 0, 0, 0, 0}, numSlotsCKKS), 1,
-        depth - lvlb[1] - levelsAvailableAfterBootstrap - levelsComputation, nullptr, numSlotsCKKS);
+        depth + extOff - lvlb[1] - levelsAvailableAfterBootstrap - levelsComputation, nullptr, numSlotsCKKS);
 
     /* 7. When leveled computations (multiplications, rotations) are desired to be performed while in
      * slot-packed CKKS (before returning to RLWE coefficient packing), and the FFT method is used
@@ -546,6 +557,9 @@ void MultiPrecisionSign(BigInteger QBFVInit, BigInteger PInput, BigInteger PDigi
      * The SPARSE_TERNARY distribution is for testing purposes as it gives a larger probability of
      * failure but less noise, while the SPARSE_ENCAPSULATED distribution gives a smaller probability
      * of failure at a cost of slightly more noise.
+     * The supported rescaling techniques are FIXEDMANUAL, FIXEDAUTO, FLEXIBLEAUTO and FLEXIBLEAUTOEXT.
+     * The FLEXIBLEAUTO and FLEXIBLEAUTOEXT techniques track the exact level-specific scaling factors,
+     * hence they yield less noise than the FIXED* techniques for the same parameters.
      */
     uint32_t dcrtBits                       = Bigq.GetMSB() - 1;
     uint32_t firstMod                       = Bigq.GetMSB() - 1;
@@ -553,13 +567,14 @@ void MultiPrecisionSign(BigInteger QBFVInit, BigInteger PInput, BigInteger PDigi
     uint32_t levelsAvailableBeforeBootstrap = 0;
     uint32_t dnum                           = 3;
     SecretKeyDist secretKeyDist             = SPARSE_ENCAPSULATED;
+    ScalingTechnique scalTech               = FIXEDMANUAL;
     std::vector<uint32_t> lvlb              = {3, 3};
 
     CCParams<CryptoContextCKKSRNS> parameters;
     parameters.SetSecretKeyDist(secretKeyDist);
     parameters.SetSecurityLevel(HEStd_NotSet);
     parameters.SetScalingModSize(dcrtBits);
-    parameters.SetScalingTechnique(FIXEDMANUAL);
+    parameters.SetScalingTechnique(scalTech);
     parameters.SetFirstModSize(firstMod);
     parameters.SetNumLargeDigits(dnum);
     parameters.SetBatchSize(numSlotsCKKS);
@@ -581,8 +596,8 @@ void MultiPrecisionSign(BigInteger QBFVInit, BigInteger PInput, BigInteger PDigi
 
     auto keyPair = cc->KeyGen();
 
-    std::cout << "CKKS scheme is using ring dimension " << cc->GetRingDimension() << " and a multiplicative depth of "
-              << depth << std::endl
+    std::cout << "CKKS scheme is using ring dimension " << cc->GetRingDimension() << ", a multiplicative depth of "
+              << depth << " and the " << scalTech << " rescaling technique" << std::endl
               << std::endl;
 
     /* 6. Compute various moduli and scaling sizes, used for scheme conversions.

--- a/src/pke/lib/scheme/ckksrns/ckksrns-fhe.cpp
+++ b/src/pke/lib/scheme/ckksrns/ckksrns-fhe.cpp
@@ -3009,6 +3009,21 @@ void FHECKKSRNS::FitToNativeVector(uint32_t ringDim, const std::vector<int128_t>
 }
 #endif
 
+// CKKS Functional Bootstrapping implements the tower-drop and rescaling conventions only for the
+// techniques below. Composite scaling is not supported yet: it needs a level-specific scaling-factor
+// chain whose rescalings are multiples of the composite degree, which the tower drops here do not follow.
+static void ValidateFBTScalingTechnique(const std::shared_ptr<CryptoParametersCKKSRNS>& cryptoParams) {
+    auto st = cryptoParams->GetScalingTechnique();
+    if (st != FIXEDMANUAL && st != FIXEDAUTO && st != FLEXIBLEAUTO && st != FLEXIBLEAUTOEXT)
+        OPENFHE_THROW(
+            "CKKS Functional Bootstrapping is supported for the FIXEDMANUAL, FIXEDAUTO, FLEXIBLEAUTO, and "
+            "FLEXIBLEAUTOEXT methods only.");
+#if NATIVEINT == 128
+    if (st == FLEXIBLEAUTO || st == FLEXIBLEAUTOEXT)
+        OPENFHE_THROW("128-bit CKKS Functional Bootstrapping is supported for FIXEDMANUAL and FIXEDAUTO methods only.");
+#endif
+}
+
 template <typename VectorDataType>
 void FHECKKSRNS::EvalFBTSetupInternal(const CryptoContextImpl<DCRTPoly>& cc, const std::vector<VectorDataType>& coeffs,
                                       uint32_t numSlots, const BigInteger& PIn, const BigInteger& POut,
@@ -3018,10 +3033,7 @@ void FHECKKSRNS::EvalFBTSetupInternal(const CryptoContextImpl<DCRTPoly>& cc, con
     const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersCKKSRNS>(cc.GetCryptoParameters());
     if (cryptoParams->GetKeySwitchTechnique() != HYBRID)
         OPENFHE_THROW("CKKS Functional Bootstrapping is only supported for the Hybrid key switching method.");
-#if NATIVEINT == 128
-    if (cryptoParams->GetScalingTechnique() == FLEXIBLEAUTO || cryptoParams->GetScalingTechnique() == FLEXIBLEAUTOEXT)
-        OPENFHE_THROW("128-bit CKKS Functional Bootstrapping is supported for FIXEDMANUAL and FIXEDAUTO methods only.");
-#endif
+    ValidateFBTScalingTechnique(cryptoParams);
 
     uint32_t M     = cc.GetCyclotomicOrder();
     uint32_t slots = (numSlots == 0) ? M / 4 : numSlots;
@@ -3182,6 +3194,7 @@ void FHECKKSRNS::EvalFBTSetup(const CryptoContextImpl<DCRTPoly>& cc, const std::
 Ciphertext<DCRTPoly> FHECKKSRNS::EvalHomDecoding(ConstCiphertext<DCRTPoly>& ciphertext, uint64_t postScaling,
                                                  uint32_t levelToReduce) {
     const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersCKKSRNS>(ciphertext->GetCryptoParameters());
+    ValidateFBTScalingTechnique(cryptoParams);
 
     auto ctxtEnc = ciphertext->Clone();
 
@@ -3200,6 +3213,13 @@ Ciphertext<DCRTPoly> FHECKKSRNS::EvalHomDecoding(ConstCiphertext<DCRTPoly>& ciph
             // Note that for a degree-2 input, EvalMultInPlace first rescales (consuming one tower).
             uint32_t dstLevel = ctxtEnc->GetLevel() + levelToReduce;
             uint32_t curLevel = ctxtEnc->GetLevel() + (ctxtEnc->GetNoiseScaleDeg() == 2);
+            // The level-specific scaling factors are precomputed only up to the second-to-last level
+            // (the accessors silently fall back for larger indices), and the rescale before
+            // SlotsToCoeffs consumes one more tower anyway.
+            uint32_t sizeQ = cryptoParams->GetElementParams()->GetParams().size();
+            if (dstLevel > sizeQ - 2)
+                OPENFHE_THROW("levelToReduce is too large: the level after reduction (" + std::to_string(dstLevel) +
+                              ") must be at most " + std::to_string(sizeQ - 2) + ".");
             cc->EvalMultInPlace(ctxtEnc, cryptoParams->GetScalingFactorRealBig(dstLevel) /
                                              cryptoParams->GetScalingFactorRealBig(curLevel));
             if (dstLevel > ctxtEnc->GetLevel())
@@ -3258,12 +3278,16 @@ std::shared_ptr<seriesPowers<DCRTPoly>> FHECKKSRNS::EvalMVBPrecomputeInternal(
     if (cryptoParams->GetKeySwitchTechnique() != HYBRID)
         OPENFHE_THROW("CKKS Bootstrapping is only supported for the Hybrid key switching method.");
 
+    ValidateFBTScalingTechnique(cryptoParams);
     auto st               = cryptoParams->GetScalingTechnique();
     const bool isFlexible = (st == FLEXIBLEAUTO || st == FLEXIBLEAUTOEXT);
-#if NATIVEINT == 128
-    if (isFlexible)
-        OPENFHE_THROW("128-bit CKKS Functional Bootstrapping is supported for FIXEDMANUAL and FIXEDAUTO methods only.");
-#endif
+
+    // The RLWE-imported payload must not include the FLEXIBLEAUTOEXT extra modulus, so the input has
+    // to be imported at least one level deep (SchemeletRLWEMP applies this offset automatically).
+    if (st == FLEXIBLEAUTOEXT && ciphertext->GetLevel() == 0)
+        OPENFHE_THROW(
+            "For FLEXIBLEAUTOEXT, the input to CKKS Functional Bootstrapping must be at level 1 or deeper so that it "
+            "does not include the extra modulus.");
 
     // For FLEXIBLEAUTOEXT the raised ciphertext does not include the extra modulus
     auto elementParamsRaised = *(cryptoParams->GetElementParams());
@@ -3308,8 +3332,24 @@ std::shared_ptr<seriesPowers<DCRTPoly>> FHECKKSRNS::EvalMVBPrecomputeInternal(
     // AA: make the check more granular (around 1.0000x?)
     // For FLEXIBLE* the correction is instead folded into the multiplication by 1/(k*N) after ModRaise,
     // which does not consume an extra level.
-    if (!isFlexible && std::llround(correction) != 1.0)
-        AdjustCiphertextFBT(raised, correction);
+    if (!isFlexible) {
+        if (std::llround(correction) != 1.0)
+            AdjustCiphertextFBT(raised, correction);
+    }
+    else {
+        // The modulus raise below keeps only tower 0, so a multi-tower input (an initialScaling that
+        // spans several RNS limbs, e.g. when levels are available before bootstrapping) must first be
+        // brought down to a single tower by rounded rescaling. Each rescale divides the raw payload by
+        // the dropped modulus, which correction absorbs, so the residual w.r.t. the nominal 2^p is
+        // still folded in exactly after ModRaise. The noise scale degree is restored because the raw
+        // payload is not on the CKKS scaling convention.
+        while (raised->GetElements()[0].GetNumOfElements() > 1) {
+            uint32_t deg = raised->GetNoiseScaleDeg();
+            correction *= raised->GetElements()[0].GetParams()->GetParams().back()->GetModulus().ConvertToDouble();
+            algo->ModReduceInternalInPlace(raised, 1);
+            raised->SetNoiseScaleDeg(deg);
+        }
+    }
 
     uint32_t L0 = cryptoParams->GetElementParams()->GetParams().size();
     if (cryptoParams->GetSecretKeyDist() == SPARSE_ENCAPSULATED) {
@@ -3563,10 +3603,7 @@ Ciphertext<DCRTPoly> FHECKKSRNS::EvalMVBNoDecodingInternal(const std::shared_ptr
         std::dynamic_pointer_cast<CryptoParametersCKKSRNS>(ciphertexts->powersRe[0]->GetCryptoParameters());
     if (cryptoParams->GetKeySwitchTechnique() != HYBRID)
         OPENFHE_THROW("CKKS Bootstrapping is only supported for the Hybrid key switching method.");
-#if NATIVEINT == 128
-    if (cryptoParams->GetScalingTechnique() == FLEXIBLEAUTO || cryptoParams->GetScalingTechnique() == FLEXIBLEAUTOEXT)
-        OPENFHE_THROW("128-bit CKKS Functional Bootstrapping is supported for FIXEDMANUAL and FIXEDAUTO methods only.");
-#endif
+    ValidateFBTScalingTechnique(cryptoParams);
 
     auto cc        = ciphertexts->powersRe[0]->GetCryptoContext();
     uint32_t M4    = cc->GetCyclotomicOrder() / 4;
@@ -3588,8 +3625,8 @@ Ciphertext<DCRTPoly> FHECKKSRNS::EvalMVBNoDecodingInternal(const std::shared_ptr
         //------------------------------------------------------------------------------
 
         if (digitBitSize == 1 && order == 1) {
-            ctxtEnc  = ciphertexts->powersRe[0];
-            ctxtEncI = ciphertexts->powersIm[0];
+            ctxtEnc  = ciphertexts->powersRe[0]->Clone();
+            ctxtEncI = ciphertexts->powersIm[0]->Clone();
             // Assumes the function is integer and real!
             if (ToReal(coefficients[1]) > 0) {  // MultByInteger only works with positive integers
                 algo->MultByIntegerInPlace(ctxtEnc, ToReal(coefficients[1]));
@@ -3643,7 +3680,7 @@ Ciphertext<DCRTPoly> FHECKKSRNS::EvalMVBNoDecodingInternal(const std::shared_ptr
         //------------------------------------------------------------------------------
 
         if (digitBitSize == 1 && order == 1) {
-            ctxtEnc = ciphertexts->powersRe[0];
+            ctxtEnc = ciphertexts->powersRe[0]->Clone();
             // Assumes the function is integer and real!
             if (ToReal(coefficients[1]) > 0) {  // MultByInteger only works with positive integers
                 algo->MultByIntegerInPlace(ctxtEnc, ToReal(coefficients[1]));

--- a/src/pke/lib/scheme/ckksrns/ckksrns-fhe.cpp
+++ b/src/pke/lib/scheme/ckksrns/ckksrns-fhe.cpp
@@ -3012,15 +3012,19 @@ void FHECKKSRNS::FitToNativeVector(uint32_t ringDim, const std::vector<int128_t>
 // CKKS Functional Bootstrapping implements the tower-drop and rescaling conventions only for the
 // techniques below. Composite scaling is not supported yet: it needs a level-specific scaling-factor
 // chain whose rescalings are multiples of the composite degree, which the tower drops here do not follow.
-static void ValidateFBTScalingTechnique(const std::shared_ptr<CryptoParametersCKKSRNS>& cryptoParams) {
+// The whole 128-bit build is rejected as well, for every scaling technique: functional bootstrapping has
+// no counterpart to the correction-factor scaling path that standard CKKS bootstrapping implements for
+// 128 bits, and enabling the unit tests on a 128-bit build shows every case, the FIXED* modes included,
+// producing silently wrong results. Supporting it is future work.
+static void ValidateFBTScalingTechnique([[maybe_unused]] const std::shared_ptr<CryptoParametersCKKSRNS>& cryptoParams) {
+#if NATIVEINT == 128
+    OPENFHE_THROW("CKKS Functional Bootstrapping is not supported for the 128-bit build (NATIVE_SIZE == 128).");
+#else
     auto st = cryptoParams->GetScalingTechnique();
     if (st != FIXEDMANUAL && st != FIXEDAUTO && st != FLEXIBLEAUTO && st != FLEXIBLEAUTOEXT)
         OPENFHE_THROW(
             "CKKS Functional Bootstrapping is supported for the FIXEDMANUAL, FIXEDAUTO, FLEXIBLEAUTO, and "
             "FLEXIBLEAUTOEXT methods only.");
-#if NATIVEINT == 128
-    if (st == FLEXIBLEAUTO || st == FLEXIBLEAUTOEXT)
-        OPENFHE_THROW("128-bit CKKS Functional Bootstrapping is supported for FIXEDMANUAL and FIXEDAUTO methods only.");
 #endif
 }
 
@@ -3096,13 +3100,18 @@ void FHECKKSRNS::EvalFBTSetupInternal(const CryptoContextImpl<DCRTPoly>& cc, con
     }
 
     auto& params = pubKey->GetPublicElements()[0].GetParams()->GetParams();
-    uint32_t cnt = 0;
 
-    const uint32_t lvlsAfterBootSaved = lvlsAfterBoot;
+    // The output of functional bootstrapping keeps 1 + lvlsAfterBoot towers, so the modulus chain has to
+    // be long enough to provide them. Without this check the loop below reads past the end of the params
+    // vector and the level arithmetic further down wraps around.
+    if (lvlsAfterBoot >= params.size())
+        OPENFHE_THROW("lvlsAfterBoot (" + std::to_string(lvlsAfterBoot) +
+                      ") is too large: it must be less than the number of moduli (" + std::to_string(params.size()) +
+                      ").");
 
     BigInteger QPrime = params[0]->GetModulus();
-    while (lvlsAfterBoot-- > 0)
-        QPrime *= params[++cnt]->GetModulus();
+    for (uint32_t i = 1; i <= lvlsAfterBoot; ++i)
+        QPrime *= params[i]->GetModulus();
 
     BigInteger q    = cryptoParams->GetElementParams()->GetParams()[0]->GetModulus().ConvertToInt();
     auto qDouble    = q.ConvertToLongDouble();
@@ -3131,12 +3140,25 @@ void FHECKKSRNS::EvalFBTSetupInternal(const CryptoContextImpl<DCRTPoly>& cc, con
         double pow2p         = std::pow(2.0, static_cast<double>(cryptoParams->GetPlaintextModulus()));
         uint32_t raisedLevel = (st == FLEXIBLEAUTOEXT) ? 1 : 0;
         // the output of functional bootstrapping has 1 + lvlsAfterBoot towers remaining
-        uint32_t finalLevel = L0 - 1 - lvlsAfterBootSaved;
+        uint32_t finalLevel = L0 - 1 - lvlsAfterBoot;
         scaleEnc *= cryptoParams->GetScalingFactorReal(raisedLevel) / pow2p;
         scaleDec *= pow2p / cryptoParams->GetScalingFactorReal(finalLevel);
     }
 
     L0 -= (st == FLEXIBLEAUTOEXT);
+
+    // The encoding and decoding matrices are precomputed at the levels below, which have to exist on the
+    // chain. Checking here reports the parameter that is actually wrong, instead of letting the unsigned
+    // subtractions wrap and failing later inside the plaintext encoding with an unrelated message.
+    if (levelBudget[0] >= L0)
+        OPENFHE_THROW("The encoding level budget (" + std::to_string(levelBudget[0]) +
+                      ") is too large for the available number of levels (" + std::to_string(L0) + ").");
+    if (depthBT > L0)
+        OPENFHE_THROW("The functional bootstrapping depth (" + std::to_string(depthBT) +
+                      ") exceeds the available number of levels (" + std::to_string(L0) +
+                      "). Increase the multiplicative depth, or reduce the level budget or "
+                      "depthLeveledComputation.");
+
     uint32_t lEnc = L0 - levelBudget[0] - 1;
     uint32_t lDec = L0 - depthBT;
 

--- a/src/pke/lib/scheme/ckksrns/ckksrns-fhe.cpp
+++ b/src/pke/lib/scheme/ckksrns/ckksrns-fhe.cpp
@@ -3016,10 +3016,12 @@ void FHECKKSRNS::EvalFBTSetupInternal(const CryptoContextImpl<DCRTPoly>& cc, con
                                       const std::vector<uint32_t>& dim1, const std::vector<uint32_t>& levelBudget,
                                       uint32_t lvlsAfterBoot, uint32_t depthLeveledComputation, size_t order) {
     const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersCKKSRNS>(cc.GetCryptoParameters());
-    if (cryptoParams->GetScalingTechnique() == FLEXIBLEAUTO || cryptoParams->GetScalingTechnique() == FLEXIBLEAUTOEXT)
-        OPENFHE_THROW("CKKS Functional Bootstrapping is supported for FIXEDMANUAL and FIXEDAUTO methods only.");
     if (cryptoParams->GetKeySwitchTechnique() != HYBRID)
         OPENFHE_THROW("CKKS Functional Bootstrapping is only supported for the Hybrid key switching method.");
+#if NATIVEINT == 128
+    if (cryptoParams->GetScalingTechnique() == FLEXIBLEAUTO || cryptoParams->GetScalingTechnique() == FLEXIBLEAUTOEXT)
+        OPENFHE_THROW("128-bit CKKS Functional Bootstrapping is supported for FIXEDMANUAL and FIXEDAUTO methods only.");
+#endif
 
     uint32_t M     = cc.GetCyclotomicOrder();
     uint32_t slots = (numSlots == 0) ? M / 4 : numSlots;
@@ -3084,6 +3086,8 @@ void FHECKKSRNS::EvalFBTSetupInternal(const CryptoContextImpl<DCRTPoly>& cc, con
     auto& params = pubKey->GetPublicElements()[0].GetParams()->GetParams();
     uint32_t cnt = 0;
 
+    const uint32_t lvlsAfterBootSaved = lvlsAfterBoot;
+
     BigInteger QPrime = params[0]->GetModulus();
     while (lvlsAfterBoot-- > 0)
         QPrime *= params[++cnt]->GetModulus();
@@ -3099,7 +3103,28 @@ void FHECKKSRNS::EvalFBTSetupInternal(const CryptoContextImpl<DCRTPoly>& cc, con
     uint32_t depthBT = depthLeveledComputation + GetFBTDepth(levelBudget, coeffs, PIn, order, skd);
 
     // compute # of levels to remain when encoding the coefficients
-    uint32_t L0   = cryptoParams->GetElementParams()->GetParams().size();
+    // for FLEXIBLEAUTOEXT the raised ciphertext does not include the extra modulus
+    auto st     = cryptoParams->GetScalingTechnique();
+    uint32_t L0 = cryptoParams->GetElementParams()->GetParams().size();
+
+    if (st == FLEXIBLEAUTO || st == FLEXIBLEAUTOEXT) {
+        // In the FLEXIBLE* modes, the ciphertext right after ModRaise is declared to carry the exact
+        // level-specific scaling factor (so that all subsequent operations stay on the precomputed
+        // scaling-factor chain), while the FBT scale bookkeeping above is done in terms of the nominal
+        // power-of-two scaling factor 2^p. The two ratios below convert between the conventions:
+        // - scaleEnc absorbs SF(raised level)/2^p so the values entering the Chebyshev interpolation
+        //   match the nominal convention exactly;
+        // - scaleDec absorbs 2^p/SF(final level) so the decoded RLWE output lands at the exact absolute
+        //   scale QPrime/POut regardless of the level-specific scaling factor at the output level.
+        double pow2p         = std::pow(2.0, static_cast<double>(cryptoParams->GetPlaintextModulus()));
+        uint32_t raisedLevel = (st == FLEXIBLEAUTOEXT) ? 1 : 0;
+        // the output of functional bootstrapping has 1 + lvlsAfterBoot towers remaining
+        uint32_t finalLevel = L0 - 1 - lvlsAfterBootSaved;
+        scaleEnc *= cryptoParams->GetScalingFactorReal(raisedLevel) / pow2p;
+        scaleDec *= pow2p / cryptoParams->GetScalingFactorReal(finalLevel);
+    }
+
+    L0 -= (st == FLEXIBLEAUTOEXT);
     uint32_t lEnc = L0 - levelBudget[0] - 1;
     uint32_t lDec = L0 - depthBT;
 
@@ -3162,15 +3187,38 @@ Ciphertext<DCRTPoly> FHECKKSRNS::EvalHomDecoding(ConstCiphertext<DCRTPoly>& ciph
 
     // Drop levels if needed
     auto cc = ciphertext->GetCryptoContext();
-    if (levelToReduce > 0)
-        cc->LevelReduceInPlace(ctxtEnc, nullptr, levelToReduce);
+    auto st = cryptoParams->GetScalingTechnique();
+    if (levelToReduce > 0) {
+        if (st == FIXEDMANUAL) {
+            cc->LevelReduceInPlace(ctxtEnc, nullptr, levelToReduce);
+        }
+        else if (st == FLEXIBLEAUTO || st == FLEXIBLEAUTOEXT) {
+            // In the FLEXIBLE* modes, towers cannot simply be dropped because the ciphertext has to stay
+            // on the chain of level-specific scaling factors. As in AdjustLevelsAndDepthInPlace, a single
+            // scalar multiplication adjusts the value to the scaling factor of the destination level, the
+            // remaining towers are dropped directly, and the destination scaling factor is set explicitly.
+            // Note that for a degree-2 input, EvalMultInPlace first rescales (consuming one tower).
+            uint32_t dstLevel = ctxtEnc->GetLevel() + levelToReduce;
+            uint32_t curLevel = ctxtEnc->GetLevel() + (ctxtEnc->GetNoiseScaleDeg() == 2);
+            cc->EvalMultInPlace(ctxtEnc, cryptoParams->GetScalingFactorRealBig(dstLevel) /
+                                             cryptoParams->GetScalingFactorRealBig(curLevel));
+            if (dstLevel > ctxtEnc->GetLevel())
+                cc->GetScheme()->LevelReduceInternalInPlace(ctxtEnc, dstLevel - ctxtEnc->GetLevel());
+            ctxtEnc->SetScalingFactor(cryptoParams->GetScalingFactorRealBig(dstLevel));
+        }
+        else {
+            // FIXEDAUTO uses the same scaling factor at every level, so towers can be dropped directly
+            // (the public LevelReduce is a no-op for the AUTO modes).
+            cc->GetScheme()->LevelReduceInternalInPlace(ctxtEnc, levelToReduce);
+        }
+    }
 
     //------------------------------------------------------------------------------
     // Running SlotsToCoeffs
     //------------------------------------------------------------------------------
 
     // In the case of FLEXIBLEAUTO, we need one extra tower
-    if (cryptoParams->GetScalingTechnique() != FIXEDMANUAL)
+    if (st != FIXEDMANUAL)
         cc->GetScheme()->ModReduceInternalInPlace(ctxtEnc, BASE_NUM_LEVELS_TO_DROP);
 
     // linear transform for decoding
@@ -3191,7 +3239,12 @@ Ciphertext<DCRTPoly> FHECKKSRNS::EvalHomDecoding(ConstCiphertext<DCRTPoly>& ciph
     if (postScaling > 1)
         cc->GetScheme()->MultByIntegerInPlace(ctxtDec, postScaling);
 
-    cc->ModReduceInPlace(ctxtDec);
+    // The public ModReduce is a no-op for the AUTO scaling techniques, so the internal rescaling is
+    // called explicitly to bring the result to noise degree 1 (the RLWE output convention).
+    if (st == FIXEDMANUAL)
+        cc->ModReduceInPlace(ctxtDec);
+    else
+        cc->GetScheme()->ModReduceInternalInPlace(ctxtDec, BASE_NUM_LEVELS_TO_DROP);
 
     // 64-bit only: No need to scale back the message to its original scale.
     return ctxtDec;
@@ -3202,12 +3255,22 @@ std::shared_ptr<seriesPowers<DCRTPoly>> FHECKKSRNS::EvalMVBPrecomputeInternal(
     ConstCiphertext<DCRTPoly>& ciphertext, const std::vector<VectorDataType>& coefficients, uint32_t digitBitSize,
     const BigInteger& initialScaling, size_t order) {
     const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersCKKSRNS>(ciphertext->GetCryptoParameters());
-    if (cryptoParams->GetScalingTechnique() == FLEXIBLEAUTO || cryptoParams->GetScalingTechnique() == FLEXIBLEAUTOEXT)
-        OPENFHE_THROW("CKKS Functional Bootstrapping is supported for FIXEDMANUAL and FIXEDAUTO methods only.");
     if (cryptoParams->GetKeySwitchTechnique() != HYBRID)
         OPENFHE_THROW("CKKS Bootstrapping is only supported for the Hybrid key switching method.");
 
-    const auto& paramsQ = cryptoParams->GetElementParams()->GetParams();
+    auto st               = cryptoParams->GetScalingTechnique();
+    const bool isFlexible = (st == FLEXIBLEAUTO || st == FLEXIBLEAUTOEXT);
+#if NATIVEINT == 128
+    if (isFlexible)
+        OPENFHE_THROW("128-bit CKKS Functional Bootstrapping is supported for FIXEDMANUAL and FIXEDAUTO methods only.");
+#endif
+
+    // For FLEXIBLEAUTOEXT the raised ciphertext does not include the extra modulus
+    auto elementParamsRaised = *(cryptoParams->GetElementParams());
+    if (st == FLEXIBLEAUTOEXT)
+        elementParamsRaised.PopLastParam();
+
+    const auto& paramsQ = elementParamsRaised.GetParams();
     uint32_t sizeQ      = paramsQ.size();
     std::vector<NativeInteger> moduli(sizeQ);
     std::vector<NativeInteger> roots(sizeQ);
@@ -3226,7 +3289,12 @@ std::shared_ptr<seriesPowers<DCRTPoly>> FHECKKSRNS::EvalMVBPrecomputeInternal(
     // because the message doesn't have to be scaled down.
     // Instead, we need to correct the encoding if it originates from a different ciphertext
     // (not typical CKKS).
-    double correction = cryptoParams->GetScalingFactorReal(0) / initialScaling.ConvertToDouble();
+    // For FLEXIBLE* the correction is expressed w.r.t. the nominal power-of-two scaling factor 2^p
+    // (the residual ratio between 2^p and the level-specific scaling factor is folded into the
+    // homomorphic encoding/decoding matrices in EvalFBTSetup).
+    double nominalSF  = (isFlexible) ? std::pow(2.0, static_cast<double>(cryptoParams->GetPlaintextModulus())) :
+                                       cryptoParams->GetScalingFactorReal(0);
+    double correction = nominalSF / initialScaling.ConvertToDouble();
 
     //------------------------------------------------------------------------------
     // RAISING THE MODULUS
@@ -3238,7 +3306,9 @@ std::shared_ptr<seriesPowers<DCRTPoly>> FHECKKSRNS::EvalMVBPrecomputeInternal(
 
     // If correction ~ 1, we should not do this adjustment and save a level
     // AA: make the check more granular (around 1.0000x?)
-    if (std::llround(correction) != 1.0)
+    // For FLEXIBLE* the correction is instead folded into the multiplication by 1/(k*N) after ModRaise,
+    // which does not consume an extra level.
+    if (!isFlexible && std::llround(correction) != 1.0)
         AdjustCiphertextFBT(raised, correction);
 
     uint32_t L0 = cryptoParams->GetElementParams()->GetParams().size();
@@ -3275,6 +3345,13 @@ std::shared_ptr<seriesPowers<DCRTPoly>> FHECKKSRNS::EvalMVBPrecomputeInternal(
         raised->SetLevel(L0 - ctxtDCRTs[0].GetNumOfElements());
     }
 
+    // In the FLEXIBLE* modes, declare the raised ciphertext to carry the exact scaling factor of its level,
+    // so all subsequent operations track the precomputed chain of level-specific scaling factors. The ratio
+    // between this scaling factor and the nominal 2^p is compensated in the homomorphic encoding matrix
+    // (see EvalFBTSetup).
+    if (isFlexible)
+        raised->SetScalingFactor(cryptoParams->GetScalingFactorReal(raised->GetLevel()));
+
 #ifdef BOOTSTRAPTIMING
     std::cerr << "\nNumber of levels at the beginning of bootstrapping: "
               << raised->GetElements()[0].GetNumOfElements() - 1 << std::endl;
@@ -3287,7 +3364,8 @@ std::shared_ptr<seriesPowers<DCRTPoly>> FHECKKSRNS::EvalMVBPrecomputeInternal(
     auto skd = cryptoParams->GetSecretKeyDist();
     double k = (skd == SPARSE_TERNARY || skd == SPARSE_ENCAPSULATED) ? 1.0 : K_UNIFORM;
 
-    cc->EvalMultInPlace(raised, 1.0 / (k * N));
+    // For FLEXIBLE* the initial-scaling correction is folded in here so no extra level is consumed.
+    cc->EvalMultInPlace(raised, ((isFlexible) ? correction : 1.0) / (k * N));
 
     // no linear transformations are needed for Chebyshev series as the range has been normalized to [-1,1]
     double coeffLowerBound = -1.0;
@@ -3483,10 +3561,12 @@ Ciphertext<DCRTPoly> FHECKKSRNS::EvalMVBNoDecodingInternal(const std::shared_ptr
                                                            uint32_t digitBitSize, size_t order) {
     const auto cryptoParams =
         std::dynamic_pointer_cast<CryptoParametersCKKSRNS>(ciphertexts->powersRe[0]->GetCryptoParameters());
-    if (cryptoParams->GetScalingTechnique() == FLEXIBLEAUTO || cryptoParams->GetScalingTechnique() == FLEXIBLEAUTOEXT)
-        OPENFHE_THROW("CKKS Functional Bootstrapping is supported for FIXEDMANUAL and FIXEDAUTO methods only.");
     if (cryptoParams->GetKeySwitchTechnique() != HYBRID)
         OPENFHE_THROW("CKKS Bootstrapping is only supported for the Hybrid key switching method.");
+#if NATIVEINT == 128
+    if (cryptoParams->GetScalingTechnique() == FLEXIBLEAUTO || cryptoParams->GetScalingTechnique() == FLEXIBLEAUTOEXT)
+        OPENFHE_THROW("128-bit CKKS Functional Bootstrapping is supported for FIXEDMANUAL and FIXEDAUTO methods only.");
+#endif
 
     auto cc        = ciphertexts->powersRe[0]->GetCryptoContext();
     uint32_t M4    = cc->GetCyclotomicOrder() / 4;

--- a/src/pke/lib/schemelet/rlwe-mp.cpp
+++ b/src/pke/lib/schemelet/rlwe-mp.cpp
@@ -31,6 +31,7 @@
 
 #include "schemebase/rlwe-cryptoparameters.h"
 #include "schemelet/rlwe-mp.h"
+#include "schemerns/rns-cryptoparameters.h"
 #include "cryptocontext.h"
 
 #include <stdint.h>
@@ -122,6 +123,10 @@ std::shared_ptr<ILDCRTParams<DCRTPoly::Integer>> SchemeletRLWEMP::GetElementPara
     const PrivateKey<DCRTPoly>& privateKey, uint32_t level) {
     const auto cryptoParams =
         std::dynamic_pointer_cast<CryptoParametersRLWE<DCRTPoly>>(privateKey->GetCryptoParameters());
+
+    const auto cryptoParamsRNS = std::dynamic_pointer_cast<CryptoParametersRNS>(privateKey->GetCryptoParameters());
+    if (cryptoParamsRNS != nullptr && cryptoParamsRNS->GetScalingTechnique() == FLEXIBLEAUTOEXT)
+        ++level;
 
     auto ep = std::make_shared<ILDCRTParams<DCRTPoly::Integer>>(*(cryptoParams->GetElementParams()));
     for (uint32_t i = 0; i < level; ++i)
@@ -261,6 +266,10 @@ Ciphertext<DCRTPoly> SchemeletRLWEMP::ConvertRLWEToCKKS(const CryptoContextImpl<
                                                         const std::vector<Poly>& coeffs,
                                                         const PublicKey<DCRTPoly>& pubKey, const BigInteger& Bigq,
                                                         uint32_t slots, uint32_t level) {
+    const auto cryptoParamsRNS = std::dynamic_pointer_cast<CryptoParametersRNS>(cc.GetCryptoParameters());
+    if (cryptoParamsRNS != nullptr && cryptoParamsRNS->GetScalingTechnique() == FLEXIBLEAUTOEXT)
+        ++level;
+
     std::vector<std::complex<double>> y(1);
     auto ptxt = cc.MakeCKKSPackedPlaintext(y, 1, level);
     ptxt->SetLength(slots);

--- a/src/pke/unittest/utckksrns/UnitTestFBT.cpp
+++ b/src/pke/unittest/utckksrns/UnitTestFBT.cpp
@@ -193,8 +193,10 @@ static auto testName = [](const testing::TestParamInfo<TEST_CASE_FBT>& test) {
 
 // clang-format off
 static std::vector<TEST_CASE_FBT> testCases = {
-// Functional Bootstrapping does not support NATIVE_SIZE == 128. Composite scaling, which serves that
-// purpose elsewhere in CKKS, is not supported here either (EvalFBTSetup rejects it), so the supported
+// Functional Bootstrapping does not support NATIVE_SIZE == 128: every case below fails there, for the
+// FIXED* modes as well, because the 128-bit scaling path that standard CKKS bootstrapping implements
+// (the correction factor) has no counterpart here. Composite scaling, which serves that purpose
+// elsewhere in CKKS, is not supported here either (EvalFBTSetup rejects it), so the supported
 // rescaling modes are FIXEDMANUAL, FIXEDAUTO, FLEXIBLEAUTO, and FLEXIBLEAUTOEXT on the 64-bit build.
 #if NATIVEINT != 128
 #ifndef BENCH
@@ -1463,9 +1465,10 @@ protected:
     }
 
     // Checks that invalid usage is rejected with an exception instead of silently corrupting results:
-    // 1) an oversized levelToReduce in EvalHomDecoding under FLEXIBLE*, and 2) a FLEXIBLEAUTOEXT input
-    // that still includes the extra modulus. EvalFBTSetup also rejects the scaling techniques it does
-    // not support, which is left to be covered when composite scaling is supported.
+    // 1) more levels requested after bootstrapping than the modulus chain has, 2) an oversized
+    // levelToReduce in EvalHomDecoding under FLEXIBLE*, and 3) a FLEXIBLEAUTOEXT input that still
+    // includes the extra modulus. EvalFBTSetup also rejects the scaling techniques it does not support,
+    // which is left to be covered when composite scaling is supported.
     void UnitTest_InvalidArgs(TEST_CASE_FBT t, const std::string& failmsg = std::string()) {
         try {
             bool flagSP       = (t.numSlots <= t.ringDim / 2);  // sparse packing
@@ -1509,6 +1512,15 @@ protected:
                 auto cc         = GenCryptoContext(parameters);
                 enableAll(cc);
                 auto keyPair = cc->KeyGen();
+
+                // more levels after bootstrapping than the chain provides is rejected at setup, rather
+                // than reading past the modulus vector and wrapping the level arithmetic
+                const std::vector<uint32_t> dim1{0, 0};
+                EXPECT_THROW(cc->EvalFBTSetup(coeffint, numSlotsCKKS, t.PInput, t.POutput, t.Bigq, keyPair.publicKey,
+                                              dim1, t.lvlb, depth + 1, 0, t.order),
+                             OpenFHEException)
+                    << failmsg << " oversized lvlsAfterBoot not rejected";
+
                 cc->EvalFBTSetup(coeffint, numSlotsCKKS, t.PInput, t.POutput, t.Bigq, keyPair.publicKey, {0, 0},
                                  t.lvlb, t.levelsAvailableAfterBootstrap, 0, t.order);
                 std::vector<double> y(numSlotsCKKS, 0.5);

--- a/src/pke/unittest/utckksrns/UnitTestFBT.cpp
+++ b/src/pke/unittest/utckksrns/UnitTestFBT.cpp
@@ -70,6 +70,8 @@ enum TEST_CASE_TYPE : int {
     FBT_CONSECLEV,
     FBT_MVB,
     FBT_NOISE,
+    FBT_MVB_REUSE,
+    FBT_INVALID,
 };
 
 static std::ostream& operator<<(std::ostream& os, const TEST_CASE_TYPE& type) {
@@ -89,6 +91,12 @@ static std::ostream& operator<<(std::ostream& os, const TEST_CASE_TYPE& type) {
             break;
         case FBT_NOISE:
             typeName = "FBT_NOISE";
+            break;
+        case FBT_MVB_REUSE:
+            typeName = "FBT_MVB_REUSE";
+            break;
+        case FBT_INVALID:
+            typeName = "FBT_INVALID";
             break;
         default:
             typeName = "UNKNOWN";
@@ -185,8 +193,9 @@ static auto testName = [](const testing::TestParamInfo<TEST_CASE_FBT>& test) {
 
 // clang-format off
 static std::vector<TEST_CASE_FBT> testCases = {
-// Functional Bootstrapping does not support NATIVE_SIZE == 128
-// For higher precision, consider using composite scaling instead
+// Functional Bootstrapping does not support NATIVE_SIZE == 128. Composite scaling, which serves that
+// purpose elsewhere in CKKS, is not supported here either (EvalFBTSetup rejects it), so the supported
+// rescaling modes are FIXEDMANUAL, FIXEDAUTO, FLEXIBLEAUTO, and FLEXIBLEAUTOEXT on the 64-bit build.
 #if NATIVEINT != 128
 #ifndef BENCH
     // TestCaseType, Desc, QBFVInit, PInput, POutput,  Q, Bigq, scaleTHI, scaleStepTHI, order,   numSlots, ringDim, lvlsAfterBoot, lvlsBeforeBoot, dnum, lvlsComp, lvlBudget, SecretKeyDist
@@ -262,6 +271,18 @@ static std::vector<TEST_CASE_FBT> testCases = {
     // and the test checks that the FLEXIBLE* technique yields smaller noise in the output RLWE ciphertext.
     {     FBT_NOISE, "501",      Q60,      2,       2, Q33, Q33,        1, SCALESTEPTHI,     1,   SLOTFULL,  RINGDM,     AFTERBOOT,     BEFOREBOOT,    3, LVLSCOMP,  LVLBDFLT, SPARSE_TERNARY, FLEXIBLEAUTO},
     {     FBT_NOISE, "502",      Q60,      2,       2, Q33, Q33,        1, SCALESTEPTHI,     1,   SLOTFULL,  RINGDM,     AFTERBOOT,     BEFOREBOOT,    3, LVLSCOMP,  LVLBDFLT, SPARSE_TERNARY, FLEXIBLEAUTOEXT},
+    // Multi-limb initial scaling: the RLWE ciphertext is imported with one level available before
+    // bootstrapping, so initialScaling in EvalFBT covers two RNS limbs (q0*q1) and must be
+    // corrected before the modulus raise.
+    {    FBT_ARBLUT, "601",      Q60,      2,       2, Q33, Q33,        1, SCALESTEPTHI,     1,   SLOTFULL,  RINGDM,     AFTERBOOT,              1,    3, LVLSCOMP,  LVLBDFLT, SPARSE_TERNARY},
+    {    FBT_ARBLUT, "602",      Q60,      2,       2, Q33, Q33,        1, SCALESTEPTHI,     1,   SLOTFULL,  RINGDM,     AFTERBOOT,              1,    3, LVLSCOMP,  LVLBDFLT, SPARSE_TERNARY, FLEXIBLEAUTO},
+    {    FBT_ARBLUT, "603",      Q60,      2,       2, Q33, Q33,        1, SCALESTEPTHI,     1,   SLOTFULL,  RINGDM,     AFTERBOOT,              1,    3, LVLSCOMP,  LVLBDFLT, SPARSE_TERNARY, FLEXIBLEAUTOEXT},
+    {    FBT_ARBLUT, "604",      Q60,      2,       2, Q33, Q33,        1, SCALESTEPTHI,     1,   SLOTFULL,  RINGDM,     AFTERBOOT,              1,    3, LVLSCOMP,  LVLBDFLT, SPARSE_TERNARY, FIXEDAUTO},
+    // Repeated LUT evaluation on the same precomputed powers (checks the precomputation is not
+    // corrupted in place) and rejection of invalid arguments.
+    { FBT_MVB_REUSE, "701",      Q60,      2,       4, Q35, Q35,        1, SCALESTEPTHI,     1,   SLOTFULL,  RINGDM,     AFTERBOOT,     BEFOREBOOT,    3, LVLSCOMP,  LVLBDFLT, SPARSE_TERNARY},
+    { FBT_MVB_REUSE, "702",      Q60,      2,       4, Q35, Q35,        1, SCALESTEPTHI,     1,   SLOTFULL,  RINGDM,     AFTERBOOT,     BEFOREBOOT,    3, LVLSCOMP,  LVLBDFLT, SPARSE_TERNARY, FLEXIBLEAUTO},
+    {   FBT_INVALID, "801",      Q60,      2,       2, Q33, Q33,        1, SCALESTEPTHI,     1,   SLOTFULL,  RINGDM,     AFTERBOOT,     BEFOREBOOT,    3, LVLSCOMP,  LVLBDFLT, SPARSE_TERNARY, FLEXIBLEAUTO},
 #else
     // TestCaseType, Desc, QBFVInit, PInput, POutput,  Q, Bigq, scaleTHI, scaleStepTHI, order, numSlots, ringDim, lvlsAfterBoot, lvlsBeforeBoot, dnum, lvlsComp, lvlBudget, SecretKeyDist
     {    FBT_ARBLUT, "01",      Q60,      2,       2, Q33, Q33,        1, SCALESTEPTHI,     1,  1 << 15, 1 << 15,     AFTERBOOT,     BEFOREBOOT,    3, LVLSCOMP,    {3, 3}, SPARSE_TERNARY},
@@ -413,9 +434,6 @@ protected:
             auto start = std::chrono::high_resolution_clock::now();
 #endif
             bool flagSP = (t.numSlots <= t.ringDim / 2);  // sparse packing
-            // for FLEXIBLEAUTOEXT, the cryptocontext has an extra modulus, so the RLWE ciphertext is
-            // imported one level deeper to keep a single tower
-            const uint32_t extOff = (t.scalTech == FLEXIBLEAUTOEXT) ? 1 : 0;
             // t.numSlots represents number of values to be encrypted in BFV. If same as ring dimension, CKKS slots is halved.
             auto numSlotsCKKS = flagSP ? t.numSlots : t.numSlots / 2;
 
@@ -502,7 +520,7 @@ protected:
 #endif
 
             auto ep = SchemeletRLWEMP::GetElementParams(keyPair.secretKey,
-                                                        depth + extOff - (t.levelsAvailableBeforeBootstrap > 0));
+                                                        depth - (t.levelsAvailableBeforeBootstrap > 0));
 
             auto ctxtBFV = SchemeletRLWEMP::EncryptCoeff(x, t.QBFVInit, t.PInput, keyPair.secretKey, ep);
 
@@ -515,7 +533,7 @@ protected:
             SchemeletRLWEMP::ModSwitch(ctxtBFV, t.Q, t.QBFVInit);
 
             auto ctxt = SchemeletRLWEMP::ConvertRLWEToCKKS(*cc, ctxtBFV, keyPair.publicKey, t.Bigq, numSlotsCKKS,
-                                                           depth + extOff - (t.levelsAvailableBeforeBootstrap > 0));
+                                                           depth - (t.levelsAvailableBeforeBootstrap > 0));
 
             Ciphertext<DCRTPoly> ctxtAfterFBT;
             if (binaryLUT)
@@ -572,9 +590,6 @@ protected:
             auto start = std::chrono::high_resolution_clock::now();
 #endif
             bool flagSP = (t.numSlots <= t.ringDim / 2);  // sparse packing
-            // for FLEXIBLEAUTOEXT, the cryptocontext has an extra modulus, so the RLWE ciphertext is
-            // imported one level deeper to keep a single tower
-            const uint32_t extOff = (t.scalTech == FLEXIBLEAUTOEXT) ? 1 : 0;
             // t.numSlots represents number of values to be encrypted in BFV. If same as ring dimension, CKKS slots is halved.
             auto numSlotsCKKS = flagSP ? t.numSlots : t.numSlots / 2;
 
@@ -677,7 +692,7 @@ protected:
 #endif
 
             auto ep = SchemeletRLWEMP::GetElementParams(keyPair.secretKey,
-                                                        depth + extOff - (t.levelsAvailableBeforeBootstrap > 0));
+                                                        depth - (t.levelsAvailableBeforeBootstrap > 0));
 
             auto ctxtBFV = SchemeletRLWEMP::EncryptCoeff(x, t.QBFVInit, t.PInput, keyPair.secretKey, ep);
 
@@ -724,7 +739,7 @@ protected:
 
                 auto ctxt =
                     SchemeletRLWEMP::ConvertRLWEToCKKS(*cc, encryptedDigit, keyPair.publicKey, t.Bigq, numSlotsCKKS,
-                                                       depth + extOff - (t.levelsAvailableBeforeBootstrap > 0));
+                                                       depth - (t.levelsAvailableBeforeBootstrap > 0));
 
                 // Bootstrap the digit.
                 Ciphertext<DCRTPoly> ctxtAfterFBT;
@@ -816,9 +831,6 @@ protected:
 #endif
             bool flagBR = (t.lvlb[0] != 1 || t.lvlb[1] != 1);
             bool flagSP = (t.numSlots <= t.ringDim / 2);  // sparse packing
-            // for FLEXIBLEAUTOEXT, the cryptocontext has an extra modulus, so the RLWE ciphertext is
-            // imported one level deeper to keep a single tower
-            const uint32_t extOff = (t.scalTech == FLEXIBLEAUTOEXT) ? 1 : 0;
 
             // t.numSlots represents number of values to be encrypted in BFV. If same as ring dimension, CKKS slots is halved.
             auto numSlotsCKKS = flagSP ? t.numSlots : t.numSlots / 2;
@@ -908,6 +920,9 @@ protected:
 
             auto mask_real = Fill<double>({1, 1, 1, 1, 0, 0, 0, 0}, t.numSlots);
 
+            // The mask level is counted on the full modulus chain, which has an extra modulus for FLEXIBLEAUTOEXT
+            const uint32_t extOff = (t.scalTech == FLEXIBLEAUTOEXT) ? 1 : 0;
+
             // Note that the corresponding plaintext mask for full packing can be just real, as real times complex multiplies both real and imaginary parts
             Plaintext ptxt_mask = cc->MakeCKKSPackedPlaintext(
                 Fill<double>({1, 1, 1, 1, 0, 0, 0, 0}, numSlotsCKKS), 1,
@@ -915,7 +930,7 @@ protected:
                 numSlotsCKKS);
 
             auto ep = SchemeletRLWEMP::GetElementParams(keyPair.secretKey,
-                                                        depth + extOff - (t.levelsAvailableBeforeBootstrap > 0));
+                                                        depth - (t.levelsAvailableBeforeBootstrap > 0));
 
             // Set bitReverse true to be able to perform correct rotations in CKKS
             auto ctxtBFV = SchemeletRLWEMP::EncryptCoeff(x, t.QBFVInit, t.PInput, keyPair.secretKey, ep, flagBR);
@@ -929,7 +944,7 @@ protected:
             SchemeletRLWEMP::ModSwitch(ctxtBFV, t.Q, t.QBFVInit);
 
             auto ctxt = SchemeletRLWEMP::ConvertRLWEToCKKS(*cc, ctxtBFV, keyPair.publicKey, t.Bigq, numSlotsCKKS,
-                                                           depth + extOff - (t.levelsAvailableBeforeBootstrap > 0));
+                                                           depth - (t.levelsAvailableBeforeBootstrap > 0));
 
             // Apply LUT and remain in slots encodings.
             Ciphertext<DCRTPoly> ctxtAfterFBT;
@@ -952,7 +967,7 @@ protected:
 
             // Apply a subsequent LUT
             ctxt = SchemeletRLWEMP::ConvertRLWEToCKKS(*cc, polys1, keyPair.publicKey, t.Bigq, numSlotsCKKS,
-                                                      depth + extOff - (t.levelsAvailableBeforeBootstrap > 0));
+                                                      depth - (t.levelsAvailableBeforeBootstrap > 0));
 
             if (binaryLUT)
                 ctxtAfterFBT = cc->EvalFBT(ctxt, coeffint, t.PInput.GetMSB() - 1, ep->GetModulus(), t.scaleTHI,
@@ -1034,9 +1049,6 @@ protected:
             auto start = std::chrono::high_resolution_clock::now();
 #endif
             bool flagSP = (t.numSlots <= t.ringDim / 2);  // sparse packing
-            // for FLEXIBLEAUTOEXT, the cryptocontext has an extra modulus, so the RLWE ciphertext is
-            // imported one level deeper to keep a single tower
-            const uint32_t extOff = (t.scalTech == FLEXIBLEAUTOEXT) ? 1 : 0;
             // t.numSlots represents number of values to be encrypted in BFV. If same as ring dimension, CKKS slots is halved.
             auto numSlotsCKKS = flagSP ? t.numSlots : t.numSlots / 2;
 
@@ -1132,7 +1144,7 @@ protected:
 #endif
 
             auto ep = SchemeletRLWEMP::GetElementParams(keyPair.secretKey,
-                                                        depth + extOff - (t.levelsAvailableBeforeBootstrap > 0));
+                                                        depth - (t.levelsAvailableBeforeBootstrap > 0));
 
             auto ctxtBFV = SchemeletRLWEMP::EncryptCoeff(x, t.QBFVInit, t.PInput, keyPair.secretKey, ep);
 
@@ -1145,7 +1157,7 @@ protected:
             SchemeletRLWEMP::ModSwitch(ctxtBFV, t.Q, t.QBFVInit);
 
             auto ctxt = SchemeletRLWEMP::ConvertRLWEToCKKS(*cc, ctxtBFV, keyPair.publicKey, t.Bigq, numSlotsCKKS,
-                                                           depth + extOff - (t.levelsAvailableBeforeBootstrap > 0));
+                                                           depth - (t.levelsAvailableBeforeBootstrap > 0));
 
             std::vector<Ciphertext<DCRTPoly>> complexExp;
             Ciphertext<DCRTPoly> ctxtAfterFBT1, ctxtAfterFBT2;
@@ -1239,9 +1251,8 @@ protected:
     void UnitTest_Noise(TEST_CASE_FBT t, const std::string& failmsg = std::string()) {
         try {
             auto runOnce = [&t](ScalingTechnique scalTech, int64_t& maxErr) -> double {
-                bool flagSP           = (t.numSlots <= t.ringDim / 2);  // sparse packing
-                const uint32_t extOff = (scalTech == FLEXIBLEAUTOEXT) ? 1 : 0;
-                auto numSlotsCKKS     = flagSP ? t.numSlots : t.numSlots / 2;
+                bool flagSP       = (t.numSlots <= t.ringDim / 2);  // sparse packing
+                auto numSlotsCKKS = flagSP ? t.numSlots : t.numSlots / 2;
 
                 auto a = t.PInput.ConvertToInt<int64_t>();
                 auto b = t.POutput.ConvertToInt<int64_t>();
@@ -1306,14 +1317,14 @@ protected:
                 cc->EvalBootstrapKeyGen(keyPair.secretKey, numSlotsCKKS);
                 cc->EvalMultKeyGen(keyPair.secretKey);
 
-                auto ep = SchemeletRLWEMP::GetElementParams(keyPair.secretKey, depth + extOff);
+                auto ep = SchemeletRLWEMP::GetElementParams(keyPair.secretKey, depth);
 
                 auto ctxtBFV = SchemeletRLWEMP::EncryptCoeff(x, t.QBFVInit, t.PInput, keyPair.secretKey, ep);
 
                 SchemeletRLWEMP::ModSwitch(ctxtBFV, t.Q, t.QBFVInit);
 
                 auto ctxt = SchemeletRLWEMP::ConvertRLWEToCKKS(*cc, ctxtBFV, keyPair.publicKey, t.Bigq, numSlotsCKKS,
-                                                               depth + extOff);
+                                                               depth);
 
                 Ciphertext<DCRTPoly> ctxtAfterFBT;
                 if (binaryLUT)
@@ -1366,6 +1377,174 @@ protected:
             UNIT_TEST_HANDLE_ALL_EXCEPTIONS;
         }
     }
+
+    // Evaluates the same binary LUT twice on the same precomputed powers and checks that both results
+    // are correct, so the second evaluation detects any in-place corruption of the shared precomputation.
+    // The LUT values f(0) = 2, f(1) = 1 give the coefficients {1, 1}, for which the evaluation performs
+    // an in-place multiplication and addition (coefficients {c, -1}, as in UnitTest_MVB, take a
+    // different, non-mutating path).
+    void UnitTest_MVBReuse(TEST_CASE_FBT t, const std::string& failmsg = std::string()) {
+        try {
+            bool flagSP       = (t.numSlots <= t.ringDim / 2);  // sparse packing
+            auto numSlotsCKKS = flagSP ? t.numSlots : t.numSlots / 2;
+
+            auto f = [](int64_t x) -> int64_t {
+                return 2 - (x % 2);
+            };
+            std::vector<int64_t> coeffint = {f(1), f(0) - f(1)};
+
+            std::vector<int64_t> x = {1, 0, 1, 1, 0, 1, 0, 0};
+            if (x.size() < t.numSlots)
+                x = Fill<int64_t>(x, t.numSlots);
+
+            const uint32_t dcrtBits = t.Bigq.GetMSB() - 1;
+            CCParams<CryptoContextCKKSRNS> parameters;
+            parameters.SetSecretKeyDist(t.skd);
+            parameters.SetSecurityLevel(HEStd_NotSet);
+            parameters.SetScalingModSize(dcrtBits);
+            parameters.SetScalingTechnique(t.scalTech);
+            parameters.SetFirstModSize(dcrtBits);
+            parameters.SetNumLargeDigits(t.dnum);
+            parameters.SetBatchSize(numSlotsCKKS);
+            parameters.SetRingDim(t.ringDim);
+            uint32_t depth = t.levelsAvailableAfterBootstrap +
+                             FHECKKSRNS::GetFBTDepth(t.lvlb, coeffint, t.PInput, t.order, t.skd);
+            parameters.SetMultiplicativeDepth(depth);
+
+            auto cc = GenCryptoContext(parameters);
+            cc->Enable(PKE);
+            cc->Enable(KEYSWITCH);
+            cc->Enable(LEVELEDSHE);
+            cc->Enable(ADVANCEDSHE);
+            cc->Enable(FHE);
+
+            auto keyPair = cc->KeyGen();
+
+            cc->EvalFBTSetup(coeffint, numSlotsCKKS, t.PInput, t.POutput, t.Bigq, keyPair.publicKey, {0, 0}, t.lvlb,
+                             t.levelsAvailableAfterBootstrap, 0, t.order);
+            cc->EvalBootstrapKeyGen(keyPair.secretKey, numSlotsCKKS);
+            cc->EvalMultKeyGen(keyPair.secretKey);
+
+            auto ep      = SchemeletRLWEMP::GetElementParams(keyPair.secretKey, depth);
+            auto ctxtBFV = SchemeletRLWEMP::EncryptCoeff(x, t.QBFVInit, t.PInput, keyPair.secretKey, ep);
+            SchemeletRLWEMP::ModSwitch(ctxtBFV, t.Q, t.QBFVInit);
+            auto ctxt =
+                SchemeletRLWEMP::ConvertRLWEToCKKS(*cc, ctxtBFV, keyPair.publicKey, t.Bigq, numSlotsCKKS, depth);
+
+            auto powers = cc->EvalMVBPrecompute(ctxt, coeffint, t.PInput.GetMSB() - 1, ep->GetModulus(), t.order);
+
+            auto exact(x);
+            std::transform(x.begin(), x.end(), exact.begin(), f);
+
+            for (uint32_t run = 1; run <= 2; ++run) {
+                auto ctxtAfterFBT = cc->EvalMVB(powers, coeffint, t.PInput.GetMSB() - 1, t.scaleTHI, 0, t.order);
+                auto polys        = SchemeletRLWEMP::ConvertCKKSToRLWE(ctxtAfterFBT, t.Q);
+                auto computed     = SchemeletRLWEMP::DecryptCoeff(polys, t.Q, t.POutput, keyPair.secretKey, ep,
+                                                                  numSlotsCKKS, t.numSlots);
+
+                std::vector<int64_t> err(exact.size());
+                std::transform(exact.begin(), exact.end(), computed.begin(), err.begin(), std::minus<int64_t>());
+                std::transform(err.begin(), err.end(), err.begin(),
+                               [&](int64_t elem) { return (std::abs(elem)) % (t.POutput.ConvertToInt()); });
+                auto max_error_it = std::max_element(err.begin(), err.end());
+                checkEquality((*max_error_it), static_cast<int64_t>(0), 0.0001,
+                              failmsg + " LUT evaluation " + std::to_string(run) + " on the reused precomputation fails");
+            }
+
+            cc->ClearStaticMapsAndVectors();
+        }
+        catch (std::exception& e) {
+            std::cerr << "Exception thrown from " << __func__ << "(): " << e.what() << std::endl;
+            EXPECT_TRUE(0 == 1) << failmsg;
+        }
+        catch (...) {
+            UNIT_TEST_HANDLE_ALL_EXCEPTIONS;
+        }
+    }
+
+    // Checks that invalid usage is rejected with an exception instead of silently corrupting results:
+    // 1) an oversized levelToReduce in EvalHomDecoding under FLEXIBLE*, and 2) a FLEXIBLEAUTOEXT input
+    // that still includes the extra modulus. EvalFBTSetup also rejects the scaling techniques it does
+    // not support, which is left to be covered when composite scaling is supported.
+    void UnitTest_InvalidArgs(TEST_CASE_FBT t, const std::string& failmsg = std::string()) {
+        try {
+            bool flagSP       = (t.numSlots <= t.ringDim / 2);  // sparse packing
+            auto numSlotsCKKS = flagSP ? t.numSlots : t.numSlots / 2;
+
+            auto a = t.PInput.ConvertToInt<int64_t>();
+            auto b = t.POutput.ConvertToInt<int64_t>();
+            auto f = [a, b](int64_t x) -> int64_t {
+                return (x % a - a / 2) % b;
+            };
+            std::vector<int64_t> coeffint = {f(1), f(0) - f(1)};
+
+            const uint32_t dcrtBits = t.Bigq.GetMSB() - 1;
+            uint32_t depth          = t.levelsAvailableAfterBootstrap +
+                             FHECKKSRNS::GetFBTDepth(t.lvlb, coeffint, t.PInput, t.order, t.skd);
+
+            auto makeParams = [&](ScalingTechnique st) {
+                CCParams<CryptoContextCKKSRNS> parameters;
+                parameters.SetSecretKeyDist(t.skd);
+                parameters.SetSecurityLevel(HEStd_NotSet);
+                parameters.SetScalingModSize(dcrtBits);
+                parameters.SetScalingTechnique(st);
+                parameters.SetFirstModSize(dcrtBits);
+                parameters.SetNumLargeDigits(t.dnum);
+                parameters.SetBatchSize(numSlotsCKKS);
+                parameters.SetRingDim(t.ringDim);
+                parameters.SetMultiplicativeDepth(depth);
+                return parameters;
+            };
+            auto enableAll = [](CryptoContext<DCRTPoly>& cc) {
+                cc->Enable(PKE);
+                cc->Enable(KEYSWITCH);
+                cc->Enable(LEVELEDSHE);
+                cc->Enable(ADVANCEDSHE);
+                cc->Enable(FHE);
+            };
+
+            {
+                // an oversized levelToReduce under FLEXIBLE* is rejected instead of silently zeroing the result
+                auto parameters = makeParams(FLEXIBLEAUTO);
+                auto cc         = GenCryptoContext(parameters);
+                enableAll(cc);
+                auto keyPair = cc->KeyGen();
+                cc->EvalFBTSetup(coeffint, numSlotsCKKS, t.PInput, t.POutput, t.Bigq, keyPair.publicKey, {0, 0},
+                                 t.lvlb, t.levelsAvailableAfterBootstrap, 0, t.order);
+                std::vector<double> y(numSlotsCKKS, 0.5);
+                auto ctxt = cc->Encrypt(keyPair.publicKey, cc->MakeCKKSPackedPlaintext(y));
+                EXPECT_THROW(cc->EvalHomDecoding(ctxt, 1, depth), OpenFHEException)
+                    << failmsg << " oversized levelToReduce not rejected";
+                cc->ClearStaticMapsAndVectors();
+            }
+
+            {
+                // a FLEXIBLEAUTOEXT input that includes the extra modulus is rejected
+                auto parameters = makeParams(FLEXIBLEAUTOEXT);
+                auto cc         = GenCryptoContext(parameters);
+                enableAll(cc);
+                auto keyPair = cc->KeyGen();
+                cc->EvalFBTSetup(coeffint, numSlotsCKKS, t.PInput, t.POutput, t.Bigq, keyPair.publicKey, {0, 0},
+                                 t.lvlb, t.levelsAvailableAfterBootstrap, 0, t.order);
+                cc->EvalBootstrapKeyGen(keyPair.secretKey, numSlotsCKKS);
+                cc->EvalMultKeyGen(keyPair.secretKey);
+                std::vector<double> y(numSlotsCKKS, 0.5);
+                // a level-0 ciphertext still includes the FLEXIBLEAUTOEXT extra modulus
+                auto ctxt = cc->Encrypt(keyPair.publicKey, cc->MakeCKKSPackedPlaintext(y));
+                EXPECT_THROW(cc->EvalFBT(ctxt, coeffint, t.PInput.GetMSB() - 1, t.Bigq, t.scaleTHI, 0, t.order),
+                             OpenFHEException)
+                    << failmsg << " FLEXIBLEAUTOEXT level-0 input not rejected";
+                cc->ClearStaticMapsAndVectors();
+            }
+        }
+        catch (std::exception& e) {
+            std::cerr << "Exception thrown from " << __func__ << "(): " << e.what() << std::endl;
+            EXPECT_TRUE(0 == 1) << failmsg;
+        }
+        catch (...) {
+            UNIT_TEST_HANDLE_ALL_EXCEPTIONS;
+        }
+    }
 };
 
 // ===========================================================================================================
@@ -1388,6 +1567,12 @@ TEST_P(UTCKKSRNS_FBT, CKKSRNS) {
             break;
         case FBT_NOISE:
             UnitTest_Noise(test, test.buildTestName());
+            break;
+        case FBT_MVB_REUSE:
+            UnitTest_MVBReuse(test, test.buildTestName());
+            break;
+        case FBT_INVALID:
+            UnitTest_InvalidArgs(test, test.buildTestName());
             break;
         default:
             break;

--- a/src/pke/unittest/utckksrns/UnitTestFBT.cpp
+++ b/src/pke/unittest/utckksrns/UnitTestFBT.cpp
@@ -43,11 +43,17 @@
 #include "UnitTestUtils.h"
 #include "utils/debug.h"
 
+#include <algorithm>
 #include <chrono>
 #include <complex>
+#include <functional>
+#include <iostream>
 #include <iterator>
+#include <memory>
 #include <numeric>
 #include <ostream>
+#include <string>
+#include <utility>
 #include <vector>
 
 // Define BENCH below to enable more fine-grained benchmarking.
@@ -63,6 +69,7 @@ enum TEST_CASE_TYPE : int {
     FBT_SIGNDIGIT,
     FBT_CONSECLEV,
     FBT_MVB,
+    FBT_NOISE,
 };
 
 static std::ostream& operator<<(std::ostream& os, const TEST_CASE_TYPE& type) {
@@ -80,11 +87,29 @@ static std::ostream& operator<<(std::ostream& os, const TEST_CASE_TYPE& type) {
         case FBT_MVB:
             typeName = "FBT_MVB";
             break;
+        case FBT_NOISE:
+            typeName = "FBT_NOISE";
+            break;
         default:
             typeName = "UNKNOWN";
             break;
     }
     return os << typeName;
+}
+
+static std::string ScalTechName(ScalingTechnique st) {
+    switch (st) {
+        case FIXEDMANUAL:
+            return "FIXEDMANUAL";
+        case FIXEDAUTO:
+            return "FIXEDAUTO";
+        case FLEXIBLEAUTO:
+            return "FLEXIBLEAUTO";
+        case FLEXIBLEAUTOEXT:
+            return "FLEXIBLEAUTOEXT";
+        default:
+            return "UNKNOWN";
+    }
 }
 
 struct TEST_CASE_FBT {
@@ -107,10 +132,12 @@ struct TEST_CASE_FBT {
     uint32_t levelsComputation;
     std::vector<uint32_t> lvlb;
     SecretKeyDist skd;
+    // scaling technique used for the CKKS cryptocontext; FIXEDMANUAL by default
+    ScalingTechnique scalTech = FIXEDMANUAL;
 
     std::string buildTestName() const {
         std::stringstream ss;
-        ss << testCaseType << "_" << description;
+        ss << testCaseType << "_" << description << "_" << ScalTechName(scalTech);
         return ss.str();
     }
 };
@@ -212,6 +239,29 @@ static std::vector<TEST_CASE_FBT> testCases = {
     {       FBT_MVB, "122",      Q60, PINPUT,  PINPUT, Q48, Q48, SCALETHI, SCALESTEPTHI,     1,   SLOTFULL,  RINGDM,     AFTERBOOT,     BEFOREBOOT,    3,        1,  LVLBDFLT, SPARSE_ENCAPSULATED},
     {       FBT_MVB, "123",      Q60,      2,       2, Q35, Q35,        1, SCALESTEPTHI,     1, SLOTSPARSE,  RINGDM,     AFTERBOOT,     BEFOREBOOT,    3,        1,  LVLBDFLT, SPARSE_ENCAPSULATED},
     {       FBT_MVB, "124",      Q60, PINPUT,  PINPUT, Q48, Q48, SCALETHI, SCALESTEPTHI,     1, SLOTSPARSE,  RINGDM,     AFTERBOOT,     BEFOREBOOT,    3,        1,  LVLBDFLT, SPARSE_ENCAPSULATED},
+    // TestCaseType, Desc, QBFVInit, PInput, POutput,  Q, Bigq, scaleTHI, scaleStepTHI, order,   numSlots, ringDim, lvlsAfterBoot, lvlsBeforeBoot, dnum, lvlsComp, lvlBudget, SecretKeyDist, ScalingTechnique
+    {    FBT_ARBLUT, "201",      Q60,      2,       2, Q33, Q33,        1, SCALESTEPTHI,     1,   SLOTFULL,  RINGDM,     AFTERBOOT,     BEFOREBOOT,    3, LVLSCOMP,  LVLBDFLT, SPARSE_TERNARY, FIXEDAUTO},
+    {    FBT_ARBLUT, "202",      Q60, PINPUT, POUTPUT, Q47, Q47, SCALETHI, SCALESTEPTHI,     1,   SLOTFULL,  RINGDM,     AFTERBOOT,     BEFOREBOOT,    3, LVLSCOMP,  LVLBDFLT, SPARSE_TERNARY, FIXEDAUTO},
+    {    FBT_ARBLUT, "203",      Q60, PINPUT, POUTPUT, Q47, Q47, SCALETHI, SCALESTEPTHI,     2, SLOTSPARSE,  RINGDM,     AFTERBOOT,     BEFOREBOOT,    3, LVLSCOMP,  LVLBDFLT, SPARSE_ENCAPSULATED, FIXEDAUTO},
+    { FBT_SIGNDIGIT, "204",      Q71,    Q21,       2, Q56, Q36,        1,            1,     1,   SLOTFULL,  RINGDM,     AFTERBOOT,     BEFOREBOOT,    3, LVLSCOMP,  LVLBDFLT, SPARSE_TERNARY, FIXEDAUTO},
+    { FBT_CONSECLEV, "205",      Q60, PINPUT,  PINPUT, Q48, Q48, SCALETHI, SCALESTEPTHI,     1,   SLOTFULL,  RINGDM,     AFTERBOOT,     BEFOREBOOT,    3,        1,  LVLBDFLT, SPARSE_TERNARY, FIXEDAUTO},
+    {       FBT_MVB, "206",      Q60, PINPUT,  PINPUT, Q48, Q48, SCALETHI, SCALESTEPTHI,     1, SLOTSPARSE,  RINGDM,     AFTERBOOT,     BEFOREBOOT,    3,        1,  LVLBDFLT, SPARSE_TERNARY, FIXEDAUTO},
+    {    FBT_ARBLUT, "301",      Q60,      2,       2, Q33, Q33,        1, SCALESTEPTHI,     1,   SLOTFULL,  RINGDM,     AFTERBOOT,     BEFOREBOOT,    3, LVLSCOMP,  LVLBDFLT, SPARSE_TERNARY, FLEXIBLEAUTO},
+    {    FBT_ARBLUT, "302",      Q60, PINPUT, POUTPUT, Q47, Q47, SCALETHI, SCALESTEPTHI,     1,   SLOTFULL,  RINGDM,     AFTERBOOT,     BEFOREBOOT,    3, LVLSCOMP,  LVLBDFLT, SPARSE_TERNARY, FLEXIBLEAUTO},
+    {    FBT_ARBLUT, "303",      Q60, PINPUT, POUTPUT, Q47, Q47, SCALETHI, SCALESTEPTHI,     2, SLOTSPARSE,  RINGDM,     AFTERBOOT,     BEFOREBOOT,    3, LVLSCOMP,  LVLBDFLT, SPARSE_ENCAPSULATED, FLEXIBLEAUTO},
+    { FBT_SIGNDIGIT, "304",      Q71,    Q21,       2, Q56, Q36,        1,            1,     1,   SLOTFULL,  RINGDM,     AFTERBOOT,     BEFOREBOOT,    3, LVLSCOMP,  LVLBDFLT, SPARSE_TERNARY, FLEXIBLEAUTO},
+    { FBT_CONSECLEV, "305",      Q60, PINPUT,  PINPUT, Q48, Q48, SCALETHI, SCALESTEPTHI,     1,   SLOTFULL,  RINGDM,     AFTERBOOT,     BEFOREBOOT,    3,        1,  LVLBDFLT, SPARSE_TERNARY, FLEXIBLEAUTO},
+    {       FBT_MVB, "306",      Q60, PINPUT,  PINPUT, Q48, Q48, SCALETHI, SCALESTEPTHI,     1, SLOTSPARSE,  RINGDM,     AFTERBOOT,     BEFOREBOOT,    3,        1,  LVLBDFLT, SPARSE_TERNARY, FLEXIBLEAUTO},
+    {    FBT_ARBLUT, "401",      Q60,      2,       2, Q33, Q33,        1, SCALESTEPTHI,     1,   SLOTFULL,  RINGDM,     AFTERBOOT,     BEFOREBOOT,    3, LVLSCOMP,  LVLBDFLT, SPARSE_TERNARY, FLEXIBLEAUTOEXT},
+    {    FBT_ARBLUT, "402",      Q60, PINPUT, POUTPUT, Q47, Q47, SCALETHI, SCALESTEPTHI,     1,   SLOTFULL,  RINGDM,     AFTERBOOT,     BEFOREBOOT,    3, LVLSCOMP,  LVLBDFLT, SPARSE_TERNARY, FLEXIBLEAUTOEXT},
+    {    FBT_ARBLUT, "403",      Q60, PINPUT, POUTPUT, Q47, Q47, SCALETHI, SCALESTEPTHI,     2, SLOTSPARSE,  RINGDM,     AFTERBOOT,     BEFOREBOOT,    3, LVLSCOMP,  LVLBDFLT, SPARSE_ENCAPSULATED, FLEXIBLEAUTOEXT},
+    { FBT_SIGNDIGIT, "404",      Q71,    Q21,       2, Q56, Q36,        1,            1,     1,   SLOTFULL,  RINGDM,     AFTERBOOT,     BEFOREBOOT,    3, LVLSCOMP,  LVLBDFLT, SPARSE_TERNARY, FLEXIBLEAUTOEXT},
+    { FBT_CONSECLEV, "405",      Q60, PINPUT,  PINPUT, Q48, Q48, SCALETHI, SCALESTEPTHI,     1,   SLOTFULL,  RINGDM,     AFTERBOOT,     BEFOREBOOT,    3,        1,  LVLBDFLT, SPARSE_TERNARY, FLEXIBLEAUTOEXT},
+    {       FBT_MVB, "406",      Q60, PINPUT,  PINPUT, Q48, Q48, SCALETHI, SCALESTEPTHI,     1, SLOTSPARSE,  RINGDM,     AFTERBOOT,     BEFOREBOOT,    3,        1,  LVLBDFLT, SPARSE_TERNARY, FLEXIBLEAUTOEXT},
+    // Noise-comparison tests: the same LUT is evaluated with FIXEDMANUAL and with the scaling technique below,
+    // and the test checks that the FLEXIBLE* technique yields smaller noise in the output RLWE ciphertext.
+    {     FBT_NOISE, "501",      Q60,      2,       2, Q33, Q33,        1, SCALESTEPTHI,     1,   SLOTFULL,  RINGDM,     AFTERBOOT,     BEFOREBOOT,    3, LVLSCOMP,  LVLBDFLT, SPARSE_TERNARY, FLEXIBLEAUTO},
+    {     FBT_NOISE, "502",      Q60,      2,       2, Q33, Q33,        1, SCALESTEPTHI,     1,   SLOTFULL,  RINGDM,     AFTERBOOT,     BEFOREBOOT,    3, LVLSCOMP,  LVLBDFLT, SPARSE_TERNARY, FLEXIBLEAUTOEXT},
 #else
     // TestCaseType, Desc, QBFVInit, PInput, POutput,  Q, Bigq, scaleTHI, scaleStepTHI, order, numSlots, ringDim, lvlsAfterBoot, lvlsBeforeBoot, dnum, lvlsComp, lvlBudget, SecretKeyDist
     {    FBT_ARBLUT, "01",      Q60,      2,       2, Q33, Q33,        1, SCALESTEPTHI,     1,  1 << 15, 1 << 15,     AFTERBOOT,     BEFOREBOOT,    3, LVLSCOMP,    {3, 3}, SPARSE_TERNARY},
@@ -286,6 +336,66 @@ static std::vector<TEST_CASE_FBT> testCases = {
 };
 // clang-format on
 
+// Measures the maximum noise (in bits) in the message coefficients of an RLWE ciphertext encrypting
+// delta*m for delta = Q/p. It follows SchemeletRLWEMP::DecryptCoeff, but instead of rounding to the
+// nearest multiple of delta, it returns the centered residual modulo delta (the rounding error).
+static double MeasureNoiseBits(const std::vector<Poly>& input, const BigInteger& Q, const BigInteger& p,
+                               const PrivateKey<DCRTPoly>& privateKey,
+                               const std::shared_ptr<ILDCRTParams<DCRTPoly::Integer>>& ep, uint32_t numSlots,
+                               uint32_t length) {
+    const auto& bigQPrime = ep->GetModulus();
+
+    Poly bPoly = input[0];
+    Poly aPoly = input[1];
+    if (Q < bigQPrime) {
+        bPoly.SwitchModulus(bigQPrime, 1, 0, 0);
+        bPoly = bPoly.MultiplyAndRound(bigQPrime, Q);
+        aPoly.SwitchModulus(bigQPrime, 1, 0, 0);
+        aPoly = aPoly.MultiplyAndRound(bigQPrime, Q);
+    }
+    else {
+        bPoly = bPoly.MultiplyAndRound(bigQPrime, Q);
+        bPoly.SwitchModulus(bigQPrime, 1, 0, 0);
+        aPoly = aPoly.MultiplyAndRound(bigQPrime, Q);
+        aPoly.SwitchModulus(bigQPrime, 1, 0, 0);
+    }
+
+    std::vector<DCRTPoly> ba{DCRTPoly(bPoly, ep), DCRTPoly(aPoly, ep)};
+    ba[0].SetFormat(Format::EVALUATION);
+    ba[1].SetFormat(Format::EVALUATION);
+
+    auto scopy(privateKey->GetPrivateElement());
+    scopy.DropLastElements(scopy.GetParams()->GetParams().size() - ep->GetParams().size());
+
+    auto m = ba[0] + ba[1] * scopy;
+    m.SetFormat(Format::COEFFICIENT);
+    auto mPoly = m.CRTInterpolate();
+
+    if (Q < bigQPrime) {
+        mPoly = mPoly.MultiplyAndRound(Q, bigQPrime);
+        mPoly.SwitchModulus(Q, 1, 0, 0);
+    }
+    else {
+        mPoly.SwitchModulus(Q, 1, 0, 0);
+        mPoly = mPoly.MultiplyAndRound(Q, bigQPrime);
+    }
+
+    BigInteger delta = Q / p;
+    BigInteger half  = delta >> 1;
+    uint32_t gap     = mPoly.GetLength() / (2 * numSlots);
+    gap              = (gap == 0) ? 1 : gap;
+
+    BigInteger maxNoise(0);
+    for (uint32_t i = 0, idx = 0; i < length; ++i, idx += gap) {
+        BigInteger r = mPoly[idx].Mod(delta);
+        if (r > half)
+            r = delta - r;
+        if (r > maxNoise)
+            maxNoise = r;
+    }
+    return std::log2(maxNoise.ConvertToDouble() + 1);
+}
+
 class UTCKKSRNS_FBT : public ::testing::TestWithParam<TEST_CASE_FBT> {
 protected:
     void SetUp() {
@@ -303,6 +413,9 @@ protected:
             auto start = std::chrono::high_resolution_clock::now();
 #endif
             bool flagSP = (t.numSlots <= t.ringDim / 2);  // sparse packing
+            // for FLEXIBLEAUTOEXT, the cryptocontext has an extra modulus, so the RLWE ciphertext is
+            // imported one level deeper to keep a single tower
+            const uint32_t extOff = (t.scalTech == FLEXIBLEAUTOEXT) ? 1 : 0;
             // t.numSlots represents number of values to be encrypted in BFV. If same as ring dimension, CKKS slots is halved.
             auto numSlotsCKKS = flagSP ? t.numSlots : t.numSlots / 2;
 
@@ -337,7 +450,7 @@ protected:
             parameters.SetSecretKeyDist(t.skd);
             parameters.SetSecurityLevel(HEStd_NotSet);
             parameters.SetScalingModSize(dcrtBits);
-            parameters.SetScalingTechnique(FIXEDMANUAL);
+            parameters.SetScalingTechnique(t.scalTech);
             parameters.SetFirstModSize(dcrtBits);
             parameters.SetNumLargeDigits(t.dnum);
             parameters.SetBatchSize(numSlotsCKKS);
@@ -388,8 +501,8 @@ protected:
             start = std::chrono::high_resolution_clock::now();
 #endif
 
-            auto ep =
-                SchemeletRLWEMP::GetElementParams(keyPair.secretKey, depth - (t.levelsAvailableBeforeBootstrap > 0));
+            auto ep = SchemeletRLWEMP::GetElementParams(keyPair.secretKey,
+                                                        depth + extOff - (t.levelsAvailableBeforeBootstrap > 0));
 
             auto ctxtBFV = SchemeletRLWEMP::EncryptCoeff(x, t.QBFVInit, t.PInput, keyPair.secretKey, ep);
 
@@ -402,7 +515,7 @@ protected:
             SchemeletRLWEMP::ModSwitch(ctxtBFV, t.Q, t.QBFVInit);
 
             auto ctxt = SchemeletRLWEMP::ConvertRLWEToCKKS(*cc, ctxtBFV, keyPair.publicKey, t.Bigq, numSlotsCKKS,
-                                                           depth - (t.levelsAvailableBeforeBootstrap > 0));
+                                                           depth + extOff - (t.levelsAvailableBeforeBootstrap > 0));
 
             Ciphertext<DCRTPoly> ctxtAfterFBT;
             if (binaryLUT)
@@ -440,7 +553,7 @@ protected:
             auto max_error_it = std::max_element(exact.begin(), exact.end());
             // std::cerr << "\n=======Error count: " << std::accumulate(exact.begin(), exact.end(), 0) << "\n";
             // std::cerr << "\n=======Max absolute error: " << *max_error_it << "\n";
-            checkEquality((*max_error_it), int64_t(0), 0.0001, failmsg + " LUT evaluation fails");
+            checkEquality((*max_error_it), static_cast<int64_t>(0), 0.0001, failmsg + " LUT evaluation fails");
 
             cc->ClearStaticMapsAndVectors();
         }
@@ -459,6 +572,9 @@ protected:
             auto start = std::chrono::high_resolution_clock::now();
 #endif
             bool flagSP = (t.numSlots <= t.ringDim / 2);  // sparse packing
+            // for FLEXIBLEAUTOEXT, the cryptocontext has an extra modulus, so the RLWE ciphertext is
+            // imported one level deeper to keep a single tower
+            const uint32_t extOff = (t.scalTech == FLEXIBLEAUTOEXT) ? 1 : 0;
             // t.numSlots represents number of values to be encrypted in BFV. If same as ring dimension, CKKS slots is halved.
             auto numSlotsCKKS = flagSP ? t.numSlots : t.numSlots / 2;
 
@@ -508,7 +624,7 @@ protected:
             parameters.SetSecretKeyDist(t.skd);
             parameters.SetSecurityLevel(HEStd_NotSet);
             parameters.SetScalingModSize(dcrtBits);
-            parameters.SetScalingTechnique(FIXEDMANUAL);
+            parameters.SetScalingTechnique(t.scalTech);
             parameters.SetFirstModSize(dcrtBits);
             parameters.SetNumLargeDigits(t.dnum);
             parameters.SetBatchSize(numSlotsCKKS);
@@ -560,8 +676,8 @@ protected:
             start = std::chrono::high_resolution_clock::now();
 #endif
 
-            auto ep =
-                SchemeletRLWEMP::GetElementParams(keyPair.secretKey, depth - (t.levelsAvailableBeforeBootstrap > 0));
+            auto ep = SchemeletRLWEMP::GetElementParams(keyPair.secretKey,
+                                                        depth + extOff - (t.levelsAvailableBeforeBootstrap > 0));
 
             auto ctxtBFV = SchemeletRLWEMP::EncryptCoeff(x, t.QBFVInit, t.PInput, keyPair.secretKey, ep);
 
@@ -608,7 +724,7 @@ protected:
 
                 auto ctxt =
                     SchemeletRLWEMP::ConvertRLWEToCKKS(*cc, encryptedDigit, keyPair.publicKey, t.Bigq, numSlotsCKKS,
-                                                       depth - (t.levelsAvailableBeforeBootstrap > 0));
+                                                       depth + extOff - (t.levelsAvailableBeforeBootstrap > 0));
 
                 // Bootstrap the digit.
                 Ciphertext<DCRTPoly> ctxtAfterFBT;
@@ -664,7 +780,8 @@ protected:
                     auto max_error_it = std::max_element(exact.begin(), exact.end());
                     // std::cerr << "\n=======Error count: " << std::accumulate(exact.begin(), exact.end(), 0) << "\n";
                     // std::cerr << "\n=======Max absolute error: " << *max_error_it << "\n";
-                    checkEquality((*max_error_it), int64_t(0), 0.0001, failmsg + " MP sign evaluation fails");
+                    checkEquality((*max_error_it), static_cast<int64_t>(0), 0.0001,
+                                  failmsg + " MP sign evaluation fails");
                 }
 
                 if (checkgt2 && !go && !step) {
@@ -699,6 +816,9 @@ protected:
 #endif
             bool flagBR = (t.lvlb[0] != 1 || t.lvlb[1] != 1);
             bool flagSP = (t.numSlots <= t.ringDim / 2);  // sparse packing
+            // for FLEXIBLEAUTOEXT, the cryptocontext has an extra modulus, so the RLWE ciphertext is
+            // imported one level deeper to keep a single tower
+            const uint32_t extOff = (t.scalTech == FLEXIBLEAUTOEXT) ? 1 : 0;
 
             // t.numSlots represents number of values to be encrypted in BFV. If same as ring dimension, CKKS slots is halved.
             auto numSlotsCKKS = flagSP ? t.numSlots : t.numSlots / 2;
@@ -734,7 +854,7 @@ protected:
             parameters.SetSecretKeyDist(t.skd);
             parameters.SetSecurityLevel(HEStd_NotSet);
             parameters.SetScalingModSize(dcrtBits);
-            parameters.SetScalingTechnique(FIXEDMANUAL);
+            parameters.SetScalingTechnique(t.scalTech);
             parameters.SetFirstModSize(dcrtBits);
             parameters.SetNumLargeDigits(t.dnum);
             parameters.SetBatchSize(numSlotsCKKS);
@@ -791,10 +911,11 @@ protected:
             // Note that the corresponding plaintext mask for full packing can be just real, as real times complex multiplies both real and imaginary parts
             Plaintext ptxt_mask = cc->MakeCKKSPackedPlaintext(
                 Fill<double>({1, 1, 1, 1, 0, 0, 0, 0}, numSlotsCKKS), 1,
-                depth - t.lvlb[1] - t.levelsAvailableAfterBootstrap - t.levelsComputation, nullptr, numSlotsCKKS);
+                depth + extOff - t.lvlb[1] - t.levelsAvailableAfterBootstrap - t.levelsComputation, nullptr,
+                numSlotsCKKS);
 
-            auto ep =
-                SchemeletRLWEMP::GetElementParams(keyPair.secretKey, depth - (t.levelsAvailableBeforeBootstrap > 0));
+            auto ep = SchemeletRLWEMP::GetElementParams(keyPair.secretKey,
+                                                        depth + extOff - (t.levelsAvailableBeforeBootstrap > 0));
 
             // Set bitReverse true to be able to perform correct rotations in CKKS
             auto ctxtBFV = SchemeletRLWEMP::EncryptCoeff(x, t.QBFVInit, t.PInput, keyPair.secretKey, ep, flagBR);
@@ -808,7 +929,7 @@ protected:
             SchemeletRLWEMP::ModSwitch(ctxtBFV, t.Q, t.QBFVInit);
 
             auto ctxt = SchemeletRLWEMP::ConvertRLWEToCKKS(*cc, ctxtBFV, keyPair.publicKey, t.Bigq, numSlotsCKKS,
-                                                           depth - (t.levelsAvailableBeforeBootstrap > 0));
+                                                           depth + extOff - (t.levelsAvailableBeforeBootstrap > 0));
 
             // Apply LUT and remain in slots encodings.
             Ciphertext<DCRTPoly> ctxtAfterFBT;
@@ -831,7 +952,7 @@ protected:
 
             // Apply a subsequent LUT
             ctxt = SchemeletRLWEMP::ConvertRLWEToCKKS(*cc, polys1, keyPair.publicKey, t.Bigq, numSlotsCKKS,
-                                                      depth - (t.levelsAvailableBeforeBootstrap > 0));
+                                                      depth + extOff - (t.levelsAvailableBeforeBootstrap > 0));
 
             if (binaryLUT)
                 ctxtAfterFBT = cc->EvalFBT(ctxt, coeffint, t.PInput.GetMSB() - 1, ep->GetModulus(), t.scaleTHI,
@@ -880,7 +1001,7 @@ protected:
             auto max_error_it = std::max_element(exact2.begin(), exact2.end());
             // std::cerr << "\n=======Error count: " << std::accumulate(exact.begin(), exact.end(), 0) << "\n";
             // std::cerr << "\n=======Max absolute error: " << *max_error_it << "\n";
-            checkEquality((*max_error_it), int64_t(0), 0.0001, failmsg + " LUT evaluation fails");
+            checkEquality((*max_error_it), static_cast<int64_t>(0), 0.0001, failmsg + " LUT evaluation fails");
 
             std::transform(exact3.begin(), exact3.end(), exact.begin(), [&](int64_t elem) {
                 return (f(elem) % t.POutput.ConvertToInt() > t.POutput.ConvertToDouble() / 2.) ?
@@ -894,7 +1015,7 @@ protected:
             max_error_it = std::max_element(exact.begin(), exact.end());
             // std::cerr << "\n=======Error count: " << std::accumulate(exact.begin(), exact.end(), 0) << "\n";
             // std::cerr << "\n=======Max absolute error: " << *max_error_it << "\n";
-            checkEquality((*max_error_it), int64_t(0), 0.0001, failmsg + " LUT evaluation fails");
+            checkEquality((*max_error_it), static_cast<int64_t>(0), 0.0001, failmsg + " LUT evaluation fails");
 
             cc->ClearStaticMapsAndVectors();
         }
@@ -913,6 +1034,9 @@ protected:
             auto start = std::chrono::high_resolution_clock::now();
 #endif
             bool flagSP = (t.numSlots <= t.ringDim / 2);  // sparse packing
+            // for FLEXIBLEAUTOEXT, the cryptocontext has an extra modulus, so the RLWE ciphertext is
+            // imported one level deeper to keep a single tower
+            const uint32_t extOff = (t.scalTech == FLEXIBLEAUTOEXT) ? 1 : 0;
             // t.numSlots represents number of values to be encrypted in BFV. If same as ring dimension, CKKS slots is halved.
             auto numSlotsCKKS = flagSP ? t.numSlots : t.numSlots / 2;
 
@@ -956,7 +1080,7 @@ protected:
             parameters.SetSecretKeyDist(t.skd);
             parameters.SetSecurityLevel(HEStd_NotSet);
             parameters.SetScalingModSize(dcrtBits);
-            parameters.SetScalingTechnique(FIXEDMANUAL);
+            parameters.SetScalingTechnique(t.scalTech);
             parameters.SetFirstModSize(dcrtBits);
             parameters.SetNumLargeDigits(t.dnum);
             parameters.SetBatchSize(numSlotsCKKS);
@@ -1007,8 +1131,8 @@ protected:
             start = std::chrono::high_resolution_clock::now();
 #endif
 
-            auto ep =
-                SchemeletRLWEMP::GetElementParams(keyPair.secretKey, depth - (t.levelsAvailableBeforeBootstrap > 0));
+            auto ep = SchemeletRLWEMP::GetElementParams(keyPair.secretKey,
+                                                        depth + extOff - (t.levelsAvailableBeforeBootstrap > 0));
 
             auto ctxtBFV = SchemeletRLWEMP::EncryptCoeff(x, t.QBFVInit, t.PInput, keyPair.secretKey, ep);
 
@@ -1021,7 +1145,7 @@ protected:
             SchemeletRLWEMP::ModSwitch(ctxtBFV, t.Q, t.QBFVInit);
 
             auto ctxt = SchemeletRLWEMP::ConvertRLWEToCKKS(*cc, ctxtBFV, keyPair.publicKey, t.Bigq, numSlotsCKKS,
-                                                           depth - (t.levelsAvailableBeforeBootstrap > 0));
+                                                           depth + extOff - (t.levelsAvailableBeforeBootstrap > 0));
 
             std::vector<Ciphertext<DCRTPoly>> complexExp;
             Ciphertext<DCRTPoly> ctxtAfterFBT1, ctxtAfterFBT2;
@@ -1081,7 +1205,7 @@ protected:
             auto max_error_it = std::max_element(exact.begin(), exact.end());
             // std::cerr << "\n=======Error count: " << std::accumulate(exact.begin(), exact.end(), 0) << "\n";
             // std::cerr << "\n=======Max absolute error: " << *max_error_it << "\n";
-            checkEquality((*max_error_it), int64_t(0), 0.0001, failmsg + " LUT evaluation fails");
+            checkEquality((*max_error_it), static_cast<int64_t>(0), 0.0001, failmsg + " LUT evaluation fails");
 
             std::transform(x.begin(), x.end(), exact.begin(), [&](int64_t elem) {
                 return (f2(elem) % t.POutput.ConvertToInt() > t.POutput.ConvertToDouble() / 2.) ?
@@ -1095,9 +1219,144 @@ protected:
             max_error_it = std::max_element(exact.begin(), exact.end());
             // std::cerr << "\n=======Error count: " << std::accumulate(exact.begin(), exact.end(), 0) << "\n";
             // std::cerr << "\n=======Max absolute error: " << *max_error_it << "\n";
-            checkEquality((*max_error_it), int64_t(0), 0.0001, failmsg + " LUT evaluation fails");
+            checkEquality((*max_error_it), static_cast<int64_t>(0), 0.0001, failmsg + " LUT evaluation fails");
 
             cc->ClearStaticMapsAndVectors();
+        }
+        catch (std::exception& e) {
+            std::cerr << "Exception thrown from " << __func__ << "(): " << e.what() << std::endl;
+            EXPECT_TRUE(0 == 1) << failmsg;
+        }
+        catch (...) {
+            UNIT_TEST_HANDLE_ALL_EXCEPTIONS;
+        }
+    }
+    // Evaluates the same LUT with FIXEDMANUAL and with t.scalTech (a FLEXIBLE* technique) and checks that
+    // the FLEXIBLE* technique yields smaller noise in the output RLWE ciphertext. The FLEXIBLE* techniques
+    // track the exact level-specific scaling factors, so the scaling-factor drift of the FIXED* techniques
+    // is absent; for the same parameters this shows up as smaller output noise (equivalently, correctness
+    // can be achieved with a smaller CKKS scaling factor).
+    void UnitTest_Noise(TEST_CASE_FBT t, const std::string& failmsg = std::string()) {
+        try {
+            auto runOnce = [&t](ScalingTechnique scalTech, int64_t& maxErr) -> double {
+                bool flagSP           = (t.numSlots <= t.ringDim / 2);  // sparse packing
+                const uint32_t extOff = (scalTech == FLEXIBLEAUTOEXT) ? 1 : 0;
+                auto numSlotsCKKS     = flagSP ? t.numSlots : t.numSlots / 2;
+
+                auto a = t.PInput.ConvertToInt<int64_t>();
+                auto b = t.POutput.ConvertToInt<int64_t>();
+                auto f = [a, b](int64_t x) -> int64_t {
+                    return (x % a - a / 2) % b;
+                };
+
+                std::vector<int64_t> x = {(t.PInput.ConvertToInt<int64_t>() / 2),
+                                          (t.PInput.ConvertToInt<int64_t>() / 2) + 1,
+                                          0,
+                                          3,
+                                          16,
+                                          33,
+                                          64,
+                                          (t.PInput.ConvertToInt<int64_t>() - 1)};
+                if (x.size() < t.numSlots)
+                    x = Fill<int64_t>(x, t.numSlots);
+
+                std::vector<int64_t> coeffint;
+                std::vector<std::complex<double>> coeffcomp;
+                bool binaryLUT = (t.PInput.ConvertToInt() == 2) && (t.order == 1);
+                if (binaryLUT)  // coeffs for [1, cos^2(pi x)], not [1, cos(2pi x)]
+                    coeffint = {f(1), f(0) - f(1)};
+                else  // divided by 2
+                    coeffcomp = GetHermiteTrigCoefficients(f, t.PInput.ConvertToInt(), t.order, t.scaleTHI);
+
+                const uint32_t dcrtBits = t.Bigq.GetMSB() - 1;
+                CCParams<CryptoContextCKKSRNS> parameters;
+                parameters.SetSecretKeyDist(t.skd);
+                parameters.SetSecurityLevel(HEStd_NotSet);
+                parameters.SetScalingModSize(dcrtBits);
+                parameters.SetScalingTechnique(scalTech);
+                parameters.SetFirstModSize(dcrtBits);
+                parameters.SetNumLargeDigits(t.dnum);
+                parameters.SetBatchSize(numSlotsCKKS);
+                parameters.SetRingDim(t.ringDim);
+                uint32_t depth = t.levelsAvailableAfterBootstrap;
+
+                if (binaryLUT)
+                    depth += FHECKKSRNS::GetFBTDepth(t.lvlb, coeffint, t.PInput, t.order, t.skd);
+                else
+                    depth += FHECKKSRNS::GetFBTDepth(t.lvlb, coeffcomp, t.PInput, t.order, t.skd);
+
+                parameters.SetMultiplicativeDepth(depth);
+
+                auto cc = GenCryptoContext(parameters);
+                cc->Enable(PKE);
+                cc->Enable(KEYSWITCH);
+                cc->Enable(LEVELEDSHE);
+                cc->Enable(ADVANCEDSHE);
+                cc->Enable(FHE);
+
+                auto keyPair = cc->KeyGen();
+
+                if (binaryLUT)
+                    cc->EvalFBTSetup(coeffint, numSlotsCKKS, t.PInput, t.POutput, t.Bigq, keyPair.publicKey, {0, 0},
+                                     t.lvlb, t.levelsAvailableAfterBootstrap, 0, t.order);
+                else
+                    cc->EvalFBTSetup(coeffcomp, numSlotsCKKS, t.PInput, t.POutput, t.Bigq, keyPair.publicKey, {0, 0},
+                                     t.lvlb, t.levelsAvailableAfterBootstrap, 0, t.order);
+
+                cc->EvalBootstrapKeyGen(keyPair.secretKey, numSlotsCKKS);
+                cc->EvalMultKeyGen(keyPair.secretKey);
+
+                auto ep = SchemeletRLWEMP::GetElementParams(keyPair.secretKey, depth + extOff);
+
+                auto ctxtBFV = SchemeletRLWEMP::EncryptCoeff(x, t.QBFVInit, t.PInput, keyPair.secretKey, ep);
+
+                SchemeletRLWEMP::ModSwitch(ctxtBFV, t.Q, t.QBFVInit);
+
+                auto ctxt = SchemeletRLWEMP::ConvertRLWEToCKKS(*cc, ctxtBFV, keyPair.publicKey, t.Bigq, numSlotsCKKS,
+                                                               depth + extOff);
+
+                Ciphertext<DCRTPoly> ctxtAfterFBT;
+                if (binaryLUT)
+                    ctxtAfterFBT =
+                        cc->EvalFBT(ctxt, coeffint, t.PInput.GetMSB() - 1, ep->GetModulus(), t.scaleTHI, 0, t.order);
+                else
+                    ctxtAfterFBT =
+                        cc->EvalFBT(ctxt, coeffcomp, t.PInput.GetMSB() - 1, ep->GetModulus(), t.scaleTHI, 0, t.order);
+
+                auto polys = SchemeletRLWEMP::ConvertCKKSToRLWE(ctxtAfterFBT, t.Q);
+
+                auto computed = SchemeletRLWEMP::DecryptCoeff(polys, t.Q, t.POutput, keyPair.secretKey, ep,
+                                                              numSlotsCKKS, t.numSlots);
+
+                auto exact(x);
+                std::transform(x.begin(), x.end(), exact.begin(), [&](int64_t elem) {
+                    return (f(elem) > t.POutput.ConvertToDouble() / 2.) ? f(elem) - t.POutput.ConvertToInt<int64_t>() :
+                                                                          f(elem);
+                });
+
+                std::transform(exact.begin(), exact.end(), computed.begin(), exact.begin(), std::minus<int64_t>());
+                std::transform(exact.begin(), exact.end(), exact.begin(),
+                               [&](int64_t elem) { return (std::abs(elem)) % (t.POutput.ConvertToInt()); });
+                maxErr = *std::max_element(exact.begin(), exact.end());
+
+                double noiseBits =
+                    MeasureNoiseBits(polys, t.Q, t.POutput, keyPair.secretKey, ep, numSlotsCKKS, t.numSlots);
+
+                cc->ClearStaticMapsAndVectors();
+                return noiseBits;
+            };
+
+            int64_t errFixed  = -1;
+            int64_t errFlex   = -1;
+            double noiseFixed = runOnce(FIXEDMANUAL, errFixed);
+            double noiseFlex  = runOnce(t.scalTech, errFlex);
+
+            checkEquality(errFixed, static_cast<int64_t>(0), 0.0001, failmsg + " FIXEDMANUAL LUT evaluation fails");
+            checkEquality(errFlex, static_cast<int64_t>(0), 0.0001,
+                          failmsg + " " + ScalTechName(t.scalTech) + " LUT evaluation fails");
+            EXPECT_LT(noiseFlex, noiseFixed)
+                << failmsg << " " << ScalTechName(t.scalTech) << " did not yield smaller noise than FIXEDMANUAL ("
+                << noiseFlex << " vs " << noiseFixed << " bits)";
         }
         catch (std::exception& e) {
             std::cerr << "Exception thrown from " << __func__ << "(): " << e.what() << std::endl;
@@ -1126,6 +1385,9 @@ TEST_P(UTCKKSRNS_FBT, CKKSRNS) {
             break;
         case FBT_MVB:
             UnitTest_MVB(test, test.buildTestName());
+            break;
+        case FBT_NOISE:
+            UnitTest_Noise(test, test.buildTestName());
             break;
         default:
             break;


### PR DESCRIPTION
## Summary

Adds support for the **FIXEDAUTO**, **FLEXIBLEAUTO**, and **FLEXIBLEAUTOEXT** scaling techniques to the CKKS functional bootstrapping capability (`EvalFBTSetup`/`EvalFBT`/`EvalMVB*`/`EvalHomDecoding`), which previously fully supported only FIXEDMANUAL. The FLEXIBLE* modes track the exact level-specific scaling factors, which removes the scaling-factor drift of the FIXED* modes: for the same parameters they achieve smaller output noise (equivalently, correctness can be achieved with a smaller CKKS scaling factor).

Closes #1218

## Design

The FBT input is an imported RLWE ciphertext whose true scale is the RLWE modulus (not a CKKS-tracked scaling factor), while in the FLEXIBLE* modes every scalar/plaintext multiplication encodes constants at the precomputed level-specific scaling factor `GetScalingFactorReal(level)`. The implementation keeps the whole pipeline on that precomputed chain **without consuming any extra levels** (the depth budget returned by `GetFBTDepth` is unchanged across all modes):

- **Declaration + matrix folds.** After `ModRaise`, the raised ciphertext is declared to carry the exact scaling factor of its level. The two residual ratios against the nominal power-of-two scaling factor `2^p` are folded into the homomorphic encoding/decoding matrices at setup time:
  - `scaleEnc *= SF(raised level) / 2^p`, so the values entering the trigonometric Hermite interpolation match the nominal convention exactly;
  - `scaleDec *= 2^p / SF(final level)`, so the decoded RLWE output lands at the exact absolute scale `QPrime/POut` (the output has `1 + lvlsAfterBoot` towers).
- **Initial-scaling correction.** For FLEXIBLE*, the `initialScaling` correction is folded into the existing multiplication by `1/(k*N)` after `ModRaise`, so no extra level is consumed (the FIXED* path is unchanged).
- **FLEXIBLEAUTOEXT (RE-CKKS-DE).** The raised basis excludes the extra modulus (as in `EvalBootstrap`), the raised ciphertext sits at level 1, and the input RLWE ciphertext is imported one level deeper so that it consists of a single tower (see the `extOff` logic in the unit tests).
- **`EvalHomDecoding`.** The public `ModReduce`/`LevelReduce` are no-ops outside FIXEDMANUAL, so the final rescaling now calls the internal rescaling explicitly for the AUTO modes. For FLEXIBLE*, `levelToReduce` is handled with a single scalar multiplication that adjusts the value to the scaling factor of the destination level, followed by a direct tower drop (the same logic as `AdjustLevelsAndDepthInPlace`).

The 128-bit build keeps throwing for FLEXIBLE*, matching regular CKKS bootstrapping.

## Tests

- All 48 existing FIXEDMANUAL FBT tests pass unchanged (`TEST_CASE_FBT` gained a `scalTech` field with a default member initializer, so existing rows are untouched).
- New cases 201–206 / 301–306 / 401–406 cover FIXEDAUTO / FLEXIBLEAUTO / FLEXIBLEAUTOEXT for: arbitrary LUTs (binary and 8-bit, orders 1–2, full and sparse packing, SPARSE_TERNARY and SPARSE_ENCAPSULATED), multi-precision sign, consecutive-level computations in the slots domain, and multi-value bootstrapping.
- New `FBT_NOISE` cases 501–502 evaluate the same LUT under FIXEDMANUAL and under FLEXIBLEAUTO(EXT), measure the actual pre-rounding noise in the output RLWE ciphertext (new `MeasureNoiseBits` helper: centered residual modulo `Q/p`), and assert that FLEXIBLE* yields strictly smaller noise.
- Full `pke_tests` suite passes (1917/1917).

## Measured noise (max over slots, in bits)

The size of the FLEXIBLE* advantage depends on which noise source dominates. The FIXED* scaling-factor drift grows roughly linearly with the ring dimension (the distance of the primes from `2^p` grows with `2N`), while the error of the polynomial approximation of the complex exponential is independent of the ring dimension. As a result, **for smaller ring dimensions the FLEXIBLE* benefit can disappear** (all scaling techniques converge to the same approximation-error floor), **but for the larger ring dimensions used in practice it reappears and grows**, since the drift climbs past that floor.

Binary LUT, `Q = 2^33`, SPARSE_TERNARY, full packing, ring `2^5` (drift-dominated even at a small ring, since the binary path uses the cosine evaluation with a smaller approximation error):

| Mode | Noise (bits) |
|---|---|
| FIXEDMANUAL | 21.0 |
| FIXEDAUTO | 21.0 |
| FLEXIBLEAUTO | **14.0** |
| FLEXIBLEAUTOEXT | **14.2** |

8-bit LUT, `Q = 2^47`, SPARSE_ENCAPSULATED, full packing, FIXEDMANUAL vs FLEXIBLEAUTO across ring dimensions:

| Ring dimension | FIXEDMANUAL | FLEXIBLEAUTO | Gap |
|---|---|---|---|
| 2^5 | 25.1 | 24.1 | 1.0 |
| 2^11 | 30.2 | 24.5 | 5.8 |
| 2^13 | 31.3 | 24.8 | 6.5 |
| 2^14 | 33.1 | 25.0 | 8.1 |
| 2^15 | 33.4 | **25.5** | **7.9** |

The same reappearance is seen for SPARSE_TERNARY at ring `2^15` (both configurations show no gap at ring `2^5`, where they sit on the approximation floor of the degree-58 exponential for the wider `[-25, 25]` range):

| Configuration | FIXEDMANUAL | FLEXIBLEAUTO | Gap |
|---|---|---|---|
| 4-bit, `Q = 2^38` | 32.2 | **27.4** | **4.8** |
| 8-bit, `Q = 2^47` | 34.3 | 33.0 | 1.4 |

Notes from the noise analysis:
- The mode-independent floors were experimentally confirmed to be the Chebyshev approximation error of the complex exponential (degree 46 for SPARSE_ENCAPSULATED, degree 58 for SPARSE_TERNARY): substituting a higher-degree approximation removes the floor and restores the FLEXIBLE* gap at small rings. At practical ring dimensions (`2^15`+) this is unnecessary for SPARSE_ENCAPSULATED with up to 8-bit plaintext moduli, because the ring-dependent noise already exceeds the degree-46 floor. The 8-bit SPARSE_TERNARY configuration remains close to its (higher) floor even at `2^15`, which is why its gap is only ~1.4 bits; a higher-degree approximation for the `[-25, 25]` range would widen it.
- FLEXIBLEAUTO and FLEXIBLEAUTOEXT perform equivalently for FBT (the RE-CKKS-DE fresh-encryption advantage does not engage for imported RLWE inputs).
- FIXEDAUTO is consistently ~2–3 bits worse than FIXEDMANUAL in some configurations (lazy-rescale placement effect; pre-existing behavior, correctness unaffected).
