### PR TITLE
Performance optimization of CKKS encoding, serialization, and threshold-FHE operations

### DIFF
--- a/src/core/include/math/dftransform.h
+++ b/src/core/include/math/dftransform.h
@@ -38,6 +38,7 @@
 
 #include <complex>
 #include <cstdint>
+#include <shared_mutex>
 #include <unordered_map>
 #include <vector>
 
@@ -121,11 +122,20 @@ private:
         std::vector<uint32_t> m_rotGroup;
         // ksi powers
         std::vector<std::complex<double>> m_ksiPows;
+        // per-stage butterfly twiddles for FFTSpecial/FFTSpecialInv, stored contiguously:
+        // the stage with half-length lenh (a power of two <= Nh/2) occupies [lenh - 1, 2*lenh - 1)
+        std::vector<std::complex<double>> m_fwdTw;
+        std::vector<std::complex<double>> m_invTw;
 
         PrecomputedValues(uint32_t m, uint32_t nh);
     };
     // precomputedValues: key - cyclotomic order, data - values precomputed for the given cyclotomic order
     static std::unordered_map<uint32_t, PrecomputedValues> precomputedValues;
+
+    // guards precomputedValues; map nodes are reference-stable, so readers may use the
+    // returned reference after the shared lock is released
+    static std::shared_mutex& PrecompMutex();
+    static const PrecomputedValues& GetPrecomp(uint32_t cyclOrder);
 
     static void BitReverse(std::vector<std::complex<double>>& vals);
 };

--- a/src/core/include/math/hal/intnat/mubintvecnat.h
+++ b/src/core/include/math/hal/intnat/mubintvecnat.h
@@ -654,12 +654,7 @@ public:
         ar(size);
         m_data.resize(size);
         if (size > 0) {
-            auto* data = reinterpret_cast<IntegerType*>(malloc(size * sizeof(IntegerType)));
-            ar(::cereal::binary_data(data, size * sizeof(IntegerType)));
-            for (::cereal::size_type i = 0; i < size; i++) {
-                m_data[i] = data[i];
-            }
-            free(data);
+            ar(::cereal::binary_data(m_data.data(), size * sizeof(IntegerType)));
         }
         ar(m_modulus);
     }

--- a/src/core/lib/math/dftransform.cpp
+++ b/src/core/lib/math/dftransform.cpp
@@ -67,6 +67,36 @@ DiscreteFourierTransform::PrecomputedValues::PrecomputedValues(uint32_t m, uint3
     }
 
     m_ksiPows[m_M] = m_ksiPows[0];
+
+    m_fwdTw.resize(m_Nh > 0 ? m_Nh - 1 : 0);
+    m_invTw.resize(m_fwdTw.size());
+    for (uint32_t lenh = 1; lenh <= m_Nh / 2; lenh <<= 1) {
+        uint32_t lenq = lenh << 3;
+        uint32_t gap  = m_M / lenq;
+        auto* fwd     = &m_fwdTw[lenh - 1];
+        auto* inv     = &m_invTw[lenh - 1];
+        for (uint32_t j = 0; j < lenh; ++j) {
+            uint32_t rg = m_rotGroup[j] % lenq;
+            fwd[j]      = m_ksiPows[rg * gap];
+            inv[j]      = m_ksiPows[(lenq - rg) * gap];
+        }
+    }
+}
+
+std::shared_mutex& DiscreteFourierTransform::PrecompMutex() {
+    static std::shared_mutex mtx;
+    return mtx;
+}
+
+const DiscreteFourierTransform::PrecomputedValues& DiscreteFourierTransform::GetPrecomp(uint32_t cyclOrder) {
+    std::shared_lock<std::shared_mutex> lock(PrecompMutex());
+    const auto it = precomputedValues.find(cyclOrder);
+    if (it == precomputedValues.end()) {
+        std::string errMsg("DiscreteFourierTransform::Initialize() must be called for cyclOrder = ");
+        errMsg += std::to_string(cyclOrder);
+        OPENFHE_THROW(errMsg);
+    }
+    return it->second;
 }
 
 void DiscreteFourierTransform::Reset() {
@@ -77,11 +107,9 @@ void DiscreteFourierTransform::Reset() {
 }
 
 void DiscreteFourierTransform::Initialize(uint32_t m, uint32_t nh) {
-#pragma omp critical
     // add a PrecomputedValues object to the map of precomputedValues only if it doesn't already exist for the given cyclotomic order
-    if (precomputedValues.find(m) == precomputedValues.end()) {
-        precomputedValues.insert({m, PrecomputedValues(m, nh)});
-    }
+    std::unique_lock<std::shared_mutex> lock(PrecompMutex());
+    precomputedValues.try_emplace(m, m, nh);
 }
 
 void DiscreteFourierTransform::PreComputeTable(uint32_t s) {
@@ -207,61 +235,55 @@ std::vector<std::complex<double>> DiscreteFourierTransform::InverseTransform(std
 }
 
 void DiscreteFourierTransform::FFTSpecialInv(std::vector<std::complex<double>>& vals, uint32_t cyclOrder) {
-    // check if the precomputed table exists for the given cyclotomic order
-    const auto it = precomputedValues.find(cyclOrder);
-    if (it == precomputedValues.end()) {
-        std::string errMsg("DiscreteFourierTransform::Initialize() must be called for cyclOrder = ");
-        errMsg += std::to_string(cyclOrder);
-        OPENFHE_THROW(errMsg);
-    }
+    const PrecomputedValues& pv = GetPrecomp(cyclOrder);
 
-    const uint32_t valsSize = vals.size();
-    for (size_t len = valsSize; len >= 1; len >>= 1) {
+    const size_t valsSize = vals.size();
+    for (size_t len = valsSize; len >= 2; len >>= 1) {
+        const size_t lenh = len >> 1;
+        const auto* tw    = &pv.m_invTw[lenh - 1];
         for (size_t i = 0; i < valsSize; i += len) {
-            size_t lenh = len >> 1;
-            size_t lenq = len << 2;
-            size_t gap  = it->second.m_M / lenq;
+            auto* lo = &vals[i];
+            auto* hi = lo + lenh;
             for (size_t j = 0; j < lenh; ++j) {
-                size_t idx             = (lenq - (it->second.m_rotGroup[j] % lenq)) * gap;
-                std::complex<double> u = vals[i + j] + vals[i + j + lenh];
-                std::complex<double> v = vals[i + j] - vals[i + j + lenh];
-                v *= it->second.m_ksiPows[idx];
-                vals[i + j]        = u;
-                vals[i + j + lenh] = v;
+                const double ur = lo[j].real() + hi[j].real();
+                const double ui = lo[j].imag() + hi[j].imag();
+                const double vr = lo[j].real() - hi[j].real();
+                const double vi = lo[j].imag() - hi[j].imag();
+                const double wr = tw[j].real();
+                const double wi = tw[j].imag();
+                lo[j]           = {ur, ui};
+                hi[j]           = {vr * wr - vi * wi, vr * wi + vi * wr};
             }
         }
     }
     BitReverse(vals);
 
+    const double inv = 1.0 / static_cast<double>(valsSize);
     for (size_t i = 0; i < valsSize; ++i) {
-        vals[i] /= valsSize;
+        vals[i] *= inv;
     }
 }
 
 void DiscreteFourierTransform::FFTSpecial(std::vector<std::complex<double>>& vals, uint32_t cyclOrder) {
-    // check if the precomputed table exists for the given cyclotomic order
-    const auto it = precomputedValues.find(cyclOrder);
-    if (it == precomputedValues.end()) {
-        std::string errMsg("DiscreteFourierTransform::Initialize() must be called for cyclOrder = ");
-        errMsg += std::to_string(cyclOrder);
-        OPENFHE_THROW(errMsg);
-    }
-    const PrecomputedValues& prepValues = it->second;
+    const PrecomputedValues& pv = GetPrecomp(cyclOrder);
 
     BitReverse(vals);
-    uint32_t size = vals.size();
-    for (size_t len = 2; len <= size; len <<= 1) {
-        size_t lenh = len >> 1;
-        size_t lenq = len << 2;
-        size_t gap  = prepValues.m_M / lenq;
-        for (size_t i = 0; i < size; i += len) {
+    const size_t valsSize = vals.size();
+    for (size_t len = 2; len <= valsSize; len <<= 1) {
+        const size_t lenh = len >> 1;
+        const auto* tw    = &pv.m_fwdTw[lenh - 1];
+        for (size_t i = 0; i < valsSize; i += len) {
+            auto* lo = &vals[i];
+            auto* hi = lo + lenh;
             for (size_t j = 0; j < lenh; ++j) {
-                int64_t idx            = ((prepValues.m_rotGroup[j] % lenq)) * gap;
-                std::complex<double> u = vals[i + j];
-                std::complex<double> v = vals[i + j + lenh];
-                v *= prepValues.m_ksiPows[idx];
-                vals[i + j]        = u + v;
-                vals[i + j + lenh] = u - v;
+                const double wr = tw[j].real();
+                const double wi = tw[j].imag();
+                const double vr = hi[j].real() * wr - hi[j].imag() * wi;
+                const double vi = hi[j].real() * wi + hi[j].imag() * wr;
+                const double ur = lo[j].real();
+                const double ui = lo[j].imag();
+                lo[j]           = {ur + vr, ui + vi};
+                hi[j]           = {ur - vr, ui - vi};
             }
         }
     }

--- a/src/pke/include/ciphertext.h
+++ b/src/pke/include/ciphertext.h
@@ -196,6 +196,20 @@ public:
     }
 
     /**
+   * Sets the data element by std::move.
+   *
+   * @param &&element is a polynomial ring element.
+   */
+    void SetElement(Element&& element) {
+        if (m_elements.size() == 0)
+            m_elements.push_back(std::move(element));
+        else if (m_elements.size() == 1)
+            m_elements[0] = std::move(element);
+        else
+            OPENFHE_THROW("Can be called on a Ciphertext with a single element ONLY");
+    }
+
+    /**
    * Sets the data elements.
    *
    * @param &element is a polynomial ring element.

--- a/src/pke/lib/encoding/ckkspackedencoding.cpp
+++ b/src/pke/lib/encoding/ckkspackedencoding.cpp
@@ -194,21 +194,17 @@ bool CKKSPackedEncoding::Encode() {
     }
     DCRTPoly::Integer intPowP = NativeInteger(1) << pBits;
 #else  // NATIVEINT == 64
-    int32_t logc = std::numeric_limits<int32_t>::min();
+    double maxAbs = 0.;
     for (uint32_t i = 0; i < slots; ++i) {
         inverse[i] *= scalingFactor;
-        if (inverse[i].real() != 0.) {
-            auto logci = static_cast<int32_t>(std::ceil(std::log2(std::abs(inverse[i].real()))));
-            if (logc < logci)
-                logc = logci;
-        }
-        if (inverse[i].imag() != 0.) {
-            auto logci = static_cast<int32_t>(std::ceil(std::log2(std::abs(inverse[i].imag()))));
-            if (logc < logci)
-                logc = logci;
-        }
+        const double re = std::abs(inverse[i].real());
+        const double im = std::abs(inverse[i].imag());
+        if (maxAbs < re)
+            maxAbs = re;
+        if (maxAbs < im)
+            maxAbs = im;
     }
-    logc = (logc == std::numeric_limits<int32_t>::min()) ? 0 : logc;
+    int32_t logc = (maxAbs == 0.) ? 0 : static_cast<int32_t>(std::ceil(std::log2(maxAbs)));
     if (logc < 0)
         OPENFHE_THROW("Scaling factor too small");
 
@@ -527,6 +523,31 @@ void CKKSPackedEncoding::FitToNativeVector(const std::vector<int64_t>& vec, int6
     uint32_t ringDim   = GetElementRingDimension();
     uint32_t dslots    = vec.size();
     uint32_t gap       = ringDim / dslots;
+#if defined(HAVE_INT128) && NATIVEINT == 64
+    // word-scaled-reciprocal reduction (one multiply per element instead of a divide);
+    // unlike ComputeMu/ModMu Barrett it is valid for the full 64-bit input range.
+    // The biased values are nonnegative, so the int64 -> uint64 conversion is value-preserving.
+    const uint64_t q{modulus.ConvertToInt<uint64_t>()};
+    const int64_t e{static_cast<int64_t>(lbcrypto::GetMSB(q)) - 2};
+    if (e >= 1) {
+        const uint64_t half{static_cast<uint64_t>(bigBound) >> 1};
+        const uint64_t diffR{(static_cast<uint64_t>(bigBound) - q) % q};
+        const uint64_t mu{static_cast<uint64_t>((static_cast<unsigned __int128>(1) << (64 + e)) / q)};
+        for (uint32_t i = 0; i < dslots; ++i) {
+            const uint64_t v{static_cast<uint64_t>(vec[i])};
+            uint64_t av{v};
+            if (av >= q) {
+                av -= static_cast<uint64_t>((static_cast<unsigned __int128>(v) * mu) >> 64 >> e) * q;
+                if (av >= q)
+                    av -= q;
+            }
+            uint64_t t{av - (diffR & (0 - static_cast<uint64_t>(v > half)))};
+            t += q & (0 - (t >> 63));
+            (*nativeVec)[gap * i] = t;
+        }
+        return;
+    }
+#endif
     for (uint32_t i = 0; i < vec.size(); i++) {
         NativeInteger n(vec[i]);
         if (n > bigValueHf) {

--- a/src/pke/lib/scheme/ckksrns/ckksrns-fhe.cpp
+++ b/src/pke/lib/scheme/ckksrns/ckksrns-fhe.cpp
@@ -2983,6 +2983,31 @@ void FHECKKSRNS::FitToNativeVector(uint32_t ringDim, const std::vector<int64_t>&
     NativeInteger diff = bigBound - modulus;
     uint32_t dslots    = vec.size();
     uint32_t gap       = ringDim / dslots;
+#if defined(HAVE_INT128) && NATIVEINT == 64
+    // word-scaled-reciprocal reduction (one multiply per element instead of a divide);
+    // unlike ComputeMu/ModMu Barrett it is valid for the full 64-bit input range.
+    // The biased values are nonnegative, so the int64 -> uint64 conversion is value-preserving.
+    const uint64_t q{modulus.ConvertToInt<uint64_t>()};
+    const int64_t e{static_cast<int64_t>(GetMSB(q)) - 2};
+    if (e >= 1) {
+        const uint64_t half{static_cast<uint64_t>(bigBound) >> 1};
+        const uint64_t diffR{(static_cast<uint64_t>(bigBound) - q) % q};
+        const uint64_t mu{static_cast<uint64_t>((static_cast<unsigned __int128>(1) << (64 + e)) / q)};
+        for (uint32_t i = 0; i < dslots; ++i) {
+            const uint64_t v{static_cast<uint64_t>(vec[i])};
+            uint64_t av{v};
+            if (av >= q) {
+                av -= static_cast<uint64_t>((static_cast<unsigned __int128>(v) * mu) >> 64 >> e) * q;
+                if (av >= q)
+                    av -= q;
+            }
+            uint64_t t{av - (diffR & (0 - static_cast<uint64_t>(v > half)))};
+            t += q & (0 - (t >> 63));
+            (*nativeVec)[gap * i] = t;
+        }
+        return;
+    }
+#endif
     for (uint32_t i = 0; i < dslots; ++i) {
         NativeInteger n(vec[i]);
         if (n > bigValueHf) {

--- a/src/pke/lib/schemebase/base-multiparty.cpp
+++ b/src/pke/lib/schemebase/base-multiparty.cpp
@@ -42,6 +42,7 @@
 #include <iostream>
 #include <map>
 #include <memory>
+#include <set>
 #include <utility>
 #include <vector>
 
@@ -70,12 +71,18 @@ KeyPair<Element> MultipartyBase<Element>::MultipartyKeyGen(CryptoContext<Element
     NativeInteger ns = cryptoParams->GetNoiseScale();
 
     // b = ns * e - a * s
-    Element b(std::move((e *= ns) -= (a * s)));
+    if (ns != 1)
+        e *= ns;
+    Element b(std::move(e -= a * s));
 
     KeyPair<Element> keyPair(std::make_shared<PublicKeyImpl<Element>>(cc),
                              std::make_shared<PrivateKeyImpl<Element>>(cc));
     keyPair.secretKey->SetPrivateElement(std::move(s));
-    keyPair.publicKey->SetPublicElements({std::move(b), std::move(a)});
+    std::vector<Element> pkElems;
+    pkElems.reserve(2);
+    pkElems.push_back(std::move(b));
+    pkElems.push_back(std::move(a));
+    keyPair.publicKey->SetPublicElements(std::move(pkElems));
     return keyPair;
 }
 
@@ -115,7 +122,9 @@ KeyPair<Element> MultipartyBase<Element>::MultipartyKeyGen(CryptoContext<Element
 
     // b = ns * e - a * s
     // When PRE is not used, a joint key is computed
-    Element b(std::move((e *= ns) -= (a * s)));
+    if (ns != 1)
+        e *= ns;
+    Element b(std::move(e -= a * s));
     if (!fresh)
         b += pk[0];
 
@@ -127,7 +136,11 @@ KeyPair<Element> MultipartyBase<Element>::MultipartyKeyGen(CryptoContext<Element
     KeyPair<Element> keyPair(std::make_shared<PublicKeyImpl<Element>>(cc),
                              std::make_shared<PrivateKeyImpl<Element>>(cc));
     keyPair.secretKey->SetPrivateElement(std::move(s));
-    keyPair.publicKey->SetPublicElements({std::move(b), std::move(a)});
+    std::vector<Element> pkElems;
+    pkElems.reserve(2);
+    pkElems.push_back(std::move(b));
+    pkElems.push_back(std::move(a));
+    keyPair.publicKey->SetPublicElements(std::move(pkElems));
     return keyPair;
 }
 
@@ -150,26 +163,35 @@ std::shared_ptr<std::map<uint32_t, EvalKey<Element>>> MultipartyBase<Element>::M
 
     const auto cc = privateKey->GetCryptoContext();
 
+    // deduplicated work list; the base keys are looked up (and missing ones reported) before
+    // the parallel loop because an exception may not cross an OpenMP region boundary
+    const std::set<uint32_t> indexSet(indexList.begin(), indexList.end());
+    const std::vector<uint32_t> indices(indexSet.begin(), indexSet.end());
+    const uint32_t sz = indices.size();
+    std::vector<EvalKey<Element>> baseKeys(sz);
+    for (uint32_t i = 0; i < sz; ++i) {
+        auto evalKeyIterator = evalKeyMap->find(indices[i]);
+        if (evalKeyIterator == evalKeyMap->end()) {
+            OPENFHE_THROW("EvalKey for index [" + std::to_string(indices[i]) + "] is not found.");
+        }
+        baseKeys[i] = evalKeyIterator->second;
+    }
+
+    // pre-created map slots so the parallel loop assigns without a critical section
     auto result = std::make_shared<std::map<uint32_t, EvalKey<Element>>>();
+    for (auto indx : indices)
+        (*result)[indx];
 
-    // #pragma omp parallel for if (indexList.size() >= 4)
-    for (uint32_t i = 0; i < indexList.size(); i++) {
-        PrivateKey<Element> privateKeyPermuted = std::make_shared<PrivateKeyImpl<Element>>(cc);
-
-        uint32_t index = NativeInteger(indexList[i]).ModInverse(2 * N).ConvertToInt();
+#pragma omp parallel for num_threads(OpenFHEParallelControls.GetThreadLimit(sz))
+    for (uint32_t i = 0; i < sz; ++i) {
+        uint32_t index = NativeInteger(indices[i]).ModInverse(2 * N).ConvertToInt();
         std::vector<uint32_t> vec(N);
         PrecomputeAutoMap(N, index, &vec);
 
-        Element sPermuted = s.AutomorphismTransform(index, vec);
-        privateKeyPermuted->SetPrivateElement(std::move(sPermuted));
+        auto privateKeyPermuted = std::make_shared<PrivateKeyImpl<Element>>(cc);
+        privateKeyPermuted->SetPrivateElement(s.AutomorphismTransform(index, vec));
 
-        // verify if the key indexList[i] exists in the evalKeyMap
-        auto evalKeyIterator = evalKeyMap->find(indexList[i]);
-        if (evalKeyIterator == evalKeyMap->end()) {
-            OPENFHE_THROW("EvalKey for index [" + std::to_string(indexList[i]) + "] is not found.");
-        }
-
-        (*result)[indexList[i]] = MultiKeySwitchGen(privateKey, privateKeyPermuted, evalKeyIterator->second);
+        (*result)[indices[i]] = MultiKeySwitchGen(privateKey, privateKeyPermuted, baseKeys[i]);
     }
     return result;
 }
@@ -205,17 +227,14 @@ Ciphertext<Element> MultipartyBase<Element>::MultipartyDecryptLead(ConstCipherte
     const auto ns                                 = cryptoParams->GetNoiseScale();
 
     const std::vector<Element>& cv = ciphertext->GetElements();
-
-    const Element& s = privateKey->GetPrivateElement();
+    const Element& s               = privateKey->GetPrivateElement();
 
     DggType dgg(NoiseFlooding::MP_SD);
     Element e(dgg, elementParams, Format::EVALUATION);
-
-    Element b = cv[0] + s * cv[1] + ns * e;
-    //  b.SwitchFormat();
-
+    if (ns != 1)
+        e *= typename Element::Integer(ns);
     auto result = ciphertext->CloneEmpty();
-    result->SetElement(std::move(b));
+    result->SetElement(cv[0] + s * cv[1] + e);
     return result;
 }
 
@@ -233,28 +252,20 @@ Ciphertext<Element> MultipartyBase<Element>::MultipartyDecryptMain(ConstCipherte
 
     DggType dgg(NoiseFlooding::MP_SD);
     Element e(dgg, elementParams, Format::EVALUATION);
-
-    // e is added to do noise flooding
-    Element b = s * cv[1] + es * e;
-
+    if (es != 1)
+        e *= typename Element::Integer(es);
     auto result = ciphertext->CloneEmpty();
-    result->SetElement(std::move(b));
+    result->SetElement(s * cv[1] + e);
     return result;
 }
 
 template <class Element>
 DecryptResult MultipartyBase<Element>::MultipartyDecryptFusion(const std::vector<Ciphertext<Element>>& ciphertextVec,
                                                                NativePoly* plaintext) const {
-    const auto cryptoParams =
-        std::dynamic_pointer_cast<CryptoParametersRLWE<Element>>(ciphertextVec[0]->GetCryptoParameters());
-
-    const std::vector<Element>& cv0 = ciphertextVec[0]->GetElements();
-
-    Element b = cv0[0];
-    for (size_t i = 1; i < ciphertextVec.size(); i++) {
-        const std::vector<Element>& cvi = ciphertextVec[i]->GetElements();
-        b += cvi[0];
-    }
+    Element b = (ciphertextVec.size() > 1) ? ciphertextVec[0]->GetElements()[0] + ciphertextVec[1]->GetElements()[0] :
+                                             ciphertextVec[0]->GetElements()[0];
+    for (size_t i = 2; i < ciphertextVec.size(); i++)
+        b += ciphertextVec[i]->GetElements()[0];
     b.SetFormat(Format::COEFFICIENT);
 
     *plaintext = b.ToNativePoly();
@@ -270,7 +281,11 @@ PublicKey<Element> MultipartyBase<Element>::MultiAddPubKeys(PublicKey<Element> p
     const Element& b1 = publicKey1->GetPublicElements()[0];
     const Element& b2 = publicKey2->GetPublicElements()[0];
     const Element& a  = publicKey1->GetPublicElements()[1];
-    publicKeySum->SetPublicElements(std::vector<Element>{(b1 + b2), a});
+    std::vector<Element> pkElems;
+    pkElems.reserve(2);
+    pkElems.push_back(b1 + b2);
+    pkElems.push_back(a);
+    publicKeySum->SetPublicElements(std::move(pkElems));
 
     return publicKeySum;
 }
@@ -348,8 +363,14 @@ EvalKey<Element> MultipartyBase<Element>::MultiMultEvalKey(PrivateKey<Element> p
     b.reserve(a0.size());
 
     for (uint32_t i = 0; i < a0.size(); i++) {
-        a.push_back(a0[i] * s + ns * Element(dgg, elementParams, Format::EVALUATION));
-        b.push_back(b0[i] * s + ns * Element(dgg, elementParams, Format::EVALUATION));
+        Element ea(dgg, elementParams, Format::EVALUATION);
+        if (ns != 1)
+            ea *= typename Element::Integer(ns);
+        a.push_back(std::move(ea += a0[i] * s));
+        Element eb(dgg, elementParams, Format::EVALUATION);
+        if (ns != 1)
+            eb *= typename Element::Integer(ns);
+        b.push_back(std::move(eb += b0[i] * s));
     }
 
     evalKeyResult->SetAVector(std::move(a));
@@ -376,15 +397,7 @@ template <class Element>
 std::shared_ptr<std::map<uint32_t, EvalKey<Element>>> MultipartyBase<Element>::MultiAddEvalSumKeys(
     const std::shared_ptr<std::map<uint32_t, EvalKey<Element>>> evalKeyMap1,
     const std::shared_ptr<std::map<uint32_t, EvalKey<Element>>> evalKeyMap2) const {
-    auto EvalKeyMapSum = std::make_shared<std::map<uint32_t, EvalKey<Element>>>();
-
-    for (auto it = evalKeyMap1->begin(); it != evalKeyMap1->end(); ++it) {
-        auto it2 = evalKeyMap2->find(it->first);
-        if (it2 != evalKeyMap2->end())
-            (*EvalKeyMapSum)[it->first] = MultiAddEvalKeys(it->second, it2->second);
-    }
-
-    return EvalKeyMapSum;
+    return MultiAddEvalAutomorphismKeys(evalKeyMap1, evalKeyMap2);
 }
 
 }  // namespace lbcrypto

--- a/src/pke/lib/schemerns/rns-multiparty.cpp
+++ b/src/pke/lib/schemerns/rns-multiparty.cpp
@@ -87,7 +87,7 @@ Ciphertext<DCRTPoly> MultipartyRNS::MultipartyDecryptLead(ConstCiphertext<DCRTPo
                                      cryptoParams->GetMultipartyModq0BarrettMu(), cryptoParams->GetMultipartyQInv(),
                                      Format::EVALUATION);
 
-        noise = e;
+        noise = std::move(e);
     }
     else if (cryptoParams->GetDecryptionNoiseMode() == NOISE_FLOODING_DECRYPT &&
              cryptoParams->GetExecutionMode() == EXEC_EVALUATION) {
@@ -101,11 +101,12 @@ Ciphertext<DCRTPoly> MultipartyRNS::MultipartyDecryptLead(ConstCiphertext<DCRTPo
         noise = std::move(e);
     }
 
-    // e is added to do noise flooding
-    DCRTPoly b = cv[0] + s * cv[1] + ns * noise;
+    // noise is added to do noise flooding
+    if (ns != 1)
+        noise *= DCRTPoly::Integer(ns);
 
     auto result = ciphertext->CloneEmpty();
-    result->SetElement(std::move(b));
+    result->SetElement(cv[0] + s * cv[1] + noise);
     return result;
 }
 
@@ -148,7 +149,7 @@ Ciphertext<DCRTPoly> MultipartyRNS::MultipartyDecryptMain(ConstCiphertext<DCRTPo
                                      cryptoParams->GetMultipartyModq0BarrettMu(), cryptoParams->GetMultipartyQInv(),
                                      Format::EVALUATION);
 
-        noise = e;
+        noise = std::move(e);
     }
     else if (cryptoParams->GetDecryptionNoiseMode() == NOISE_FLOODING_DECRYPT &&
              cryptoParams->GetExecutionMode() == EXEC_EVALUATION) {
@@ -163,10 +164,11 @@ Ciphertext<DCRTPoly> MultipartyRNS::MultipartyDecryptMain(ConstCiphertext<DCRTPo
     }
 
     // noise is added to do noise flooding
-    DCRTPoly b = s * cv[1] + ns * noise;
+    if (ns != 1)
+        noise *= DCRTPoly::Integer(ns);
 
     auto result = ciphertext->CloneEmpty();
-    result->SetElement(std::move(b));
+    result->SetElement(s * cv[1] + noise);
     return result;
 }
 


### PR DESCRIPTION
This PR is a targeted optimization pass over the operations that dominate
encrypted-analytics workloads built on CKKS with threshold (multiparty) decryption:
plaintext encoding/decoding, ciphertext (de)serialization, partial decryption, and
joint evaluation-key generation. Changes are bit-exact unless noted; the full core
and pke unit-test suites pass.

## Optimizations

- **CKKS special FFT (encode/decode).** The butterfly twiddle factors depend only on
  (stage, position), so they are now precomputed once per cyclotomic order into
  per-stage contiguous tables, removing a modulo and a gather from every butterfly.
  The complex multiply is written on raw doubles — bit-identical to
  `std::complex operator*` for finite inputs — which eliminates a `__muldc3`
  libcall (and its non-finite fixup branches) per butterfly, and the inverse
  transform's epilogue multiplies by the exact power-of-two reciprocal instead of
  dividing per element.

- **DFT precompute-cache thread safety.** The per-cyclotomic-order precompute map was
  read without synchronization while `Initialize()` inserted under `omp critical`.
  Lookups now take a shared lock (map nodes are reference-stable, so the returned
  reference remains valid after release), and insertion uses a unique lock with
  `try_emplace`.

- **CKKS encode scaling pass.** The encoder called `ceil(log2(|x|))` twice per slot
  just to find the maximum-magnitude component. Since `ceil(log2())` is monotonic,
  it now tracks the running max and takes a single `log2` at the end — identical
  result, and the scaling loop becomes vectorizable.

- **`FitToNativeVector` reduction.** The per-coefficient conversion to RNS residues
  performed a hardware divide (and a poorly predicted sign branch) per element. It
  now uses a word-scaled-reciprocal reduction computed once per call — valid for the
  full 64-bit input range, unlike the modulus-scaled Barrett used elsewhere — with a
  branchless centered correction (gated on `HAVE_INT128`; the legacy loop remains
  for other configurations).

- **Binary deserialization of native vectors.** `load` allocated a bounce buffer with
  `malloc`, read into it, copied element-by-element, and freed it. It now reads
  directly into the vector's storage, symmetric with `save`.

- **`SetElement` rvalue overload.** `CiphertextImpl::SetElement` only accepted a
  const reference, so every `SetElement(std::move(...))` call site silently
  deep-copied a full ring element. The move overload fixes all five call sites,
  including both threshold partial-decrypt paths.

- **Threshold partial decryption (`MultipartyDecryptLead/Main`, base and RNS).** The
  noise-scale multiply is skipped when the scale is 1 (always, for CKKS), the result
  is accumulated in place instead of through temporaries, and the RNS
  flooding-mode branch moves the noise element instead of copying it.

- **Multiparty key-generation cleanups.** Braced-initializer-list arguments to
  `SetPublicElements` silently copied both public-key elements despite `std::move`
  (an initializer_list's backing array is const), in both `MultipartyKeyGen`
  overloads and `MultiAddPubKeys`; these now build the vector with moves.
  `MultiMultEvalKey` skips the noise-scale multiply when the scale is 1 and
  accumulates each digit in place. `MultipartyDecryptFusion` drops an unused
  cryptoparameters cast and starts its accumulation with an out-of-place add rather
  than copy-then-add. `MultiAddEvalSumKeys` delegates to its identical
  automorphism-key counterpart.

- **Parallel joint rotation-key generation.** `MultiEvalAutomorphismKeyGen` now uses
  the same OpenMP pattern as the single-party `EvalAutomorphismKeyGen` (map slots
  pre-created so the parallel loop assigns without a critical section, thread count
  from `OpenFHEParallelControls`), with the index list deduplicated (duplicate
  indices would race on one slot) and the missing-key check hoisted out of the
  parallel region, since exceptions may not cross an OpenMP boundary. Generated
  keys are fresh randomness, as before; sampling order differs from the serial
  version.

## Measured highlights

Single-thread pinned A/B against current dev, minimum over repetitions, depth-0
CKKS at 53-bit scale (the threshold-decryption configuration):

- CKKS encode (`MakeCKKSPackedPlaintext`): **1.55–1.58x** (rings 2^13, 2^14);
  decode: 1.14–1.26x.
- Ciphertext binary deserialization: **1.28–1.55x** across depths.
- Threshold partial decryption (RNS Lead/Main): ~1.06–1.09x (dominated by
  noise-flooding sampling and the NTT).
- Joint rotation-key generation, 64 keys at 8 threads: **38.2 ms -> 8.4 ms
  (4.5x)** — previously flat with thread count, now matching the single-party
  path's scaling.