### PR TITLE
Add generation and compression of evaluation keys at a specified level (issue #413)

### DIFF
--- a/src/core/include/lattice/hal/default/dcrtpoly-impl.h
+++ b/src/core/include/lattice/hal/default/dcrtpoly-impl.h
@@ -885,21 +885,8 @@ typename VecType::Integer DCRTPolyImpl<VecType>::GetWorkingModulus() const {
 template <typename VecType>
 std::shared_ptr<typename DCRTPolyImpl<VecType>::Params> DCRTPolyImpl<VecType>::GetExtendedCRTBasis(
     const std::shared_ptr<Params>& paramsP) const {
-    uint32_t sizeQ  = m_vectors.size();
-    uint32_t sizeQP = sizeQ + paramsP->GetParams().size();
-    std::vector<NativeInteger> moduliQP(sizeQP);
-    std::vector<NativeInteger> rootsQP(sizeQP);
-    const auto& parq = m_params->GetParams();
-    for (uint32_t i = 0; i < sizeQ; ++i) {
-        moduliQP[i] = parq[i]->GetModulus();
-        rootsQP[i]  = parq[i]->GetRootOfUnity();
-    }
-    const auto& parp = paramsP->GetParams();
-    for (uint32_t i = sizeQ, j = 0; i < sizeQP; ++i, ++j) {
-        moduliQP[i] = parp[j]->GetModulus();
-        rootsQP[i]  = parp[j]->GetRootOfUnity();
-    }
-    return std::make_shared<Params>(2 * m_params->GetRingDimension(), moduliQP, rootsQP);
+    return std::make_shared<Params>(*m_params, static_cast<uint32_t>(m_vectors.size()), *paramsP,
+                                    static_cast<uint32_t>(paramsP->GetParams().size()));
 }
 
 template <typename VecType>

--- a/src/core/include/lattice/hal/default/ildcrtparams.h
+++ b/src/core/include/lattice/hal/default/ildcrtparams.h
@@ -192,6 +192,47 @@ public:
         RecalculateModulus();
     }
 
+    /**
+   * @brief Constructor for parameters over the leading towers of existing parameters.
+   * The component parameters are shared with the source object.
+   * @param params the source parameters.
+   * @param numTowers the number of leading towers to include (1 to params.GetParams().size()).
+   */
+    ILDCRTParams(const ILDCRTParams& params, uint32_t numTowers)
+        : ElemParams<IntType>(params.GetCyclotomicOrder(), 0) {
+        const auto& towers = params.GetParams();
+        if (numTowers == 0 || numTowers > towers.size())
+            OPENFHE_THROW("numTowers [" + std::to_string(numTowers) + "] must be in [1, " +
+                          std::to_string(towers.size()) + "]");
+        m_params.assign(towers.begin(), towers.begin() + numTowers);
+        RecalculateModulus();
+    }
+
+    /**
+   * @brief Constructor for a basis that concatenates the leading towers of two existing
+   * parameter objects: the first sizeA towers of paramsA followed by the first sizeB
+   * towers of paramsB (e.g., the key-switching basis Q_l*P built from the parameters of
+   * Q and P). The component parameters are shared with the source objects; the cyclotomic
+   * order is taken from paramsA.
+   * @param paramsA the source parameters for the leading part of the basis.
+   * @param sizeA the number of leading towers of paramsA to include.
+   * @param paramsB the source parameters for the trailing part of the basis.
+   * @param sizeB the number of leading towers of paramsB to include.
+   */
+    ILDCRTParams(const ILDCRTParams& paramsA, uint32_t sizeA, const ILDCRTParams& paramsB, uint32_t sizeB)
+        : ElemParams<IntType>(paramsA.GetCyclotomicOrder(), 0) {
+        const auto& towersA = paramsA.GetParams();
+        const auto& towersB = paramsB.GetParams();
+        if (sizeA == 0 || sizeA > towersA.size() || sizeB > towersB.size())
+            OPENFHE_THROW("sizeA [" + std::to_string(sizeA) + "] must be in [1, " + std::to_string(towersA.size()) +
+                          "] and sizeB [" + std::to_string(sizeB) + "] must be at most " +
+                          std::to_string(towersB.size()));
+        m_params.reserve(sizeA + sizeB);
+        m_params.assign(towersA.begin(), towersA.begin() + sizeA);
+        m_params.insert(m_params.end(), towersB.begin(), towersB.begin() + sizeB);
+        RecalculateModulus();
+    }
+
     ILDCRTParams(const ILDCRTParams& rhs) : ElemParams<IntType>(rhs), m_params(rhs.m_params) {}
 
     ILDCRTParams(ILDCRTParams&& rhs) noexcept

--- a/src/pke/examples/README.md
+++ b/src/pke/examples/README.md
@@ -22,6 +22,7 @@ File Listing
 - [advanced-ckks-bootstrapping.cpp](advanced-ckks-bootstrapping.cpp): an example showing CKKS bootstrapping for a ciphertext with sparse packing
 - [advanced-real-numbers.cpp](advanced-real-numbers.cpp): shows several advanced examples of approximate homomorphic encryption using CKKS
 - [advanced-real-numbers-128.cpp](advanced-real-numbers-128.cpp): shows several advanced examples of approximate homomorphic encryption using high-precision CKKS
+- [ckks-bootstrapping-leveled-keys.cpp](ckks-bootstrapping-leveled-keys.cpp): demonstrates generating the application's rotation keys at a reduced level (and CompressEvalKey) in a CKKS bootstrapping workload
 - [ckks-noise-flooding.cpp](ckks-noise-flooding.cpp): demonstrates use of experimental feature NOISE_FLOODING_DECRYPT mode in CKKS, which enhances security
 - [depth-bfvrns.cpp](depth-bfvrns.cpp): demonstrates use of the BFVrns scheme for basic homomorphic encryption
 - [depth-bfvrns-behz.cpp](depth-bfvrns-behz.cpp): demonstrates use of the BEHZ BFV variant for basic homomorphic encryption

--- a/src/pke/examples/ckks-bootstrapping-leveled-keys.cpp
+++ b/src/pke/examples/ckks-bootstrapping-leveled-keys.cpp
@@ -1,0 +1,257 @@
+//==================================================================================
+// BSD 2-Clause License
+//
+// Copyright (c) 2014-2026, NJIT, Duality Technologies Inc. and other contributors
+//
+// All rights reserved.
+//
+// Author TPOC: contact@openfhe.org
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//==================================================================================
+
+/*
+
+Example for generating the application's evaluation keys at a reduced level
+(https://github.com/openfheorg/openfhe-development/issues/413) in a CKKS
+bootstrapping workload.
+
+In an iterated computation (bootstrap -> compute -> bootstrap -> ...), the
+bootstrapping keys must be full-size: the CoeffsToSlots rotations run right
+after the modulus raise, at the largest number of RNS limbs. The application's
+own rotation keys, however, only ever touch post-bootstrap ciphertexts, which
+carry far fewer limbs. Generating those keys at the matching level (or
+compressing existing keys with CompressEvalKey) shrinks them substantially at
+no cost in performance or precision.
+
+*/
+
+#define PROFILE  // turns on the reporting of timing results
+
+#include "openfhe.h"
+
+// header files needed for (de)serialization to measure key sizes
+#include "cryptocontext-ser.h"
+#include "key/key-ser.h"
+#include "scheme/ckksrns/ckksrns-ser.h"
+
+#include <iostream>
+#include <sstream>
+#include <vector>
+
+using namespace lbcrypto;
+
+static double SerializedSizeMB(const EvalKey<DCRTPoly>& evalKey) {
+    std::stringstream ss;
+    Serial::Serialize(evalKey, ss, SerType::BINARY);
+    return static_cast<double>(ss.str().size()) / (1024.0 * 1024.0);
+}
+
+int main(int argc, char* argv[]) {
+    // Step 1: Set up the cryptocontext the same way as in simple-ckks-bootstrapping.cpp
+    CCParams<CryptoContextCKKSRNS> parameters;
+    SecretKeyDist secretKeyDist = UNIFORM_TERNARY;
+    parameters.SetSecretKeyDist(secretKeyDist);
+    // Use HEStd_NotSet only in non-production environments
+    parameters.SetSecurityLevel(HEStd_NotSet);
+    parameters.SetRingDim(1 << 12);
+
+#if NATIVEINT == 128
+    ScalingTechnique rescaleTech = FIXEDAUTO;
+    uint32_t dcrtBits            = 78;
+    uint32_t firstMod            = 89;
+#else
+    ScalingTechnique rescaleTech = FLEXIBLEAUTO;
+    uint32_t dcrtBits            = 59;
+    uint32_t firstMod            = 60;
+#endif
+    parameters.SetScalingModSize(dcrtBits);
+    parameters.SetScalingTechnique(rescaleTech);
+    parameters.SetFirstModSize(firstMod);
+
+    std::vector<uint32_t> levelBudget      = {4, 4};
+    uint32_t levelsAvailableAfterBootstrap = 10;
+    uint32_t depth = levelsAvailableAfterBootstrap + FHECKKSRNS::GetBootstrapDepth(levelBudget, secretKeyDist);
+    parameters.SetMultiplicativeDepth(depth);
+
+    CryptoContext<DCRTPoly> cryptoContext = GenCryptoContext(parameters);
+    cryptoContext->Enable(PKE);
+    cryptoContext->Enable(KEYSWITCH);
+    cryptoContext->Enable(LEVELEDSHE);
+    cryptoContext->Enable(ADVANCEDSHE);
+    cryptoContext->Enable(FHE);
+
+    uint32_t ringDim     = cryptoContext->GetRingDimension();
+    uint32_t numSlots    = ringDim / 2;
+    const uint32_t sizeQ = cryptoContext->GetElementParams()->GetParams().size();
+    std::cout << "CKKS scheme ring dimension: " << ringDim << ", RNS limbs in Q: " << sizeQ << "\n\n";
+
+    cryptoContext->EvalBootstrapSetup(levelBudget, {0, 0}, numSlots);
+
+    auto keyPair = cryptoContext->KeyGen();
+
+    // Step 2: Generate the keys that must remain FULL-SIZE.
+    // The relinearization key is used inside bootstrapping (EvalMod squarings) at a large
+    // number of limbs, and the CoeffsToSlots rotations run right after the modulus raise,
+    // so EvalBootstrapKeyGen must generate its keys at level 0.
+    cryptoContext->EvalMultKeyGen(keyPair.secretKey);
+    cryptoContext->EvalBootstrapKeyGen(keyPair.secretKey, numSlots);
+
+    // Step 3: Bootstrap once to observe how many limbs a post-bootstrap ciphertext carries.
+    // This is the largest ciphertext the application's own rotation keys will ever touch.
+    std::vector<double> x = {0.25, 0.5, 0.75, 1.0, 2.0, 3.0, 4.0, 5.0};
+    size_t encodedLength  = x.size();
+
+    // start from a depleted ciphertext that has used up all of its levels
+    Plaintext ptxt            = cryptoContext->MakeCKKSPackedPlaintext(x, 1, depth - 1);
+    Ciphertext<DCRTPoly> ciph = cryptoContext->Encrypt(keyPair.publicKey, ptxt);
+
+    TimeVar t;
+    TIC(t);
+    auto ciphertextAfter        = cryptoContext->EvalBootstrap(ciph);
+    double timeBootstrap        = TOC(t);
+    const uint32_t limbsAfterBT = ciphertextAfter->GetElements()[0].GetNumOfElements();
+    std::cout << "EvalBootstrap: " << timeBootstrap << " ms\n";
+
+    // the number of limbs to drop from the application's rotation keys
+    const uint32_t appKeyLevels = sizeQ - limbsAfterBT;
+    std::cout << "Limbs in a post-bootstrap ciphertext: " << limbsAfterBT << " (out of " << sizeQ << ")\n";
+    std::cout << "Application rotation keys are generated with levels = " << appKeyLevels << "\n";
+
+    // Step 4: Choose the application's rotation indices.
+    // EvalBootstrapKeyGen has already stored full-size keys for its own rotation indices
+    // under the same secret key. Requesting a reduced key for one of those indices is a
+    // no-op (the cryptocontext keeps the more capable, full-size key), which is correct but
+    // saves nothing for that index. To make the savings visible, this example picks
+    // rotation indices that do not overlap the bootstrapping set. We also reserve two
+    // extra non-overlapping indices for full-size reference keys used in the comparisons.
+    //
+    // Clearing the key map and regenerating does not change this picture: the bootstrapping
+    // keys must be regenerated full-size, and whichever set is generated first, an index
+    // used by bootstrapping ends up with its full-size key (there is one map slot per
+    // index, and bootstrapping needs the full key in it). Clearing is the right tool only
+    // when a pipeline is done bootstrapping for good: then ClearEvalAutomorphismKeys(keyTag)
+    // followed by regenerating only the application's keys at the reduced level also frees
+    // the entire (much larger) bootstrapping key set.
+    const uint32_t M   = 2 * ringDim;
+    const auto& algo   = cryptoContext->GetScheme();
+    const auto& keyMap = CryptoContextImpl<DCRTPoly>::GetEvalAutomorphismKeyMap(keyPair.secretKey->GetKeyTag());
+
+    std::vector<int32_t> freshRots;
+    for (int32_t r = 1; freshRots.size() < 4 && r < 1000; ++r) {
+        if (keyMap.find(algo->FindAutomorphismIndex(r, M)) == keyMap.end())
+            freshRots.push_back(r);
+    }
+    if (freshRots.size() < 4) {
+        std::cerr << "Could not find enough rotation indices without existing keys\n";
+        return 1;
+    }
+    const int32_t appRot1 = freshRots[0];
+    const int32_t appRot2 = freshRots[1];
+    const int32_t refRot1 = freshRots[2];
+    const int32_t refRot2 = freshRots[3];
+    std::cout << "Application rotation indices (chosen to not overlap the bootstrapping rotations): " << appRot1
+              << ", " << appRot2 << "\n\n";
+
+    // Step 5: Generate the application's keys at the reduced level, and two full-size
+    // reference keys for the same-shaped comparisons. Key generation scales with the key's
+    // size (digits x limbs), so the reduced keys should be proportionally faster to generate.
+    TIC(t);
+    cryptoContext->EvalRotateKeyGen(keyPair.secretKey, {appRot1, appRot2}, appKeyLevels);
+    double timeKeyGenReduced = TOC(t);
+    TIC(t);
+    cryptoContext->EvalRotateKeyGen(keyPair.secretKey, {refRot1, refRot2});
+    double timeKeyGenFull = TOC(t);
+
+    const auto& keyApp  = keyMap.at(algo->FindAutomorphismIndex(appRot1, M));
+    const auto& keyFull = keyMap.at(algo->FindAutomorphismIndex(refRot1, M));
+    std::cout << "Full-size rotation key:   " << keyFull->GetAVector()[0].GetNumOfElements() << " limbs, "
+              << SerializedSizeMB(keyFull) << " MB\n";
+    std::cout << "Application rotation key: " << keyApp->GetAVector()[0].GetNumOfElements() << " limbs, "
+              << SerializedSizeMB(keyApp) << " MB\n";
+
+    // CompressEvalKey produces the same reduction for a key that already exists:
+    auto keyCompressed = cryptoContext->CompressEvalKey(keyFull, appKeyLevels);
+    std::cout << "The full key compressed:  " << keyCompressed->GetAVector()[0].GetNumOfElements() << " limbs, "
+              << SerializedSizeMB(keyCompressed) << " MB\n\n";
+
+    // Step 6: Timings.
+    // Applying a key does NOT depend on the key's size - the cost of EvalRotate is
+    // determined by the ciphertext's limbs - so the two rotation timings below should be
+    // about equal.
+    constexpr uint32_t numTrials = 10;
+    TIC(t);
+    for (uint32_t i = 0; i < numTrials; ++i) {
+        auto tmp = cryptoContext->EvalRotate(ciphertextAfter, refRot1);
+    }
+    double timeRotFull = TOC(t) / numTrials;
+    TIC(t);
+    for (uint32_t i = 0; i < numTrials; ++i) {
+        auto tmp = cryptoContext->EvalRotate(ciphertextAfter, appRot1);
+    }
+    double timeRotReduced = TOC(t) / numTrials;
+
+    std::cout << "Timings:\n";
+    std::cout << "  rotation key generation, 2 full-size keys: " << timeKeyGenFull << " ms\n";
+    std::cout << "  rotation key generation, 2 reduced keys:   " << timeKeyGenReduced << " ms\n";
+    std::cout << "  EvalRotate with the full-size key:         " << timeRotFull << " ms (avg of " << numTrials
+              << ")\n";
+    std::cout << "  EvalRotate with the reduced key:           " << timeRotReduced << " ms (avg of " << numTrials
+              << ")\n\n";
+
+    // Step 7: Compute on the bootstrapped ciphertext using the reduced keys:
+    // a sliding-window sum followed by a squaring.
+    auto ciphSum = cryptoContext->EvalAdd(ciphertextAfter, cryptoContext->EvalRotate(ciphertextAfter, appRot1));
+    ciphSum      = cryptoContext->EvalAdd(ciphSum, cryptoContext->EvalRotate(ciphertextAfter, appRot2));
+    auto ciphOut = cryptoContext->EvalMult(ciphSum, ciphSum);
+
+    Plaintext result;
+    cryptoContext->Decrypt(keyPair.secretKey, ciphOut, &result);
+    result->SetLength(encodedLength);
+
+    auto xAt = [&x, encodedLength](size_t i) {
+        return (i < encodedLength) ? x[i] : 0.0;
+    };
+    std::cout << "Expected (x[i] + x[i+" << appRot1 << "] + x[i+" << appRot2 << "])^2: ";
+    for (size_t i = 0; i < encodedLength; ++i) {
+        double s = xAt(i) + xAt(i + appRot1) + xAt(i + appRot2);
+        std::cout << s * s << ((i + 1 < encodedLength) ? " " : "\n");
+    }
+    std::cout << "Computed with reduced keys: " << result;
+
+    // Step 8: The reduced keys refuse ciphertexts with more limbs than they support.
+    // A freshly encrypted ciphertext at level 0 carries all limbs, so rotating it with one
+    // of the application's reduced keys throws an informative exception.
+    auto ptxtFresh = cryptoContext->MakeCKKSPackedPlaintext(x);
+    auto ciphFresh = cryptoContext->Encrypt(keyPair.publicKey, ptxtFresh);
+    try {
+        cryptoContext->EvalRotate(ciphFresh, appRot1);
+        std::cout << "\nERROR: rotating a full-size ciphertext with a reduced key should have thrown\n";
+    }
+    catch (const OpenFHEException& e) {
+        std::cout << "\nRotating a fresh (full-size) ciphertext with a reduced key throws, as expected:\n    "
+                  << e.what() << "\n";
+    }
+
+    cryptoContext->ClearStaticMapsAndVectors();
+    return 0;
+}

--- a/src/pke/include/cryptocontext.h
+++ b/src/pke/include/cryptocontext.h
@@ -334,6 +334,15 @@ protected:
         }
     }
 
+    void ValidateEvalKeyGenLevels(uint32_t levels, CALLER_INFO_ARGS_HDR) const {
+        if (levels > 0 && getSchemeId() == SCHEME::BFVRNS_SCHEME) {
+            std::string errorMsg(
+                std::string("Generating or compressing evaluation keys at a nonzero level is not supported for BFV") +
+                CALLER_INFO);
+            OPENFHE_THROW(errorMsg);
+        }
+    }
+
     void ValidateCiphertext(ConstCiphertext<Element>& ciphertext, CALLER_INFO_ARGS_HDR) const {
         if (ciphertext == nullptr) {
             std::string errorMsg(std::string("Ciphertext is nullptr") + CALLER_INFO);
@@ -1063,17 +1072,19 @@ public:
     /**
     * @brief Getter for the level at which evaluation keys should be generated
     * @return level
-    * @attention For future use
+    * @deprecated Use the levels argument of the Eval*KeyGen/KeySwitchGen methods instead.
     */
-    size_t GetKeyGenLevel() const {
+    size_t GetKeyGenLevel() const __attribute__((deprecated(
+        "Use the levels argument of the Eval*KeyGen/KeySwitchGen methods instead"))) {
         return m_keyGenLevel;
     }
 
     /**
     * @brief Setter for the level at which evaluation keys should be generated
-    * @attention For future use
+    * @deprecated Use the levels argument of the Eval*KeyGen/KeySwitchGen methods instead.
     */
-    void SetKeyGenLevel(size_t level) {
+    void SetKeyGenLevel(size_t level) __attribute__((deprecated(
+        "Use the levels argument of the Eval*KeyGen/KeySwitchGen methods instead"))) {
         m_keyGenLevel = level;
     }
 
@@ -1423,13 +1434,34 @@ public:
     *
     * @param oldPrivateKey  Original secret key.
     * @param newPrivateKey  Target secret key.
+    * @param levels         Number of RNS limbs to drop from the generated key relative to a
+    *                       full key (0 by default). The key can only be applied to ciphertexts
+    *                       with at most (full - levels) limbs. Not supported for BFV.
     * @return New evaluation key for key switching.
     */
-    EvalKey<Element> KeySwitchGen(const PrivateKey<Element>& oldPrivateKey,
-                                  const PrivateKey<Element>& newPrivateKey) const {
+    EvalKey<Element> KeySwitchGen(const PrivateKey<Element>& oldPrivateKey, const PrivateKey<Element>& newPrivateKey,
+                                  uint32_t levels = 0) const {
         ValidateKey(oldPrivateKey);
         ValidateKey(newPrivateKey);
-        return m_scheme->KeySwitchGen(oldPrivateKey, newPrivateKey);
+        ValidateEvalKeyGenLevels(levels);
+        return m_scheme->KeySwitchGen(oldPrivateKey, newPrivateKey, levels);
+    }
+
+    /**
+    * @brief Creates a copy of an evaluation key with a reduced number of RNS limbs.
+    *
+    * The compressed key can only be applied to ciphertexts with at most as many limbs as the
+    * compressed key, but takes less memory and makes the corresponding homomorphic operations
+    * faster. Not supported for BFV.
+    *
+    * @param evalKey  Evaluation key to compress.
+    * @param levels   Number of RNS limbs to drop from the Q basis of the key.
+    * @return Compressed evaluation key.
+    */
+    EvalKey<Element> CompressEvalKey(const EvalKey<Element>& evalKey, uint32_t levels) const {
+        ValidateKey(evalKey);
+        ValidateEvalKeyGenLevels(levels);
+        return m_scheme->CompressEvalKey(evalKey, levels);
     }
 
     /**
@@ -1923,9 +1955,12 @@ public:
     * @brief Creates a relinearization key (for s^2) that can be used with the OpenFHE EvalMult operator
     *
     * @param key secret key
+    * @param levels number of RNS limbs to drop from the generated key relative to a full key
+    * (0 by default). The key can only be applied to ciphertexts with at most (full - levels)
+    * limbs. Not supported for BFV.
     * @note the new evaluation key is stored in cryptocontext
     */
-    void EvalMultKeyGen(const PrivateKey<Element>& key);
+    void EvalMultKeyGen(const PrivateKey<Element>& key, uint32_t levels = 0);
 
     /**
     * @brief Creates a vector evalmult keys that can be used with the OpenFHE EvalMult operator
@@ -1934,8 +1969,10 @@ public:
     * @note 1st key (for s^2) is used for multiplication of ciphertexts of depth 1,
     * 2nd key (for s^3) is used for multiplication of ciphertexts of depth 2, etc.
     * A vector of new evaluation keys is stored in crytpocontext
+    * @param levels number of RNS limbs to drop from the generated keys relative to full keys
+    * (0 by default). Not supported for BFV.
     */
-    void EvalMultKeysGen(const PrivateKey<Element>& key);
+    void EvalMultKeysGen(const PrivateKey<Element>& key, uint32_t levels = 0);
 
     /**
     * @brief Homomorphic multiplication of two ciphertexts using a relinearization key.
@@ -2302,14 +2339,18 @@ public:
     *
     * @param privateKey   Private key to use for key generation.
     * @param indexList    List of automorphism indices to be computed.
+    * @param levels       Number of RNS limbs to drop from the generated keys relative to full
+    *                     keys (0 by default). The keys can only be applied to ciphertexts with
+    *                     at most (full - levels) limbs. Not supported for BFV.
     * @return Map of generated evaluation keys.
     */
     std::shared_ptr<std::map<uint32_t, EvalKey<Element>>> EvalAutomorphismKeyGen(
-        const PrivateKey<Element> privateKey, const std::vector<uint32_t>& indexList) const {
+        const PrivateKey<Element> privateKey, const std::vector<uint32_t>& indexList, uint32_t levels = 0) const {
         ValidateKey(privateKey);
         if (indexList.empty())
             OPENFHE_THROW("Input index vector is empty");
-        auto evalKeys = m_scheme->EvalAutomorphismKeyGen(privateKey, indexList);
+        ValidateEvalKeyGenLevels(levels);
+        auto evalKeys = m_scheme->EvalAutomorphismKeyGen(privateKey, indexList, levels);
         CryptoContextImpl<Element>::InsertEvalAutomorphismKey(evalKeys, privateKey->GetKeyTag());
         return evalKeys;
     }
@@ -2527,17 +2568,24 @@ public:
     *
     * @param privateKey  Private key used for key generation.
     * @param indexList   List of rotation indices.
+    * @param levels      Number of RNS limbs to drop from the generated keys relative to full
+    *                    keys (0 by default). The keys can only be applied to ciphertexts with
+    *                    at most (full - levels) limbs. Not supported for BFV.
     */
-    void EvalAtIndexKeyGen(const PrivateKey<Element> privateKey, const std::vector<int32_t>& indexList);
+    void EvalAtIndexKeyGen(const PrivateKey<Element> privateKey, const std::vector<int32_t>& indexList,
+                           uint32_t levels = 0);
 
     /**
     * @brief Generates rotation evaluation keys for a list of indices. Internally calls EvalAtIndexKeyGen.
     *
     * @param privateKey  Private key used for key generation.
     * @param indexList   List of rotation indices.
+    * @param levels      Number of RNS limbs to drop from the generated keys relative to full
+    *                    keys (0 by default). Not supported for BFV.
     */
-    void EvalRotateKeyGen(const PrivateKey<Element> privateKey, const std::vector<int32_t>& indexList) {
-        EvalAtIndexKeyGen(privateKey, indexList);
+    void EvalRotateKeyGen(const PrivateKey<Element> privateKey, const std::vector<int32_t>& indexList,
+                          uint32_t levels = 0) {
+        EvalAtIndexKeyGen(privateKey, indexList, levels);
     };
 
     /**
@@ -3003,8 +3051,11 @@ public:
     * @brief Generates evaluation keys required for homomorphic summation (EvalSum).
     *
     * @param privateKey  Private key used for key generation.
+    * @param levels      Number of RNS limbs to drop from the generated keys relative to full
+    *                    keys (0 by default). The keys can only be applied to ciphertexts with
+    *                    at most (full - levels) limbs. Not supported for BFV.
     */
-    void EvalSumKeyGen(const PrivateKey<Element> privateKey);
+    void EvalSumKeyGen(const PrivateKey<Element> privateKey, uint32_t levels = 0);
 
     /**
     * @brief Generates automorphism keys for EvalSumRows (only for packed encoding).
@@ -3013,11 +3064,14 @@ public:
     * @param publicKey     Public key (used in NTRU schemes; unused now).
     * @param rowSize       Number of slots per row in the packed matrix.
     * @param subringDim    Subring dimension (use cyclotomic order if 0).
+    * @param levels        Number of RNS limbs to drop from the generated keys relative to full
+    *                      keys (0 by default).
     * @return Map of generated evaluation keys.
     */
     std::shared_ptr<std::map<uint32_t, EvalKey<Element>>> EvalSumRowsKeyGen(const PrivateKey<Element> privateKey,
                                                                             uint32_t rowSize    = 0,
-                                                                            uint32_t subringDim = 0);
+                                                                            uint32_t subringDim = 0,
+                                                                            uint32_t levels     = 0);
 
     // TODO: this is here for backwards compatibility; should remove in v2.0
     std::shared_ptr<std::map<uint32_t, EvalKey<Element>>> EvalSumRowsKeyGen(const PrivateKey<Element> privateKey,
@@ -3030,9 +3084,12 @@ public:
     *
     * @param privateKey  Private key used for key generation.
     * @param publicKey   Public key (used in NTRU schemes; unused now).
+    * @param levels      Number of RNS limbs to drop from the generated keys relative to full
+    *                    keys (0 by default).
     * @return Map of generated evaluation keys.
     */
-    std::shared_ptr<std::map<uint32_t, EvalKey<Element>>> EvalSumColsKeyGen(const PrivateKey<Element> privateKey);
+    std::shared_ptr<std::map<uint32_t, EvalKey<Element>>> EvalSumColsKeyGen(const PrivateKey<Element> privateKey,
+                                                                            uint32_t levels = 0);
 
     /**
     * @brief Computes the sum of all components in a packed ciphertext vector.
@@ -4048,11 +4105,22 @@ public:
     * @return indices that do not have automorphism keys associated with
     */
     static std::set<uint32_t> GetEvalAutomorphismNoKeyIndices(const std::string& keyTag,
-                                                              const std::set<uint32_t>& indices) {
-        std::set<uint32_t> existingIndices{CryptoContextImpl<Element>::GetExistingEvalAutomorphismKeyIndices(keyTag)};
-        // if no index found for the given keyTag, then the entire set "indices" is returned
-        return (existingIndices.empty()) ? indices :
-                                           CryptoContextImpl<Element>::GetUniqueValues(existingIndices, indices);
+                                                              const std::set<uint32_t>& indices,
+                                                              uint32_t minNumTowers = 0) {
+        auto keyMapIt = CryptoContextImpl<Element>::s_evalAutomorphismKeyMap.find(keyTag);
+        // if no key found for the given keyTag, then the entire set "indices" is returned
+        if (keyMapIt == CryptoContextImpl<Element>::s_evalAutomorphismKeyMap.end())
+            return indices;
+
+        // keys that exist but have fewer towers than minNumTowers must be regenerated
+        const auto& keyMap = *(keyMapIt->second);
+        std::set<uint32_t> indicesToGenerate;
+        for (uint32_t indx : indices) {
+            auto it = keyMap.find(indx);
+            if (it == keyMap.end() || it->second->GetAVector()[0].GetNumOfElements() < minNumTowers)
+                indicesToGenerate.insert(indx);
+        }
+        return indicesToGenerate;
     }
 
     /**

--- a/src/pke/include/keyswitch/README.md
+++ b/src/pke/include/keyswitch/README.md
@@ -43,3 +43,14 @@ graph BT
 - Hybrid key switching method first introduced in https://eprint.iacr.org/2012/099.pdf
 - RNS version was introduced in https://eprint.iacr.org/2019/688.
 - See the Appendix of https://eprint.iacr.org/2021/204 for more detailed description.
+
+## Evaluation keys at a specified level
+
+Key-switching keys can be generated with fewer RNS limbs than the cryptocontext by passing
+the optional `levels` argument to the `Eval*KeyGen`/`KeySwitchGen` methods (the number of
+limbs dropped relative to a full key), or by compressing an existing key with
+`CompressEvalKey`. A reduced key can be applied to any ciphertext with at most
+(full &minus; `levels`) limbs, at identical runtime cost and noise; it is proportionally
+smaller and faster to generate. Supported for BGV and CKKS with both BV and HYBRID key
+switching (BFV throws for a nonzero level). For duplicate rotation indices, the
+cryptocontext keeps the key with the most limbs.

--- a/src/pke/include/keyswitch/keyswitch-base.h
+++ b/src/pke/include/keyswitch/keyswitch-base.h
@@ -73,22 +73,51 @@ public:
    *
    * @param &originalPrivateKey Original private key used for encryption.
    * @param &newPrivateKey New private key to generate the keyswitch hint.
+   * @param levels number of RNS limbs to drop from the generated key relative to a full
+   * key; the key can only be applied to ciphertexts with at most (full - levels) limbs.
    * @param *KeySwitchHint is where the resulting keySwitchHint will be
    * placed.
    */
     virtual EvalKey<Element> KeySwitchGenInternal(const PrivateKey<Element> oldPrivateKey,
-                                                  const PrivateKey<Element> newPrivateKey) const {
+                                                  const PrivateKey<Element> newPrivateKey, uint32_t levels = 0) const {
         OPENFHE_THROW(NOT_SUPPORTED_ERROR);
     }
 
     virtual EvalKey<Element> KeySwitchGenInternal(const PrivateKey<Element> oldPrivateKey,
                                                   const PrivateKey<Element> newPrivateKey,
-                                                  const EvalKey<Element> evalKey) const {
+                                                  const EvalKey<Element> evalKey, uint32_t levels = 0) const {
         OPENFHE_THROW(NOT_SUPPORTED_ERROR);
     }
 
     virtual EvalKey<Element> KeySwitchGenInternal(const PrivateKey<Element> oldPrivateKey,
                                                   const PublicKey<Element> newPublicKey) const {
+        OPENFHE_THROW(NOT_SUPPORTED_ERROR);
+    }
+
+    /**
+   * Creates a copy of an existing evaluation key with `levels` RNS limbs removed from its
+   * Q basis. The compressed key can only be applied to ciphertexts with at most as many
+   * limbs as the compressed key.
+   *
+   * @param evalKey the evaluation key to compress.
+   * @param levels number of RNS limbs to drop.
+   * @return the compressed evaluation key.
+   */
+    virtual EvalKey<Element> CompressEvalKey(const EvalKey<Element> evalKey, uint32_t levels) const {
+        OPENFHE_THROW(NOT_SUPPORTED_ERROR);
+    }
+
+    /**
+   * Number of towers in each ring element of a key-switching key generated with `levels`
+   * RNS limbs dropped. Used to decide whether an existing evaluation key can serve in
+   * place of a newly requested one.
+   *
+   * @param cryptoParams the crypto parameters of the context.
+   * @param levels number of RNS limbs to drop.
+   * @return the number of towers of each element of such a key.
+   */
+    virtual uint32_t GetNumEvalKeyTowers(const std::shared_ptr<CryptoParametersBase<Element>> cryptoParams,
+                                         uint32_t levels) const {
         OPENFHE_THROW(NOT_SUPPORTED_ERROR);
     }
 

--- a/src/pke/include/keyswitch/keyswitch-bv.h
+++ b/src/pke/include/keyswitch/keyswitch-bv.h
@@ -65,14 +65,19 @@ public:
     virtual ~KeySwitchBV() = default;
 
     EvalKey<DCRTPoly> KeySwitchGenInternal(const PrivateKey<DCRTPoly> oldPrivateKey,
-                                           const PrivateKey<DCRTPoly> newPrivateKey) const override;
+                                           const PrivateKey<DCRTPoly> newPrivateKey, uint32_t levels = 0) const override;
 
     EvalKey<DCRTPoly> KeySwitchGenInternal(const PrivateKey<DCRTPoly> oldPrivateKey,
-                                           const PrivateKey<DCRTPoly> newPrivateKey,
-                                           const EvalKey<DCRTPoly> evalKey) const override;
+                                           const PrivateKey<DCRTPoly> newPrivateKey, const EvalKey<DCRTPoly> evalKey,
+                                           uint32_t levels = 0) const override;
 
     EvalKey<DCRTPoly> KeySwitchGenInternal(const PrivateKey<DCRTPoly> oldPrivateKey,
                                            const PublicKey<DCRTPoly> newPublicKey) const override;
+
+    EvalKey<DCRTPoly> CompressEvalKey(const EvalKey<DCRTPoly> evalKey, uint32_t levels) const override;
+
+    uint32_t GetNumEvalKeyTowers(const std::shared_ptr<CryptoParametersBase<DCRTPoly>> cryptoParams,
+                                 uint32_t levels) const override;
 
     void KeySwitchInPlace(Ciphertext<DCRTPoly>& ciphertext, const EvalKey<DCRTPoly> evalKey) const override;
 

--- a/src/pke/include/keyswitch/keyswitch-hybrid.h
+++ b/src/pke/include/keyswitch/keyswitch-hybrid.h
@@ -73,14 +73,19 @@ public:
     virtual ~KeySwitchHYBRID() = default;
 
     EvalKey<DCRTPoly> KeySwitchGenInternal(const PrivateKey<DCRTPoly> oldPrivateKey,
-                                           const PrivateKey<DCRTPoly> newPrivateKey) const override;
+                                           const PrivateKey<DCRTPoly> newPrivateKey, uint32_t levels = 0) const override;
 
     EvalKey<DCRTPoly> KeySwitchGenInternal(const PrivateKey<DCRTPoly> oldPrivateKey,
-                                           const PrivateKey<DCRTPoly> newPrivateKey,
-                                           const EvalKey<DCRTPoly> evalKey) const override;
+                                           const PrivateKey<DCRTPoly> newPrivateKey, const EvalKey<DCRTPoly> evalKey,
+                                           uint32_t levels = 0) const override;
 
     EvalKey<DCRTPoly> KeySwitchGenInternal(const PrivateKey<DCRTPoly> oldPrivateKey,
                                            const PublicKey<DCRTPoly> newPublicKey) const override;
+
+    EvalKey<DCRTPoly> CompressEvalKey(const EvalKey<DCRTPoly> evalKey, uint32_t levels) const override;
+
+    uint32_t GetNumEvalKeyTowers(const std::shared_ptr<CryptoParametersBase<DCRTPoly>> cryptoParams,
+                                 uint32_t levels) const override;
 
     void KeySwitchInPlace(Ciphertext<DCRTPoly>& ciphertext, const EvalKey<DCRTPoly> evalKey) const override;
 

--- a/src/pke/include/schemebase/base-advancedshe.h
+++ b/src/pke/include/schemebase/base-advancedshe.h
@@ -361,10 +361,11 @@ public:
    * only for packed encoding
    *
    * @param privateKey private key.
+   * @param levels number of RNS limbs to drop from the generated keys relative to full keys
    * @return returns the evaluation keys
    */
-    virtual std::shared_ptr<std::map<uint32_t, EvalKey<Element>>> EvalSumKeyGen(
-        const PrivateKey<Element> privateKey) const;
+    virtual std::shared_ptr<std::map<uint32_t, EvalKey<Element>>> EvalSumKeyGen(const PrivateKey<Element> privateKey,
+                                                                                uint32_t levels = 0) const;
 
     /**
    * Virtual function to generate the automorphism keys for EvalSumRows; works
@@ -377,8 +378,8 @@ public:
    * @return returns the evaluation keys
    */
     virtual std::shared_ptr<std::map<uint32_t, EvalKey<Element>>> EvalSumRowsKeyGen(
-        const PrivateKey<Element> privateKey, uint32_t rowSize, uint32_t subringDim,
-        std::vector<uint32_t>& indices) const;
+        const PrivateKey<Element> privateKey, uint32_t rowSize, uint32_t subringDim, std::vector<uint32_t>& indices,
+        uint32_t levels = 0) const;
 
     /**
    * Virtual function to generate the automorphism keys for EvalSumCols; works
@@ -389,7 +390,7 @@ public:
    * @return returns the evaluation keys
    */
     virtual std::shared_ptr<std::map<uint32_t, EvalKey<Element>>> EvalSumColsKeyGen(
-        const PrivateKey<Element> privateKey, std::vector<uint32_t>& indices) const;
+        const PrivateKey<Element> privateKey, std::vector<uint32_t>& indices, uint32_t levels = 0) const;
 
     /**
     * @brief Sums all elements in log (batch size) time - works only with packedvencoding

--- a/src/pke/include/schemebase/base-leveledshe.h
+++ b/src/pke/include/schemebase/base-leveledshe.h
@@ -314,7 +314,7 @@ public:
    * the same secret key as that of ciphertext1 and ciphertext2.
    * @param *newCiphertext the new resulting ciphertext.
    */
-    virtual EvalKey<Element> EvalMultKeyGen(const PrivateKey<Element> privateKey) const;
+    virtual EvalKey<Element> EvalMultKeyGen(const PrivateKey<Element> privateKey, uint32_t levels = 0) const;
 
     /**
    * Virtual function to define the interface for generating a evaluation key
@@ -323,7 +323,8 @@ public:
    * @param &originalPrivateKey Original private key used for encryption.
    * @param *evalMultKeys the resulting evalution key vector list.
    */
-    virtual std::vector<EvalKey<Element>> EvalMultKeysGen(const PrivateKey<Element> privateKey) const;
+    virtual std::vector<EvalKey<Element>> EvalMultKeysGen(const PrivateKey<Element> privateKey,
+                                                          uint32_t levels = 0) const;
 
     //------------------------------------------------------------------------------
     // EVAL MULTIPLICATION CIPHERTEXT & CIPHERTEXT
@@ -567,7 +568,7 @@ public:
    * @return returns the evaluation keys
    */
     virtual std::shared_ptr<std::map<uint32_t, EvalKey<Element>>> EvalAutomorphismKeyGen(
-        const PrivateKey<Element> privateKey, const std::vector<uint32_t>& indexList) const;
+        const PrivateKey<Element> privateKey, const std::vector<uint32_t>& indexList, uint32_t levels = 0) const;
 
     /**
    * Virtual function for evaluating automorphism of ciphertext at index i
@@ -640,7 +641,7 @@ public:
    * @return returns the evaluation keys
    */
     virtual std::shared_ptr<std::map<uint32_t, EvalKey<Element>>> EvalAtIndexKeyGen(
-        const PrivateKey<Element> privateKey, const std::vector<int32_t>& indexList) const;
+        const PrivateKey<Element> privateKey, const std::vector<int32_t>& indexList, uint32_t levels = 0) const;
 
     /**
    * Moves i-th slot to slot 0

--- a/src/pke/include/schemebase/base-scheme.h
+++ b/src/pke/include/schemebase/base-scheme.h
@@ -252,22 +252,33 @@ public:
     /////////////////////////////////////////
 
     virtual EvalKey<Element> KeySwitchGen(const PrivateKey<Element> oldPrivateKey,
-                                          const PrivateKey<Element> newPrivateKey) const {
+                                          const PrivateKey<Element> newPrivateKey, uint32_t levels = 0) const {
         VerifyKeySwitchEnabled(__func__);
-        return m_KeySwitch->KeySwitchGenInternal(oldPrivateKey, newPrivateKey);
+        return m_KeySwitch->KeySwitchGenInternal(oldPrivateKey, newPrivateKey, levels);
     }
 
     virtual EvalKey<Element> KeySwitchGen(const PrivateKey<Element> oldPrivateKey,
-                                          const PrivateKey<Element> newPrivateKey,
-                                          const EvalKey<Element> evalKey) const {
+                                          const PrivateKey<Element> newPrivateKey, const EvalKey<Element> evalKey,
+                                          uint32_t levels = 0) const {
         VerifyKeySwitchEnabled(__func__);
-        return m_KeySwitch->KeySwitchGenInternal(oldPrivateKey, newPrivateKey, evalKey);
+        return m_KeySwitch->KeySwitchGenInternal(oldPrivateKey, newPrivateKey, evalKey, levels);
     }
 
     virtual EvalKey<Element> KeySwitchGen(const PrivateKey<Element> oldPrivateKey,
                                           const PublicKey<Element> newPublicKey) const {
         VerifyKeySwitchEnabled(__func__);
         return m_KeySwitch->KeySwitchGenInternal(oldPrivateKey, newPublicKey);
+    }
+
+    virtual EvalKey<Element> CompressEvalKey(const EvalKey<Element> evalKey, uint32_t levels) const {
+        VerifyKeySwitchEnabled(__func__);
+        return m_KeySwitch->CompressEvalKey(evalKey, levels);
+    }
+
+    virtual uint32_t GetNumEvalKeyTowers(const std::shared_ptr<CryptoParametersBase<Element>> cryptoParams,
+                                         uint32_t levels) const {
+        VerifyKeySwitchEnabled(__func__);
+        return m_KeySwitch->GetNumEvalKeyTowers(cryptoParams, levels);
     }
 
     virtual Ciphertext<Element> KeySwitch(ConstCiphertext<Element>& ciphertext, const EvalKey<Element> evalKey) const {
@@ -483,9 +494,10 @@ public:
     // SHE MULTIPLICATION Wrapper
     /////////////////////////////////////////
 
-    virtual EvalKey<Element> EvalMultKeyGen(const PrivateKey<Element> privateKey) const;
+    virtual EvalKey<Element> EvalMultKeyGen(const PrivateKey<Element> privateKey, uint32_t levels = 0) const;
 
-    virtual std::vector<EvalKey<Element>> EvalMultKeysGen(const PrivateKey<Element> privateKey) const;
+    virtual std::vector<EvalKey<Element>> EvalMultKeysGen(const PrivateKey<Element> privateKey,
+                                                          uint32_t levels = 0) const;
 
     virtual Ciphertext<Element> EvalMult(ConstCiphertext<Element>& ciphertext1,
                                          ConstCiphertext<Element>& ciphertext2) const {
@@ -640,7 +652,7 @@ public:
     /////////////////////////////////////////
 
     virtual std::shared_ptr<std::map<uint32_t, EvalKey<Element>>> EvalAutomorphismKeyGen(
-        const PrivateKey<Element> privateKey, const std::vector<uint32_t>& indexList) const;
+        const PrivateKey<Element> privateKey, const std::vector<uint32_t>& indexList, uint32_t levels = 0) const;
 
     virtual Ciphertext<Element> EvalAutomorphism(ConstCiphertext<Element>& ciphertext, uint32_t i,
                                                  const std::map<uint32_t, EvalKey<Element>>& evalKeyMap,
@@ -721,7 +733,7 @@ public:
     }
 
     virtual std::shared_ptr<std::map<uint32_t, EvalKey<Element>>> EvalAtIndexKeyGen(
-        const PrivateKey<Element> privateKey, const std::vector<int32_t>& indexList) const;
+        const PrivateKey<Element> privateKey, const std::vector<int32_t>& indexList, uint32_t levels = 0) const;
 
     virtual Ciphertext<Element> EvalAtIndex(ConstCiphertext<Element>& ciphertext, uint32_t i,
                                             const std::map<uint32_t, EvalKey<Element>>& evalKeyMap) const {
@@ -949,15 +961,15 @@ public:
     // Advanced SHE EVAL SUM
     /////////////////////////////////////
 
-    virtual std::shared_ptr<std::map<uint32_t, EvalKey<Element>>> EvalSumKeyGen(
-        const PrivateKey<Element> privateKey) const;
+    virtual std::shared_ptr<std::map<uint32_t, EvalKey<Element>>> EvalSumKeyGen(const PrivateKey<Element> privateKey,
+                                                                                uint32_t levels = 0) const;
 
     virtual std::shared_ptr<std::map<uint32_t, EvalKey<Element>>> EvalSumRowsKeyGen(
-        const PrivateKey<Element> privateKey, uint32_t rowSize, uint32_t subringDim,
-        std::vector<uint32_t>& indices) const;
+        const PrivateKey<Element> privateKey, uint32_t rowSize, uint32_t subringDim, std::vector<uint32_t>& indices,
+        uint32_t levels = 0) const;
 
     virtual std::shared_ptr<std::map<uint32_t, EvalKey<Element>>> EvalSumColsKeyGen(
-        const PrivateKey<Element> privateKey, std::vector<uint32_t>& indices) const;
+        const PrivateKey<Element> privateKey, std::vector<uint32_t>& indices, uint32_t levels = 0) const;
 
     virtual Ciphertext<Element> EvalSum(ConstCiphertext<Element> ciphertext, uint32_t batchSize,
                                         const std::map<uint32_t, EvalKey<Element>>& evalKeyMap) const {

--- a/src/pke/lib/cryptocontext.cpp
+++ b/src/pke/lib/cryptocontext.cpp
@@ -86,22 +86,30 @@ void CryptoContextImpl<Element>::SetKSTechniqueInScheme() {
 // SHE MULTIPLICATION
 /////////////////////////////////////////
 template <typename Element>
-void CryptoContextImpl<Element>::EvalMultKeyGen(const PrivateKey<Element>& key) {
+void CryptoContextImpl<Element>::EvalMultKeyGen(const PrivateKey<Element>& key, uint32_t levels) {
     ValidateKey(key);
-    if (CryptoContextImpl<Element>::s_evalMultKeyMap.find(key->GetKeyTag()) ==
-        CryptoContextImpl<Element>::s_evalMultKeyMap.end()) {
-        // the key is not found in the map, so the key has to be generated
-        CryptoContextImpl<Element>::s_evalMultKeyMap[key->GetKeyTag()] = {m_scheme->EvalMultKeyGen(key)};
+    ValidateEvalKeyGenLevels(levels);
+    auto it = CryptoContextImpl<Element>::s_evalMultKeyMap.find(key->GetKeyTag());
+    // the key is generated if it is not found in the map or if the existing key has fewer
+    // towers than the requested key
+    if (it == CryptoContextImpl<Element>::s_evalMultKeyMap.end() ||
+        it->second[0]->GetAVector()[0].GetNumOfElements() <
+            m_scheme->GetNumEvalKeyTowers(GetCryptoParameters(), levels)) {
+        CryptoContextImpl<Element>::s_evalMultKeyMap[key->GetKeyTag()] = {m_scheme->EvalMultKeyGen(key, levels)};
     }
 }
 
 template <typename Element>
-void CryptoContextImpl<Element>::EvalMultKeysGen(const PrivateKey<Element>& key) {
+void CryptoContextImpl<Element>::EvalMultKeysGen(const PrivateKey<Element>& key, uint32_t levels) {
     ValidateKey(key);
-    if (CryptoContextImpl<Element>::s_evalMultKeyMap.find(key->GetKeyTag()) ==
-        CryptoContextImpl<Element>::s_evalMultKeyMap.end()) {
-        // the key is not found in the map, so the key has to be generated
-        CryptoContextImpl<Element>::s_evalMultKeyMap[key->GetKeyTag()] = m_scheme->EvalMultKeysGen(key);
+    ValidateEvalKeyGenLevels(levels);
+    auto it = CryptoContextImpl<Element>::s_evalMultKeyMap.find(key->GetKeyTag());
+    // the keys are generated if they are not found in the map or if the existing keys have
+    // fewer towers than the requested keys
+    if (it == CryptoContextImpl<Element>::s_evalMultKeyMap.end() ||
+        it->second[0]->GetAVector()[0].GetNumOfElements() <
+            m_scheme->GetNumEvalKeyTowers(GetCryptoParameters(), levels)) {
+        CryptoContextImpl<Element>::s_evalMultKeyMap[key->GetKeyTag()] = m_scheme->EvalMultKeysGen(key, levels);
     }
 }
 
@@ -146,18 +154,20 @@ void CryptoContextImpl<Element>::InsertEvalMultKey(const std::vector<EvalKey<Ele
 /////////////////////////////////////////
 
 template <typename Element>
-void CryptoContextImpl<Element>::EvalSumKeyGen(const PrivateKey<Element> privateKey) {
+void CryptoContextImpl<Element>::EvalSumKeyGen(const PrivateKey<Element> privateKey, uint32_t levels) {
     ValidateKey(privateKey);
-    auto&& evalKeys = m_scheme->EvalSumKeyGen(privateKey);
+    ValidateEvalKeyGenLevels(levels);
+    auto&& evalKeys = m_scheme->EvalSumKeyGen(privateKey, levels);
     CryptoContextImpl<Element>::InsertEvalAutomorphismKey(evalKeys, privateKey->GetKeyTag());
 }
 
 template <typename Element>
 std::shared_ptr<std::map<uint32_t, EvalKey<Element>>> CryptoContextImpl<Element>::EvalSumRowsKeyGen(
-    const PrivateKey<Element> privateKey, uint32_t rowSize, uint32_t subringDim) {
+    const PrivateKey<Element> privateKey, uint32_t rowSize, uint32_t subringDim, uint32_t levels) {
     ValidateKey(privateKey);
+    ValidateEvalKeyGenLevels(levels);
     std::vector<uint32_t> indices;
-    auto&& evalKeys = m_scheme->EvalSumRowsKeyGen(privateKey, rowSize, subringDim, indices);
+    auto&& evalKeys = m_scheme->EvalSumRowsKeyGen(privateKey, rowSize, subringDim, indices, levels);
     CryptoContextImpl<Element>::InsertEvalAutomorphismKey(evalKeys, privateKey->GetKeyTag());
     return CryptoContextImpl<Element>::GetPartialEvalAutomorphismKeyMapPtr(privateKey->GetKeyTag(), indices);
 }
@@ -171,10 +181,11 @@ inline std::shared_ptr<std::map<uint32_t, EvalKey<Element>>> CryptoContextImpl<E
 
 template <typename Element>
 std::shared_ptr<std::map<uint32_t, EvalKey<Element>>> CryptoContextImpl<Element>::EvalSumColsKeyGen(
-    const PrivateKey<Element> privateKey) {
+    const PrivateKey<Element> privateKey, uint32_t levels) {
     ValidateKey(privateKey);
+    ValidateEvalKeyGenLevels(levels);
     std::vector<uint32_t> indices;
-    auto&& evalKeys = m_scheme->EvalSumColsKeyGen(privateKey, indices);
+    auto&& evalKeys = m_scheme->EvalSumColsKeyGen(privateKey, indices, levels);
     CryptoContextImpl<Element>::InsertEvalAutomorphismKey(evalKeys, privateKey->GetKeyTag());
     return CryptoContextImpl<Element>::GetPartialEvalAutomorphismKeyMapPtr(privateKey->GetKeyTag(), indices);
 }
@@ -271,9 +282,10 @@ void CryptoContextImpl<Element>::ClearEvalSumKeys(const CryptoContext<Element> c
 
 template <typename Element>
 void CryptoContextImpl<Element>::EvalAtIndexKeyGen(const PrivateKey<Element> privateKey,
-                                                   const std::vector<int32_t>& indexList) {
+                                                   const std::vector<int32_t>& indexList, uint32_t levels) {
     ValidateKey(privateKey);
-    auto&& evalKeys = m_scheme->EvalAtIndexKeyGen(privateKey, indexList);
+    ValidateEvalKeyGenLevels(levels);
+    auto&& evalKeys = m_scheme->EvalAtIndexKeyGen(privateKey, indexList, levels);
     CryptoContextImpl<Element>::InsertEvalAutomorphismKey(evalKeys, privateKey->GetKeyTag());
 }
 
@@ -347,25 +359,21 @@ void CryptoContextImpl<Element>::InsertEvalAutomorphismKey(
 
     auto mapToInsertIt    = mapToInsert->begin();
     const std::string& id = (keyTag.empty()) ? mapToInsertIt->second->GetKeyTag() : keyTag;
-    std::set<uint32_t> existingIndices{CryptoContextImpl<Element>::GetExistingEvalAutomorphismKeyIndices(id)};
-    if (existingIndices.empty()) {
+    auto keyMapIt         = CryptoContextImpl<Element>::s_evalAutomorphismKeyMap.find(id);
+    if (keyMapIt == CryptoContextImpl<Element>::s_evalAutomorphismKeyMap.end()) {
         // there is no keys for the given id, so we insert full mapToInsert
         CryptoContextImpl<Element>::s_evalAutomorphismKeyMap[id] = mapToInsert;
     }
     else {
-        // get all indices from mapToInsert
-        std::set<uint32_t> newIndices;
-        for (const auto& [key, _] : *mapToInsert) {
-            newIndices.insert(key);
-        }
-
-        // find all indices in mapToInsert that are not in the exising map and
-        // insert those new indices and their corresponding keys to the existing map
-        std::set<uint32_t> indicesToInsert{CryptoContextImpl<Element>::GetUniqueValues(existingIndices, newIndices)};
-        auto keyMapIt = CryptoContextImpl<Element>::s_evalAutomorphismKeyMap.find(id);
-        auto& keyMap  = *(keyMapIt->second);
-        for (uint32_t indx : indicesToInsert) {
-            keyMap[indx] = (*mapToInsert)[indx];
+        // insert all new indices; for an index that already has a key, keep the key with
+        // the most towers (the more capable of the two keys)
+        auto& keyMap = *(keyMapIt->second);
+        for (const auto& [indx, key] : *mapToInsert) {
+            auto it = keyMap.find(indx);
+            if (it == keyMap.end() ||
+                key->GetAVector()[0].GetNumOfElements() > it->second->GetAVector()[0].GetNumOfElements()) {
+                keyMap[indx] = key;
+            }
         }
     }
 }

--- a/src/pke/lib/keyswitch/keyswitch-bv.cpp
+++ b/src/pke/lib/keyswitch/keyswitch-bv.cpp
@@ -47,81 +47,42 @@
 namespace lbcrypto {
 
 EvalKey<DCRTPoly> KeySwitchBV::KeySwitchGenInternal(const PrivateKey<DCRTPoly> oldKey,
-                                                    const PrivateKey<DCRTPoly> newKey) const {
-    const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersRNS>(newKey->GetCryptoParameters());
-
-    DugType dug;
-    auto dgg = cryptoParams->GetDiscreteGaussianGenerator();
-
-    const auto ns           = cryptoParams->GetNoiseScale();
-    const auto& sNew        = newKey->GetPrivateElement();
-    const auto& ep          = sNew.GetParams();
-    const auto& sOld        = oldKey->GetPrivateElement();
-    const uint32_t sizeSOld = sOld.GetNumOfElements();
-
-    std::vector<DCRTPoly> av, bv;
-    if (auto digitSize = cryptoParams->GetDigitSize(); digitSize > 0) {
-        // creates an array of digits up to a certain tower
-        std::vector<uint32_t> arrWindows(sizeSOld);
-        uint32_t nWindows = 0;
-        for (uint32_t i = 0; i < sizeSOld; ++i) {
-            arrWindows[i]  = nWindows;
-            double sOldMSB = sOld.GetElementAtIndex(i).GetModulus().GetMSB();
-            nWindows += std::ceil(sOldMSB / digitSize);
-        }
-
-        av.resize(nWindows);
-        bv.resize(nWindows);
-#pragma omp parallel for num_threads(OpenFHEParallelControls.GetThreadLimit(sizeSOld)) private(dug, dgg)
-        for (uint32_t i = 0; i < sizeSOld; ++i) {
-            auto sOldDecomposed = sOld.GetElementAtIndex(i).PowersOfBase(digitSize);
-            for (uint32_t j = arrWindows[i], k = 0; k < sOldDecomposed.size(); ++j, ++k) {
-                av[j] = DCRTPoly(dug, ep, Format::EVALUATION);
-                bv[j] = DCRTPoly(ep, Format::EVALUATION, true);
-                bv[j].SetElementAtIndex(i, std::move(sOldDecomposed[k]));
-                bv[j] -= (av[j] * sNew + DCRTPoly(dgg, ep, Format::EVALUATION) * ns);
-            }
-        }
-    }
-    else {
-        av.resize(sizeSOld);
-        bv.resize(sizeSOld);
-#pragma omp parallel for num_threads(OpenFHEParallelControls.GetThreadLimit(sizeSOld)) private(dug, dgg)
-        for (uint32_t i = 0; i < sizeSOld; ++i) {
-            av[i] = DCRTPoly(dug, ep, Format::EVALUATION);
-            bv[i] = DCRTPoly(ep, Format::EVALUATION, true);
-            bv[i].SetElementAtIndex(i, sOld.GetElementAtIndex(i));
-            bv[i] -= (av[i] * sNew + DCRTPoly(dgg, ep, Format::EVALUATION) * ns);
-        }
-    }
-
-    auto ek = std::make_shared<EvalKeyRelinImpl<DCRTPoly>>(newKey->GetCryptoContext());
-    ek->SetAVector(std::move(av));
-    ek->SetBVector(std::move(bv));
-    ek->SetKeyTag(newKey->GetKeyTag());
-    return ek;
+                                                    const PrivateKey<DCRTPoly> newKey, uint32_t levels) const {
+    return KeySwitchBV::KeySwitchGenInternal(oldKey, newKey, nullptr, levels);
 }
 
 EvalKey<DCRTPoly> KeySwitchBV::KeySwitchGenInternal(const PrivateKey<DCRTPoly> oldKey,
-                                                    const PrivateKey<DCRTPoly> newKey,
-                                                    const EvalKey<DCRTPoly> ek) const {
+                                                    const PrivateKey<DCRTPoly> newKey, const EvalKey<DCRTPoly> ek,
+                                                    uint32_t levels) const {
     const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersRNS>(oldKey->GetCryptoParameters());
 
     DugType dug;
     auto dgg = cryptoParams->GetDiscreteGaussianGenerator();
 
-    const auto ns           = cryptoParams->GetNoiseScale();
-    const auto& sNew        = newKey->GetPrivateElement();
-    const auto& ep          = sNew.GetParams();
-    const auto& sOld        = oldKey->GetPrivateElement();
-    const uint32_t sizeSOld = sOld.GetNumOfElements();
+    const auto ns        = cryptoParams->GetNoiseScale();
+    const auto& sNew     = newKey->GetPrivateElement();
+    const auto& sOld     = oldKey->GetPrivateElement();
+    const uint32_t sizeQ = sOld.GetNumOfElements();
+
+    if (levels >= sizeQ)
+        OPENFHE_THROW("levels [" + std::to_string(levels) + "] must be smaller than the number of RNS limbs [" +
+                      std::to_string(sizeQ) + "]");
+
+    // the key is generated over the basis of Q with the last `levels` limbs dropped
+    const uint32_t sizeKeyQ  = sizeQ - levels;
+    const DCRTPoly sNewClone = (levels == 0) ? DCRTPoly() : sNew.CloneTowers(0, sizeKeyQ - 1);
+    const DCRTPoly& sNewKey  = (levels == 0) ? sNew : sNewClone;
+    const auto& ep           = sNewKey.GetParams();
+
+    if (ek != nullptr && ek->GetAVector()[0].GetNumOfElements() != sizeKeyQ)
+        OPENFHE_THROW("the number of RNS limbs in the input evaluation key does not match the requested levels");
 
     std::vector<DCRTPoly> av, bv;
     if (auto digitSize = cryptoParams->GetDigitSize(); digitSize > 0) {
         // creates an array of digits up to a certain tower
-        std::vector<uint32_t> arrWindows(sizeSOld);
+        std::vector<uint32_t> arrWindows(sizeKeyQ);
         uint32_t nWindows = 0;
-        for (uint32_t i = 0; i < sizeSOld; ++i) {
+        for (uint32_t i = 0; i < sizeKeyQ; ++i) {
             arrWindows[i]  = nWindows;
             double sOldMSB = sOld.GetElementAtIndex(i).GetModulus().GetMSB();
             nWindows += std::ceil(sOldMSB / digitSize);
@@ -129,26 +90,26 @@ EvalKey<DCRTPoly> KeySwitchBV::KeySwitchGenInternal(const PrivateKey<DCRTPoly> o
 
         av.resize(nWindows);
         bv.resize(nWindows);
-#pragma omp parallel for num_threads(OpenFHEParallelControls.GetThreadLimit(sizeSOld)) private(dug, dgg)
-        for (uint32_t i = 0; i < sizeSOld; ++i) {
+#pragma omp parallel for num_threads(OpenFHEParallelControls.GetThreadLimit(sizeKeyQ)) private(dug, dgg)
+        for (uint32_t i = 0; i < sizeKeyQ; ++i) {
             auto sOldDecomposed = sOld.GetElementAtIndex(i).PowersOfBase(digitSize);
             for (uint32_t j = arrWindows[i], k = 0; k < sOldDecomposed.size(); ++j, ++k) {
                 av[j] = ek ? ek->GetAVector()[j] : DCRTPoly(dug, ep, Format::EVALUATION);
                 bv[j] = DCRTPoly(ep, Format::EVALUATION, true);
                 bv[j].SetElementAtIndex(i, std::move(sOldDecomposed[k]));
-                bv[j] -= (av[j] * sNew + DCRTPoly(dgg, ep, Format::EVALUATION) * ns);
+                bv[j] -= (av[j] * sNewKey + DCRTPoly(dgg, ep, Format::EVALUATION) * ns);
             }
         }
     }
     else {
-        av.resize(sizeSOld);
-        bv.resize(sizeSOld);
-#pragma omp parallel for num_threads(OpenFHEParallelControls.GetThreadLimit(sizeSOld)) private(dug, dgg)
-        for (uint32_t i = 0; i < sizeSOld; ++i) {
+        av.resize(sizeKeyQ);
+        bv.resize(sizeKeyQ);
+#pragma omp parallel for num_threads(OpenFHEParallelControls.GetThreadLimit(sizeKeyQ)) private(dug, dgg)
+        for (uint32_t i = 0; i < sizeKeyQ; ++i) {
             av[i] = ek ? ek->GetAVector()[i] : DCRTPoly(dug, ep, Format::EVALUATION);
             bv[i] = DCRTPoly(ep, Format::EVALUATION, true);
             bv[i].SetElementAtIndex(i, sOld.GetElementAtIndex(i));
-            bv[i] -= (av[i] * sNew + DCRTPoly(dgg, ep, Format::EVALUATION) * ns);
+            bv[i] -= (av[i] * sNewKey + DCRTPoly(dgg, ep, Format::EVALUATION) * ns);
         }
     }
 
@@ -157,6 +118,53 @@ EvalKey<DCRTPoly> KeySwitchBV::KeySwitchGenInternal(const PrivateKey<DCRTPoly> o
     evalKey->SetBVector(std::move(bv));
     evalKey->SetKeyTag(newKey->GetKeyTag());
     return evalKey;
+}
+
+EvalKey<DCRTPoly> KeySwitchBV::CompressEvalKey(const EvalKey<DCRTPoly> evalKey, uint32_t levels) const {
+    const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersRNS>(evalKey->GetCryptoParameters());
+
+    const auto& av       = evalKey->GetAVector();
+    const auto& bv       = evalKey->GetBVector();
+    const uint32_t sizeQ = av[0].GetNumOfElements();
+
+    if (levels >= sizeQ)
+        OPENFHE_THROW("levels [" + std::to_string(levels) +
+                      "] must be smaller than the number of RNS limbs in the evaluation key [" +
+                      std::to_string(sizeQ) + "]");
+    const uint32_t sizeKeyQ = sizeQ - levels;
+
+    // number of digits that correspond to the first sizeKeyQ towers
+    uint32_t numDigits = sizeKeyQ;
+    if (auto digitSize = cryptoParams->GetDigitSize(); digitSize > 0) {
+        numDigits = 0;
+        for (uint32_t i = 0; i < sizeKeyQ; ++i) {
+            double msb = av[0].GetElementAtIndex(i).GetModulus().GetMSB();
+            numDigits += std::ceil(msb / digitSize);
+        }
+    }
+
+    std::vector<DCRTPoly> avNew(numDigits);
+    std::vector<DCRTPoly> bvNew(numDigits);
+#pragma omp parallel for num_threads(OpenFHEParallelControls.GetThreadLimit(numDigits))
+    for (uint32_t j = 0; j < numDigits; ++j) {
+        avNew[j] = av[j].CloneTowers(0, sizeKeyQ - 1);
+        bvNew[j] = bv[j].CloneTowers(0, sizeKeyQ - 1);
+    }
+
+    auto ek = std::make_shared<EvalKeyRelinImpl<DCRTPoly>>(evalKey->GetCryptoContext());
+    ek->SetAVector(std::move(avNew));
+    ek->SetBVector(std::move(bvNew));
+    ek->SetKeyTag(evalKey->GetKeyTag());
+    return ek;
+}
+
+uint32_t KeySwitchBV::GetNumEvalKeyTowers(const std::shared_ptr<CryptoParametersBase<DCRTPoly>> cryptoParams,
+                                          uint32_t levels) const {
+    const uint32_t sizeQ = cryptoParams->GetElementParams()->GetParams().size();
+    if (levels >= sizeQ)
+        OPENFHE_THROW("levels [" + std::to_string(levels) + "] must be smaller than the number of RNS limbs [" +
+                      std::to_string(sizeQ) + "]");
+    return sizeQ - levels;
 }
 
 EvalKey<DCRTPoly> KeySwitchBV::KeySwitchGenInternal(const PrivateKey<DCRTPoly> oldSk,
@@ -255,8 +263,16 @@ std::vector<DCRTPoly> KeySwitchBV::EvalFastKeySwitchCore(const std::shared_ptr<s
                                                          const std::shared_ptr<ParmType> paramsQl) const {
     const std::vector<DCRTPoly>& bref = evalKey->GetBVector();
     const std::vector<DCRTPoly>& aref = evalKey->GetAVector();
-    const uint32_t lastQl             = paramsQl->GetParams().size() - 1;
+    const uint32_t sizeQl             = paramsQl->GetParams().size();
+    const uint32_t lastQl             = sizeQl - 1;
     const uint32_t limit              = (*digits).size();
+
+    // the key may have fewer towers than the cryptocontext (see the levels argument of
+    // KeySwitchGen and CompressEvalKey)
+    if (sizeQl > aref[0].GetNumOfElements() || limit > aref.size())
+        OPENFHE_THROW("The ciphertext requires an evaluation key with at least " + std::to_string(sizeQl) +
+                      " RNS limbs, but the key has only " + std::to_string(aref[0].GetNumOfElements()) +
+                      "; use a key generated at a smaller level");
     std::vector<DCRTPoly> bv(limit);
     std::vector<DCRTPoly> av(limit);
 #pragma omp parallel for num_threads(OpenFHEParallelControls.GetThreadLimit(limit))

--- a/src/pke/lib/keyswitch/keyswitch-hybrid.cpp
+++ b/src/pke/lib/keyswitch/keyswitch-hybrid.cpp
@@ -44,19 +44,37 @@
 namespace lbcrypto {
 
 EvalKey<DCRTPoly> KeySwitchHYBRID::KeySwitchGenInternal(const PrivateKey<DCRTPoly> oldKey,
-                                                        const PrivateKey<DCRTPoly> newKey) const {
-    return KeySwitchHYBRID::KeySwitchGenInternal(oldKey, newKey, nullptr);
+                                                        const PrivateKey<DCRTPoly> newKey, uint32_t levels) const {
+    return KeySwitchHYBRID::KeySwitchGenInternal(oldKey, newKey, nullptr, levels);
 }
 
 EvalKey<DCRTPoly> KeySwitchHYBRID::KeySwitchGenInternal(const PrivateKey<DCRTPoly> oldKey,
                                                         const PrivateKey<DCRTPoly> newKey,
-                                                        const EvalKey<DCRTPoly> ekPrev) const {
+                                                        const EvalKey<DCRTPoly> ekPrev, uint32_t levels) const {
     const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersRNS>(newKey->GetCryptoParameters());
     const auto& paramsQ     = cryptoParams->GetElementParams();
-    const auto& paramsQP    = cryptoParams->GetParamsQP();
-    const auto& pparamsQP   = paramsQP->GetParams();
+    const auto& paramsP     = cryptoParams->GetParamsP();
 
-    // skNew is currently in basis Q. This extends it to basis QP.
+    const uint32_t sizeQ = paramsQ->GetParams().size();
+    const uint32_t sizeP = paramsP->GetParams().size();
+
+    if (levels >= sizeQ)
+        OPENFHE_THROW("levels [" + std::to_string(levels) + "] must be smaller than the number of RNS limbs [" +
+                      std::to_string(sizeQ) + "]");
+
+    // the key is generated over the basis Q_l*P, where Q_l is Q with the last `levels` limbs dropped
+    const uint32_t sizeKeyQ  = sizeQ - levels;
+    const uint32_t sizeKeyQP = sizeKeyQ + sizeP;
+
+    auto paramsQP = cryptoParams->GetParamsQP();
+    if (levels > 0)
+        paramsQP = std::make_shared<ParmType>(*paramsQ, sizeKeyQ, *paramsP, sizeP);
+    const auto& pparamsQP = paramsQP->GetParams();
+
+    if (ekPrev != nullptr && ekPrev->GetAVector()[0].GetNumOfElements() != sizeKeyQP)
+        OPENFHE_THROW("the number of RNS limbs in the input evaluation key does not match the requested levels");
+
+    // skNew is currently in basis Q. This extends it to basis (Q_l)P.
 
     DCRTPoly sNewExt(paramsQP, Format::EVALUATION, false);
     const auto& sNew = newKey->GetPrivateElement();
@@ -64,12 +82,9 @@ EvalKey<DCRTPoly> KeySwitchHYBRID::KeySwitchGenInternal(const PrivateKey<DCRTPol
     auto sNew0 = sNew.GetElementAtIndex(0);
     sNew0.SetFormat(Format::COEFFICIENT);
 
-    const uint32_t sizeQ  = paramsQ->GetParams().size();
-    const uint32_t sizeQP = paramsQP->GetParams().size();
-
-#pragma omp parallel for num_threads(OpenFHEParallelControls.GetThreadLimit(sizeQP))
-    for (uint32_t i = 0; i < sizeQP; ++i) {
-        if (i < sizeQ) {
+#pragma omp parallel for num_threads(OpenFHEParallelControls.GetThreadLimit(sizeKeyQP))
+    for (uint32_t i = 0; i < sizeKeyQP; ++i) {
+        if (i < sizeKeyQ) {
             auto tmp = sNew.GetElementAtIndex(i);
             tmp.SetFormat(Format::EVALUATION);
             sNewExt.SetElementAtIndex(i, std::move(tmp));
@@ -85,7 +100,14 @@ EvalKey<DCRTPoly> KeySwitchHYBRID::KeySwitchGenInternal(const PrivateKey<DCRTPol
     const auto ns = cryptoParams->GetNoiseScale();
 
     const uint32_t numPerPartQ = cryptoParams->GetNumPerPartQ();
-    const uint32_t numPartQ    = cryptoParams->GetNumPartQ();
+    // the number of digits of a key over Q_l: same formula as for the ciphertext digits
+    // in EvalKeySwitchPrecomputeCore
+    uint32_t numPartQ = cryptoParams->GetNumPartQ();
+    if (levels > 0) {
+        numPartQ = std::ceil(static_cast<double>(sizeKeyQ) / numPerPartQ);
+        if (numPartQ > cryptoParams->GetNumberOfQPartitions())
+            numPartQ = cryptoParams->GetNumberOfQPartitions();
+    }
     std::vector<DCRTPoly> av(numPartQ);
     std::vector<DCRTPoly> bv(numPartQ);
 
@@ -103,9 +125,10 @@ EvalKey<DCRTPoly> KeySwitchHYBRID::KeySwitchGenInternal(const PrivateKey<DCRTPol
         DCRTPoly b(paramsQP, Format::EVALUATION, false);
 
         const uint32_t startPartIdx = numPerPartQ * part;
-        const uint32_t endPartIdx   = (sizeQ > (startPartIdx + numPerPartQ)) ? (startPartIdx + numPerPartQ) : sizeQ;
+        const uint32_t endPartIdx =
+            (sizeKeyQ > (startPartIdx + numPerPartQ)) ? (startPartIdx + numPerPartQ) : sizeKeyQ;
 
-        for (uint32_t i = 0; i < sizeQP; ++i) {
+        for (uint32_t i = 0; i < sizeKeyQP; ++i) {
             const auto& ai  = a.GetElementAtIndex(i);
             const auto& ei  = e.GetElementAtIndex(i);
             const auto& sni = sNewExt.GetElementAtIndex(i);
@@ -127,6 +150,69 @@ EvalKey<DCRTPoly> KeySwitchHYBRID::KeySwitchGenInternal(const PrivateKey<DCRTPol
     ek->SetBVector(std::move(bv));
     ek->SetKeyTag(newKey->GetKeyTag());
     return ek;
+}
+
+EvalKey<DCRTPoly> KeySwitchHYBRID::CompressEvalKey(const EvalKey<DCRTPoly> evalKey, uint32_t levels) const {
+    const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersRNS>(evalKey->GetCryptoParameters());
+
+    const auto& av = evalKey->GetAVector();
+    const auto& bv = evalKey->GetBVector();
+
+    const uint32_t sizeP     = cryptoParams->GetParamsP()->GetParams().size();
+    const uint32_t sizeKeyQP = av[0].GetNumOfElements();
+    const uint32_t sizeKeyQ  = sizeKeyQP - sizeP;
+
+    if (levels >= sizeKeyQ)
+        OPENFHE_THROW("levels [" + std::to_string(levels) +
+                      "] must be smaller than the number of RNS limbs in the Q basis of the evaluation key [" +
+                      std::to_string(sizeKeyQ) + "]");
+
+    const uint32_t newSizeQ = sizeKeyQ - levels;
+
+    // the compressed basis Q_l*P: the leading newSizeQ towers of the key's Q basis (a
+    // prefix of the context's Q) followed by the full auxiliary basis P
+    auto paramsQlP = std::make_shared<ParmType>(*av[0].GetParams(), newSizeQ, *cryptoParams->GetParamsP(), sizeP);
+
+    // the number of digits needed for a key over the compressed Q basis
+    const uint32_t numPerPartQ = cryptoParams->GetNumPerPartQ();
+    uint32_t numPartQl         = std::ceil(static_cast<double>(newSizeQ) / numPerPartQ);
+    if (numPartQl > cryptoParams->GetNumberOfQPartitions())
+        numPartQl = cryptoParams->GetNumberOfQPartitions();
+    if (numPartQl > av.size())
+        numPartQl = static_cast<uint32_t>(av.size());
+
+    std::vector<DCRTPoly> avNew(numPartQl);
+    std::vector<DCRTPoly> bvNew(numPartQl);
+#pragma omp parallel for num_threads(OpenFHEParallelControls.GetThreadLimit(numPartQl))
+    for (uint32_t part = 0; part < numPartQl; ++part) {
+        avNew[part] = DCRTPoly(paramsQlP, Format::EVALUATION, false);
+        bvNew[part] = DCRTPoly(paramsQlP, Format::EVALUATION, false);
+        for (uint32_t i = 0; i < newSizeQ; ++i) {
+            avNew[part].SetElementAtIndex(i, av[part].GetElementAtIndex(i));
+            bvNew[part].SetElementAtIndex(i, bv[part].GetElementAtIndex(i));
+        }
+        for (uint32_t i = 0; i < sizeP; ++i) {
+            avNew[part].SetElementAtIndex(newSizeQ + i, av[part].GetElementAtIndex(sizeKeyQ + i));
+            bvNew[part].SetElementAtIndex(newSizeQ + i, bv[part].GetElementAtIndex(sizeKeyQ + i));
+        }
+    }
+
+    auto ek = std::make_shared<EvalKeyRelinImpl<DCRTPoly>>(evalKey->GetCryptoContext());
+    ek->SetAVector(std::move(avNew));
+    ek->SetBVector(std::move(bvNew));
+    ek->SetKeyTag(evalKey->GetKeyTag());
+    return ek;
+}
+
+uint32_t KeySwitchHYBRID::GetNumEvalKeyTowers(const std::shared_ptr<CryptoParametersBase<DCRTPoly>> cryptoParams,
+                                              uint32_t levels) const {
+    const auto cryptoParamsRNS = std::dynamic_pointer_cast<CryptoParametersRNS>(cryptoParams);
+
+    const uint32_t sizeQ = cryptoParamsRNS->GetElementParams()->GetParams().size();
+    if (levels >= sizeQ)
+        OPENFHE_THROW("levels [" + std::to_string(levels) + "] must be smaller than the number of RNS limbs [" +
+                      std::to_string(sizeQ) + "]");
+    return sizeQ - levels + cryptoParamsRNS->GetParamsP()->GetParams().size();
 }
 
 EvalKey<DCRTPoly> KeySwitchHYBRID::KeySwitchGenInternal(const PrivateKey<DCRTPoly> oldKey,
@@ -318,17 +404,9 @@ std::shared_ptr<std::vector<DCRTPoly>> KeySwitchHYBRID::EvalKeySwitchPrecomputeC
     for (uint32_t part = 0; part < numPartQl; ++part) {
         DCRTPoly partsCt;
         if (part == numPartQl - 1) {
-            const auto& paramsPartQ = cryptoParams->GetParamsPartQ(part);
-
             uint32_t sizePartQl = sizeQl - alpha * part;
-            std::vector<NativeInteger> moduli(sizePartQl);
-            std::vector<NativeInteger> roots(sizePartQl);
-            for (uint32_t i = 0; i < sizePartQl; ++i) {
-                moduli[i] = paramsPartQ->GetParams()[i]->GetModulus();
-                roots[i]  = paramsPartQ->GetParams()[i]->GetRootOfUnity();
-            }
-            auto&& params = std::make_shared<ParmType>(paramsPartQ->GetCyclotomicOrder(), moduli, roots);
-            partsCt       = DCRTPoly(params, Format::EVALUATION, false);
+            auto&& params       = std::make_shared<ParmType>(*cryptoParams->GetParamsPartQ(part), sizePartQl);
+            partsCt             = DCRTPoly(params, Format::EVALUATION, false);
         }
         else {
             partsCt = DCRTPoly(cryptoParams->GetParamsPartQ(part), Format::EVALUATION, false);
@@ -391,10 +469,19 @@ std::vector<DCRTPoly> KeySwitchHYBRID::EvalFastKeySwitchCoreExt(const std::share
     const uint32_t limit  = digits->size();
     const uint32_t sizeQl = paramsQl->GetParams().size();
     auto&& cryptoParams   = std::dynamic_pointer_cast<CryptoParametersRNS>(evalKey->GetCryptoParameters());
-    const uint32_t delta  = cryptoParams->GetElementParams()->GetParams().size() - sizeQl;
 
     const auto& av = evalKey->GetAVector();
     const auto& bv = evalKey->GetBVector();
+
+    // key may have fewer towers in its Q basis than the cryptocontext, so towers indexed relative
+    // to key's own basis
+    const uint32_t sizeP    = cryptoParams->GetParamsP()->GetParams().size();
+    const uint32_t sizeKeyQ = av[0].GetNumOfElements() - sizeP;
+    if (sizeQl > sizeKeyQ)
+        OPENFHE_THROW("The ciphertext requires an evaluation key with at least " + std::to_string(sizeQl) +
+                      " RNS limbs in its Q basis, but the key has only " + std::to_string(sizeKeyQ) +
+                      "; use a key generated at a smaller level");
+    const uint32_t delta = sizeKeyQ - sizeQl;
 
     std::vector<DCRTPoly> result;
     result.reserve(2);

--- a/src/pke/lib/scheme/bfvrns/bfvrns-cryptoparameters.cpp
+++ b/src/pke/lib/scheme/bfvrns/bfvrns-cryptoparameters.cpp
@@ -207,50 +207,22 @@ void CryptoParametersBFVRNS::PrecomputeCRTTables(KeySwitchTechnique ksTech, Scal
             m_paramsQl.resize(1);
             m_paramsRl.resize(1);
             m_paramsQlRl.resize(1);
-            m_paramsQl[0] = std::make_shared<ILDCRTParams<BigInteger>>(2 * n, moduliQ, rootsQ);
-            m_paramsRl[0] = std::make_shared<ILDCRTParams<BigInteger>>(2 * n, moduliR, rootsR);
-            std::vector<NativeInteger> moduliQR(sizeQ + sizeR);
-            std::vector<NativeInteger> rootsQR(sizeQ + sizeR);
-            for (uint32_t i = 0; i < sizeQ; ++i) {
-                moduliQR[i] = moduliQ[i];
-                rootsQR[i]  = rootsQ[i];
-            }
-            for (uint32_t j = 0; j < sizeR; ++j) {
-                moduliQR[sizeQ + j] = moduliR[j];
-                rootsQR[sizeQ + j]  = rootsR[j];
-            }
-            m_paramsQlRl[0] = std::make_shared<ILDCRTParams<BigInteger>>(2 * n, moduliQR, rootsQR);
+            m_paramsQl[0]   = std::make_shared<ILDCRTParams<BigInteger>>(*GetElementParams(), sizeQ);
+            m_paramsRl[0]   = std::make_shared<ILDCRTParams<BigInteger>>(2 * n, moduliR, rootsR);
+            m_paramsQlRl[0] =
+                std::make_shared<ILDCRTParams<BigInteger>>(*GetElementParams(), sizeQ, *m_paramsRl[0], sizeR);
         }
         else if (multTech == HPSPOVERQLEVELED || multTech == HPSPOVERQ) {
             m_paramsQl.resize(sizeQ);
             m_paramsRl.resize(sizeQ);
             m_paramsQlRl.resize(sizeQ);
 
-            std::vector<NativeInteger> moduliQl;
-            moduliQl.reserve(sizeQ);
-            std::vector<NativeInteger> rootsQl;
-            rootsQl.reserve(sizeQ);
-            std::vector<NativeInteger> moduliRl;
-            moduliRl.reserve(sizeQ);
-            std::vector<NativeInteger> rootsRl;
-            rootsRl.reserve(sizeQ);
-            std::vector<NativeInteger> moduliQlRl;
-            moduliQlRl.reserve(2 * sizeQ);
-            std::vector<NativeInteger> rootsQlRl;
-            rootsQlRl.reserve(2 * sizeQ);
-
+            auto paramsR = std::make_shared<ILDCRTParams<BigInteger>>(2 * n, moduliR, rootsR);
             for (uint32_t l = 0; l < sizeQ; ++l) {
-                moduliQl.push_back(moduliQ[l]);
-                rootsQl.push_back(rootsQ[l]);
-                m_paramsQl[l] = std::make_shared<ILDCRTParams<BigInteger>>(2 * n, moduliQl, rootsQl);
-                moduliRl.push_back(moduliR[l]);
-                rootsRl.push_back(rootsR[l]);
-                m_paramsRl[l] = std::make_shared<ILDCRTParams<BigInteger>>(2 * n, moduliRl, rootsRl);
-                moduliQlRl.insert(moduliQlRl.begin() + l, moduliQ[l]);
-                rootsQlRl.insert(rootsQlRl.begin() + l, rootsQ[l]);
-                moduliQlRl.push_back(moduliR[l]);
-                rootsQlRl.push_back(rootsR[l]);
-                m_paramsQlRl[l] = std::make_shared<ILDCRTParams<BigInteger>>(2 * n, moduliQlRl, rootsQlRl);
+                m_paramsQl[l] = std::make_shared<ILDCRTParams<BigInteger>>(*GetElementParams(), l + 1);
+                m_paramsRl[l] = std::make_shared<ILDCRTParams<BigInteger>>(*paramsR, l + 1);
+                m_paramsQlRl[l] =
+                    std::make_shared<ILDCRTParams<BigInteger>>(*GetElementParams(), l + 1, *paramsR, l + 1);
             }
         }
 

--- a/src/pke/lib/scheme/ckksrns/ckksrns-cryptoparameters.cpp
+++ b/src/pke/lib/scheme/ckksrns/ckksrns-cryptoparameters.cpp
@@ -56,12 +56,9 @@ void CryptoParametersCKKSRNS::PrecomputeCRTTables(KeySwitchTechnique ksTech, Sca
     uint32_t compositeDegree = m_compositeDegree;
 
     std::vector<NativeInteger> moduliQ(sizeQ);
-    std::vector<NativeInteger> rootsQ(sizeQ);
 
-    for (size_t i = 0; i < sizeQ; i++) {
+    for (size_t i = 0; i < sizeQ; i++)
         moduliQ[i] = GetElementParams()->GetParams()[i]->GetModulus();
-        rootsQ[i]  = GetElementParams()->GetParams()[i]->GetRootOfUnity();
-    }
 
     // Pre-compute values for rescaling
     m_qlInvModq.resize(sizeQ - 1);
@@ -187,9 +184,9 @@ void CryptoParametersCKKSRNS::PrecomputeCRTTables(KeySwitchTechnique ksTech, Sca
         uint32_t sizeComplQl = sizeQ - sizeQl;
 
         std::vector<NativeInteger> moduliComplQl(moduliQ.begin() + sizeQl, moduliQ.end());
-        std::vector<NativeInteger> rootsComplQl(rootsQ.begin() + sizeQl, rootsQ.end());
-        m_paramsModRaiseComplQl = std::make_shared<ILDCRTParams<BigInteger>>(GetElementParams()->GetCyclotomicOrder(),
-                                                                             moduliComplQl, rootsComplQl);
+        m_paramsModRaiseComplQl = std::make_shared<ILDCRTParams<BigInteger>>(
+            GetElementParams()->GetCyclotomicOrder(),
+            GetElementParams()->GetParamPartition(sizeQl, static_cast<uint32_t>(sizeQ) - 1));
 
         BigInteger modulusQl(1);
         for (uint32_t i = 0; i < sizeQl; ++i)
@@ -332,17 +329,10 @@ void CryptoParametersCKKSRNS::PrecomputeCRTTables(KeySwitchTechnique ksTech, Sca
             modulusPSparse *= BigInteger(moduliPSparse[j]);
         }
 
-        std::vector<NativeInteger> moduliQlSparse(moduliQ.begin(), moduliQ.begin() + sizeQl);
-        std::vector<NativeInteger> rootsQlSparse(rootsQ.begin(), rootsQ.begin() + sizeQl);
-
-        m_sparseKSParamsP = std::make_shared<ILDCRTParams<BigInteger>>(2 * n, moduliPSparse, rootsPSparse);
-        m_sparseKSParamsQ = std::make_shared<ILDCRTParams<BigInteger>>(2 * n, moduliQlSparse, rootsQlSparse);
-
-        std::vector<NativeInteger> moduliQPSparse(moduliQlSparse);
-        std::vector<NativeInteger> rootsQPSparse(rootsQlSparse);
-        moduliQPSparse.insert(moduliQPSparse.end(), moduliPSparse.begin(), moduliPSparse.end());
-        rootsQPSparse.insert(rootsQPSparse.end(), rootsPSparse.begin(), rootsPSparse.end());
-        m_sparseKSParamsQP = std::make_shared<ILDCRTParams<BigInteger>>(2 * n, moduliQPSparse, rootsQPSparse);
+        m_sparseKSParamsP  = std::make_shared<ILDCRTParams<BigInteger>>(2 * n, moduliPSparse, rootsPSparse);
+        m_sparseKSParamsQ  = std::make_shared<ILDCRTParams<BigInteger>>(*GetElementParams(), sizeQl);
+        m_sparseKSParamsQP =
+            std::make_shared<ILDCRTParams<BigInteger>>(*GetElementParams(), sizeQl, *m_sparseKSParamsP, sizePSparse);
 
         // Pre-compute CRT::FFT values for P'
         ChineseRemainderTransformFTT<NativeVector>().PreCompute(rootsPSparse, 2 * n, moduliPSparse);

--- a/src/pke/lib/scheme/ckksrns/ckksrns-fhe.cpp
+++ b/src/pke/lib/scheme/ckksrns/ckksrns-fhe.cpp
@@ -821,16 +821,7 @@ Ciphertext<DCRTPoly> FHECKKSRNS::EvalBootstrap(ConstCiphertext<DCRTPoly>& cipher
     if (st == FLEXIBLEAUTOEXT)
         elementParamsRaised.PopLastParam();
 
-    const auto& paramsQ = elementParamsRaised.GetParams();
-    uint32_t sizeQ      = paramsQ.size();
-    std::vector<NativeInteger> moduli(sizeQ);
-    std::vector<NativeInteger> roots(sizeQ);
-    for (uint32_t i = 0; i < sizeQ; ++i) {
-        moduli[i] = paramsQ[i]->GetModulus();
-        roots[i]  = paramsQ[i]->GetRootOfUnity();
-    }
-    auto elementParamsRaisedPtr =
-        std::make_shared<ILDCRTParams<DCRTPoly::Integer>>(cc->GetCyclotomicOrder(), moduli, roots);
+    auto elementParamsRaisedPtr = std::make_shared<ILDCRTParams<DCRTPoly::Integer>>(elementParamsRaised);
 
     double qDouble = GetBigModulus(cryptoParams);
     double powP    = std::pow(2, cryptoParams->GetPlaintextModulus());
@@ -1201,16 +1192,7 @@ Ciphertext<DCRTPoly> FHECKKSRNS::EvalBootstrapStCFirst(ConstCiphertext<DCRTPoly>
     if (st == FLEXIBLEAUTOEXT)
         elementParamsRaised.PopLastParam();
 
-    const auto& paramsQ = elementParamsRaised.GetParams();
-    uint32_t sizeQ      = paramsQ.size();
-    std::vector<NativeInteger> moduli(sizeQ);
-    std::vector<NativeInteger> roots(sizeQ);
-    for (uint32_t i = 0; i < sizeQ; ++i) {
-        moduli[i] = paramsQ[i]->GetModulus();
-        roots[i]  = paramsQ[i]->GetRootOfUnity();
-    }
-    auto elementParamsRaisedPtr =
-        std::make_shared<ILDCRTParams<DCRTPoly::Integer>>(cc->GetCyclotomicOrder(), moduli, roots);
+    auto elementParamsRaisedPtr = std::make_shared<ILDCRTParams<DCRTPoly::Integer>>(elementParamsRaised);
 
     double qDouble = GetBigModulus(cryptoParams);
     double powP    = std::pow(2, cryptoParams->GetPlaintextModulus());
@@ -1635,21 +1617,9 @@ std::vector<ReadOnlyPlaintext> FHECKKSRNS::EvalLinearTransformPrecompute(
     for (uint32_t i = 0; i < towersToDrop; ++i)
         elementParams.PopLastParam();
 
-    const auto& paramsQ = elementParams.GetParams();
-    uint32_t sizeQ      = paramsQ.size();
-    const auto& paramsP = cryptoParams->GetParamsP()->GetParams();
-    uint32_t sizeP      = paramsP.size();
-    std::vector<NativeInteger> moduli(sizeQ + sizeP);
-    std::vector<NativeInteger> roots(sizeQ + sizeP);
-    for (uint32_t i = 0; i < sizeQ; ++i) {
-        moduli[i] = paramsQ[i]->GetModulus();
-        roots[i]  = paramsQ[i]->GetRootOfUnity();
-    }
-    for (uint32_t i = 0; i < sizeP; ++i) {
-        moduli[sizeQ + i] = paramsP[i]->GetModulus();
-        roots[sizeQ + i]  = paramsP[i]->GetRootOfUnity();
-    }
-    auto elementParamsPtr = std::make_shared<ILDCRTParams<DCRTPoly::Integer>>(cc.GetCyclotomicOrder(), moduli, roots);
+    auto elementParamsPtr = std::make_shared<ILDCRTParams<DCRTPoly::Integer>>(
+        elementParams, static_cast<uint32_t>(elementParams.GetParams().size()), *cryptoParams->GetParamsP(),
+        static_cast<uint32_t>(cryptoParams->GetParamsP()->GetParams().size()));
 
     auto g = GetBootPrecom(slots).m_paramsEnc.g;
 
@@ -1681,21 +1651,9 @@ std::vector<ReadOnlyPlaintext> FHECKKSRNS::EvalLinearTransformPrecompute(
     for (uint32_t i = 0; i < towersToDrop; ++i)
         elementParams.PopLastParam();
 
-    const auto& paramsQ = elementParams.GetParams();
-    uint32_t sizeQ      = paramsQ.size();
-    const auto& paramsP = cryptoParams->GetParamsP()->GetParams();
-    uint32_t sizeP      = paramsP.size();
-    std::vector<NativeInteger> moduli(sizeQ + sizeP);
-    std::vector<NativeInteger> roots(sizeQ + sizeP);
-    for (uint32_t i = 0; i < sizeQ; ++i) {
-        moduli[i] = paramsQ[i]->GetModulus();
-        roots[i]  = paramsQ[i]->GetRootOfUnity();
-    }
-    for (uint32_t i = 0; i < sizeP; ++i) {
-        moduli[sizeQ + i] = paramsP[i]->GetModulus();
-        roots[sizeQ + i]  = paramsP[i]->GetRootOfUnity();
-    }
-    auto elementParamsPtr = std::make_shared<ILDCRTParams<DCRTPoly::Integer>>(cc.GetCyclotomicOrder(), moduli, roots);
+    auto elementParamsPtr = std::make_shared<ILDCRTParams<DCRTPoly::Integer>>(
+        elementParams, static_cast<uint32_t>(elementParams.GetParams().size()), *cryptoParams->GetParamsP(),
+        static_cast<uint32_t>(cryptoParams->GetParamsP()->GetParams().size()));
 
     const int32_t slots = static_cast<int32_t>(A.size());
 
@@ -1780,30 +1738,15 @@ std::vector<std::vector<ReadOnlyPlaintext>> FHECKKSRNS::EvalCoeffsToSlotsPrecomp
 
     uint32_t level0 = towersToDrop + compositeDegree * (p.lvlb - 1);
 
-    const auto& paramsQ = elementParams.GetParams();
-    uint32_t sizeQ      = paramsQ.size();
-    const auto& paramsP = cryptoParams->GetParamsP()->GetParams();
-    uint32_t sizeP      = paramsP.size();
-    std::vector<NativeInteger> moduli(sizeQ + sizeP);
-    std::vector<NativeInteger> roots(sizeQ + sizeP);
-    for (uint32_t i = 0; i < sizeQ; ++i) {
-        moduli[i] = paramsQ[i]->GetModulus();
-        roots[i]  = paramsQ[i]->GetRootOfUnity();
-    }
-    for (uint32_t i = 0; i < sizeP; ++i) {
-        moduli[sizeQ + i] = paramsP[i]->GetModulus();
-        roots[sizeQ + i]  = paramsP[i]->GetRootOfUnity();
-    }
+    const auto& paramsP = cryptoParams->GetParamsP();
+    uint32_t sizeQ      = elementParams.GetParams().size();
+    uint32_t sizeP      = paramsP->GetParams().size();
 
     // we need to pre-compute the plaintexts in the extended basis P*Q
     uint32_t M = cc.GetCyclotomicOrder();
     std::vector<std::shared_ptr<ILDCRTParams<BigInteger>>> paramsVector(p.lvlb - stop);
-    for (int32_t s = p.lvlb - 1; s >= stop; --s) {
-        paramsVector[s - stop] = std::make_shared<ILDCRTParams<BigInteger>>(M, moduli, roots);
-        sizeQ -= compositeDegree;
-        moduli.erase(moduli.begin() + sizeQ, moduli.begin() + sizeQ + compositeDegree);
-        roots.erase(roots.begin() + sizeQ, roots.begin() + sizeQ + compositeDegree);
-    }
+    for (int32_t s = p.lvlb - 1; s >= stop; --s, sizeQ -= compositeDegree)
+        paramsVector[s - stop] = std::make_shared<ILDCRTParams<BigInteger>>(elementParams, sizeQ, *paramsP, sizeP);
 
     // zero-based inner indices require shifting the pre-rotation by +offset*scale
     const int32_t offset    = static_cast<int32_t>((p.numRotations + 1) / 2) - 1;
@@ -1948,31 +1891,15 @@ std::vector<std::vector<ReadOnlyPlaintext>> FHECKKSRNS::EvalSlotsToCoeffsPrecomp
     for (uint32_t i = 0; i < towersToDrop; ++i)
         elementParams.PopLastParam();
 
-    const auto& paramsQ = elementParams.GetParams();
-    uint32_t sizeQ      = paramsQ.size();
-    const auto& paramsP = cryptoParams->GetParamsP()->GetParams();
-    uint32_t sizeP      = paramsP.size();
-    std::vector<NativeInteger> moduli(sizeQ + sizeP);
-    std::vector<NativeInteger> roots(sizeQ + sizeP);
-    for (uint32_t i = 0; i < sizeQ; ++i) {
-        moduli[i] = paramsQ[i]->GetModulus();
-        roots[i]  = paramsQ[i]->GetRootOfUnity();
-    }
-    for (uint32_t i = 0; i < sizeP; ++i) {
-        moduli[sizeQ + i] = paramsP[i]->GetModulus();
-        roots[sizeQ + i]  = paramsP[i]->GetRootOfUnity();
-    }
+    const auto& paramsP = cryptoParams->GetParamsP();
+    uint32_t sizeQ      = elementParams.GetParams().size();
+    uint32_t sizeP      = paramsP->GetParams().size();
 
     // we need to pre-compute the plaintexts in the extended basis P*Q
     const uint32_t pvlen = p.lvlb + 1 - flagRem;
     std::vector<std::shared_ptr<ILDCRTParams<BigInteger>>> paramsVector(pvlen);
-    for (uint32_t s = 0; s < pvlen; ++s) {
-        paramsVector[s] = std::make_shared<ILDCRTParams<BigInteger>>(cc.GetCyclotomicOrder(), moduli, roots);
-        for (uint32_t i = 0; i < compositeDegree; ++i, --sizeQ) {
-            moduli.erase(moduli.begin() + sizeQ - 1);
-            roots.erase(roots.begin() + sizeQ - 1);
-        }
-    }
+    for (uint32_t s = 0; s < pvlen; ++s, sizeQ -= compositeDegree)
+        paramsVector[s] = std::make_shared<ILDCRTParams<BigInteger>>(elementParams, sizeQ, *paramsP, sizeP);
 
     // zero-based inner indices require shifting the pre-rotation by +offset*shiftScale
     const int32_t offset    = static_cast<int32_t>((p.numRotations + 1) / 2) - 1;
@@ -3334,20 +3261,11 @@ std::shared_ptr<seriesPowers<DCRTPoly>> FHECKKSRNS::EvalMVBPrecomputeInternal(
     if (st == FLEXIBLEAUTOEXT)
         elementParamsRaised.PopLastParam();
 
-    const auto& paramsQ = elementParamsRaised.GetParams();
-    uint32_t sizeQ      = paramsQ.size();
-    std::vector<NativeInteger> moduli(sizeQ);
-    std::vector<NativeInteger> roots(sizeQ);
-    for (uint32_t i = 0; i < sizeQ; ++i) {
-        moduli[i] = paramsQ[i]->GetModulus();
-        roots[i]  = paramsQ[i]->GetRootOfUnity();
-    }
-
     auto cc = ciphertext->GetCryptoContext();
     auto M  = cc->GetCyclotomicOrder();
     auto N  = cc->GetRingDimension();
 
-    auto elementParamsRaisedPtr = std::make_shared<ILDCRTParams<DCRTPoly::Integer>>(M, moduli, roots);
+    auto elementParamsRaisedPtr = std::make_shared<ILDCRTParams<DCRTPoly::Integer>>(elementParamsRaised);
 
     // We don't need the type of scaling and correction as in the standard CKKS bootstrapping
     // because the message doesn't have to be scaled down.

--- a/src/pke/lib/scheme/ckksrns/ckksrns-multiparty.cpp
+++ b/src/pke/lib/scheme/ckksrns/ckksrns-multiparty.cpp
@@ -191,24 +191,18 @@ Ciphertext<DCRTPoly> MultipartyCKKSRNS::IntMPBootRandomElementGen(std::shared_pt
 // Calculating RNS parameters
 void PrecomputeRNSExtensionTables(CryptoContext<DCRTPoly>& cc, uint32_t from, uint32_t to,
                                   RNSExtensionTables& rnsExtTables) {
+    const auto elemParams = cc->GetCryptoParameters()->GetElementParams();
+
     std::vector<NativeInteger> moduliQ;
     moduliQ.reserve(from);
-    std::vector<NativeInteger> rootsQ;
-    rootsQ.reserve(from);
     std::vector<NativeInteger> moduliP;
     moduliP.reserve(to - from);
-    std::vector<NativeInteger> rootsP;
-    rootsP.reserve(to - from);
 
-    for (size_t i = 0; i < from; i++) {
-        moduliQ.push_back(cc->GetCryptoParameters()->GetElementParams()->GetParams()[i]->GetModulus());
-        rootsQ.push_back(cc->GetCryptoParameters()->GetElementParams()->GetParams()[i]->GetRootOfUnity());
-    }
+    for (size_t i = 0; i < from; i++)
+        moduliQ.push_back(elemParams->GetParams()[i]->GetModulus());
 
-    for (size_t i = from; i < to; i++) {
-        moduliP.push_back(cc->GetCryptoParameters()->GetElementParams()->GetParams()[i]->GetModulus());
-        rootsP.push_back(cc->GetCryptoParameters()->GetElementParams()->GetParams()[i]->GetRootOfUnity());
-    }
+    for (size_t i = from; i < to; i++)
+        moduliP.push_back(elemParams->GetParams()[i]->GetModulus());
 
     size_t sizeQ = moduliQ.size();
     size_t sizeP = moduliP.size();
@@ -216,24 +210,12 @@ void PrecomputeRNSExtensionTables(CryptoContext<DCRTPoly>& cc, uint32_t from, ui
     for (auto& it : moduliQ)
         modulusQ *= it;
 
-    std::vector<NativeInteger> moduliQP(sizeQ + sizeP);
-    std::vector<NativeInteger> rootsQP(sizeQ + sizeP);
-
-    // populate moduli for CRT basis Q
-    for (size_t i = 0; i < sizeQ; i++) {
-        moduliQP[i] = moduliQ[i];
-        rootsQP[i]  = rootsQ[i];
-    }
-
-    // populate moduli for CRT basis P
-    for (size_t j = 0; j < sizeP; j++) {
-        moduliQP[sizeQ + j] = moduliP[j];
-        rootsQP[sizeQ + j]  = rootsP[j];
-    }
-
-    uint32_t ringDim      = cc->GetCryptoParameters()->GetElementParams()->GetRingDimension();
-    rnsExtTables.paramsP  = std::make_shared<ILDCRTParams<BigInteger>>(2 * ringDim, moduliP, rootsP);
-    rnsExtTables.paramsQP = std::make_shared<ILDCRTParams<BigInteger>>(2 * ringDim, moduliQP, rootsQP);
+    // CRT basis P: towers [from, to) of the element params (may be empty when no
+    // extension is needed); QP: towers [0, to)
+    auto towersP = (to > from) ? elemParams->GetParamPartition(from, to - 1) :
+                                 std::vector<std::shared_ptr<ILDCRTParams<BigInteger>::ILNativeParams>>{};
+    rnsExtTables.paramsP  = std::make_shared<ILDCRTParams<BigInteger>>(elemParams->GetCyclotomicOrder(), towersP);
+    rnsExtTables.paramsQP = std::make_shared<ILDCRTParams<BigInteger>>(*elemParams, to);
 
     rnsExtTables.QHatInvModq.resize(sizeQ);
     rnsExtTables.QHatInvModqPrecon.resize(sizeQ);

--- a/src/pke/lib/schemebase/base-advancedshe.cpp
+++ b/src/pke/lib/schemebase/base-advancedshe.cpp
@@ -192,7 +192,7 @@ Ciphertext<Element> AdvancedSHEBase<Element>::AddRandomNoise(ConstCiphertext<Ele
 
 template <class Element>
 std::shared_ptr<std::map<uint32_t, EvalKey<Element>>> AdvancedSHEBase<Element>::EvalSumKeyGen(
-    const PrivateKey<Element> privateKey) const {
+    const PrivateKey<Element> privateKey, uint32_t levels) const {
     if (!privateKey)
         OPENFHE_THROW("Input private key is nullptr");
 
@@ -201,12 +201,13 @@ std::shared_ptr<std::map<uint32_t, EvalKey<Element>>> AdvancedSHEBase<Element>::
     std::vector<uint32_t> indices(indx_set.begin(), indx_set.end());
 
     auto algo = privateKey->GetCryptoContext()->GetScheme();
-    return algo->EvalAutomorphismKeyGen(privateKey, indices);
+    return algo->EvalAutomorphismKeyGen(privateKey, indices, levels);
 }
 
 template <class Element>
 std::shared_ptr<std::map<uint32_t, EvalKey<Element>>> AdvancedSHEBase<Element>::EvalSumRowsKeyGen(
-    const PrivateKey<Element> privateKey, uint32_t rowSize, uint32_t subringDim, std::vector<uint32_t>& indices) const {
+    const PrivateKey<Element> privateKey, uint32_t rowSize, uint32_t subringDim, std::vector<uint32_t>& indices,
+    uint32_t levels) const {
     auto cc = privateKey->GetCryptoContext();
 
     if (!isCKKS(cc->getSchemeId()))
@@ -223,12 +224,12 @@ std::shared_ptr<std::map<uint32_t, EvalKey<Element>>> AdvancedSHEBase<Element>::
     indices.insert(indices.end(), rowsIndices.begin(), rowsIndices.end());
 
     auto algo = cc->GetScheme();
-    return algo->EvalAutomorphismKeyGen(privateKey, indices);
+    return algo->EvalAutomorphismKeyGen(privateKey, indices, levels);
 }
 
 template <class Element>
 std::shared_ptr<std::map<uint32_t, EvalKey<Element>>> AdvancedSHEBase<Element>::EvalSumColsKeyGen(
-    const PrivateKey<Element> privateKey, std::vector<uint32_t>& indices) const {
+    const PrivateKey<Element> privateKey, std::vector<uint32_t>& indices, uint32_t levels) const {
     auto cc = privateKey->GetCryptoContext();
 
     if (!isCKKS(cc->getSchemeId()))
@@ -249,7 +250,7 @@ std::shared_ptr<std::map<uint32_t, EvalKey<Element>>> AdvancedSHEBase<Element>::
     indices.insert(indices.end(), evalSumColsIndices.begin(), evalSumColsIndices.end());
 
     auto algo = cc->GetScheme();
-    return algo->EvalAutomorphismKeyGen(privateKey, indices);
+    return algo->EvalAutomorphismKeyGen(privateKey, indices, levels);
 }
 
 template <class Element>

--- a/src/pke/lib/schemebase/base-leveledshe.cpp
+++ b/src/pke/lib/schemebase/base-leveledshe.cpp
@@ -143,18 +143,20 @@ void LeveledSHEBase<Element>::EvalSubInPlace(Ciphertext<Element>& ciphertext, Co
 /////////////////////////////////////////
 
 template <class Element>
-EvalKey<Element> LeveledSHEBase<Element>::EvalMultKeyGen(const PrivateKey<Element> privateKey) const {
+EvalKey<Element> LeveledSHEBase<Element>::EvalMultKeyGen(const PrivateKey<Element> privateKey,
+                                                         uint32_t levels) const {
     const auto cc = privateKey->GetCryptoContext();
     const auto& s = privateKey->GetPrivateElement();
 
     auto privateKeySquared = std::make_shared<PrivateKeyImpl<Element>>(cc);
     privateKeySquared->SetPrivateElement(s * s);
 
-    return cc->GetScheme()->KeySwitchGen(privateKeySquared, privateKey);
+    return cc->GetScheme()->KeySwitchGen(privateKeySquared, privateKey, levels);
 }
 
 template <class Element>
-std::vector<EvalKey<Element>> LeveledSHEBase<Element>::EvalMultKeysGen(const PrivateKey<Element> privateKey) const {
+std::vector<EvalKey<Element>> LeveledSHEBase<Element>::EvalMultKeysGen(const PrivateKey<Element> privateKey,
+                                                                       uint32_t levels) const {
     const auto cc = privateKey->GetCryptoContext();
     const auto& s = privateKey->GetPrivateElement();
 
@@ -166,7 +168,7 @@ std::vector<EvalKey<Element>> LeveledSHEBase<Element>::EvalMultKeysGen(const Pri
     evalKeyVec.reserve(maxRelinSkDeg);
     for (uint32_t i = 0; i < maxRelinSkDeg; ++i) {
         privateKeyPower->SetPrivateElement(s * privateKeyPower->GetPrivateElement());
-        evalKeyVec.emplace_back(cc->GetScheme()->KeySwitchGen(privateKeyPower, privateKey));
+        evalKeyVec.emplace_back(cc->GetScheme()->KeySwitchGen(privateKeyPower, privateKey, levels));
     }
 
     return evalKeyVec;
@@ -334,11 +336,15 @@ void LeveledSHEBase<Element>::RelinearizeInPlace(Ciphertext<Element>& ciphertext
 
 template <class Element>
 std::shared_ptr<std::map<uint32_t, EvalKey<Element>>> LeveledSHEBase<Element>::EvalAutomorphismKeyGen(
-    const PrivateKey<Element> privateKey, const std::vector<uint32_t>& indexList) const {
-    // Do not generate duplicate keys that have been already generated and added to the static storage (map)
+    const PrivateKey<Element> privateKey, const std::vector<uint32_t>& indexList, uint32_t levels) const {
+    const auto cc = privateKey->GetCryptoContext();
+
+    // Do not generate duplicate keys that have been already generated and added to the static storage (map).
+    // An existing key is reused only if it has at least as many towers as the requested key.
+    const uint32_t numTowers = cc->GetScheme()->GetNumEvalKeyTowers(privateKey->GetCryptoParameters(), levels);
     std::set<uint32_t> allIndices(indexList.begin(), indexList.end());
     std::set<uint32_t> indicesToGenerate{
-        CryptoContextImpl<Element>::GetEvalAutomorphismNoKeyIndices(privateKey->GetKeyTag(), allIndices)};
+        CryptoContextImpl<Element>::GetEvalAutomorphismNoKeyIndices(privateKey->GetKeyTag(), allIndices, numTowers)};
     std::vector<uint32_t> newIndices(indicesToGenerate.begin(), indicesToGenerate.end());
 
     // we already have checks on higher level?
@@ -346,7 +352,6 @@ std::shared_ptr<std::map<uint32_t, EvalKey<Element>>> LeveledSHEBase<Element>::E
     //  if (it != newIndices.end())
     //    OPENFHE_THROW("conjugation is disabled");
 
-    const auto cc = privateKey->GetCryptoContext();
     const auto& s = privateKey->GetPrivateElement();
 
     const uint32_t N = s.GetRingDimension();
@@ -372,7 +377,7 @@ std::shared_ptr<std::map<uint32_t, EvalKey<Element>>> LeveledSHEBase<Element>::E
 
         auto privateKeyPermuted = std::make_shared<PrivateKeyImpl<Element>>(cc);
         privateKeyPermuted->SetPrivateElement(s.AutomorphismTransform(index, vec));
-        (*evalKeys)[newIndices[i]] = cc->GetScheme()->KeySwitchGen(privateKey, privateKeyPermuted);
+        (*evalKeys)[newIndices[i]] = cc->GetScheme()->KeySwitchGen(privateKey, privateKeyPermuted, levels);
     }
 
     return evalKeys;
@@ -480,12 +485,12 @@ Ciphertext<Element> LeveledSHEBase<Element>::EvalFastRotation(
 
 template <class Element>
 std::shared_ptr<std::map<uint32_t, EvalKey<Element>>> LeveledSHEBase<Element>::EvalAtIndexKeyGen(
-    const PrivateKey<Element> privateKey, const std::vector<int32_t>& indexList) const {
+    const PrivateKey<Element> privateKey, const std::vector<int32_t>& indexList, uint32_t levels) const {
     uint32_t M = privateKey->GetCryptoParameters()->GetElementParams()->GetCyclotomicOrder();
     std::vector<uint32_t> autoIndices(indexList.size());
     for (size_t i = 0; i < indexList.size(); i++)
         autoIndices[i] = FindAutomorphismIndex(indexList[i], M);
-    return EvalAutomorphismKeyGen(privateKey, autoIndices);
+    return EvalAutomorphismKeyGen(privateKey, autoIndices, levels);
 }
 
 template <class Element>

--- a/src/pke/lib/schemebase/base-scheme.cpp
+++ b/src/pke/lib/schemebase/base-scheme.cpp
@@ -55,17 +55,18 @@ Ciphertext<Element> SchemeBase<Element>::ReEncrypt(ConstCiphertext<Element>& cip
 }
 
 template <typename Element>
-EvalKey<Element> SchemeBase<Element>::EvalMultKeyGen(const PrivateKey<Element> privateKey) const {
+EvalKey<Element> SchemeBase<Element>::EvalMultKeyGen(const PrivateKey<Element> privateKey, uint32_t levels) const {
     VerifyLeveledSHEEnabled(__func__);
-    auto evalKey = m_LeveledSHE->EvalMultKeyGen(privateKey);
+    auto evalKey = m_LeveledSHE->EvalMultKeyGen(privateKey, levels);
     evalKey->SetKeyTag(privateKey->GetKeyTag());
     return evalKey;
 }
 
 template <typename Element>
-std::vector<EvalKey<Element>> SchemeBase<Element>::EvalMultKeysGen(const PrivateKey<Element> privateKey) const {
+std::vector<EvalKey<Element>> SchemeBase<Element>::EvalMultKeysGen(const PrivateKey<Element> privateKey,
+                                                                   uint32_t levels) const {
     VerifyLeveledSHEEnabled(__func__);
-    auto evalKeyVec = m_LeveledSHE->EvalMultKeysGen(privateKey);
+    auto evalKeyVec = m_LeveledSHE->EvalMultKeysGen(privateKey, levels);
     for (auto& evalKey : evalKeyVec)
         evalKey->SetKeyTag(privateKey->GetKeyTag());
     return evalKeyVec;
@@ -73,9 +74,9 @@ std::vector<EvalKey<Element>> SchemeBase<Element>::EvalMultKeysGen(const Private
 
 template <typename Element>
 std::shared_ptr<std::map<uint32_t, EvalKey<Element>>> SchemeBase<Element>::EvalAtIndexKeyGen(
-    const PrivateKey<Element> privateKey, const std::vector<int32_t>& indexList) const {
+    const PrivateKey<Element> privateKey, const std::vector<int32_t>& indexList, uint32_t levels) const {
     VerifyLeveledSHEEnabled(__func__);
-    auto evalKeyMap = m_LeveledSHE->EvalAtIndexKeyGen(privateKey, indexList);
+    auto evalKeyMap = m_LeveledSHE->EvalAtIndexKeyGen(privateKey, indexList, levels);
     for (auto& key : *evalKeyMap)
         key.second->SetKeyTag(privateKey->GetKeyTag());
     return evalKeyMap;
@@ -101,9 +102,9 @@ Ciphertext<Element> SchemeBase<Element>::ModReduce(ConstCiphertext<Element>& cip
 
 template <typename Element>
 std::shared_ptr<std::map<uint32_t, EvalKey<Element>>> SchemeBase<Element>::EvalSumKeyGen(
-    const PrivateKey<Element> privateKey) const {
+    const PrivateKey<Element> privateKey, uint32_t levels) const {
     VerifyAdvancedSHEEnabled(__func__);
-    auto evalKeyMap = m_AdvancedSHE->EvalSumKeyGen(privateKey);
+    auto evalKeyMap = m_AdvancedSHE->EvalSumKeyGen(privateKey, levels);
     for (auto& key : *evalKeyMap)
         key.second->SetKeyTag(privateKey->GetKeyTag());
     return evalKeyMap;
@@ -111,9 +112,10 @@ std::shared_ptr<std::map<uint32_t, EvalKey<Element>>> SchemeBase<Element>::EvalS
 
 template <typename Element>
 std::shared_ptr<std::map<uint32_t, EvalKey<Element>>> SchemeBase<Element>::EvalSumRowsKeyGen(
-    const PrivateKey<Element> privateKey, uint32_t rowSize, uint32_t subringDim, std::vector<uint32_t>& indices) const {
+    const PrivateKey<Element> privateKey, uint32_t rowSize, uint32_t subringDim, std::vector<uint32_t>& indices,
+    uint32_t levels) const {
     VerifyAdvancedSHEEnabled(__func__);
-    auto evalKeyMap = m_AdvancedSHE->EvalSumRowsKeyGen(privateKey, rowSize, subringDim, indices);
+    auto evalKeyMap = m_AdvancedSHE->EvalSumRowsKeyGen(privateKey, rowSize, subringDim, indices, levels);
     for (auto& key : *evalKeyMap)
         key.second->SetKeyTag(privateKey->GetKeyTag());
     return evalKeyMap;
@@ -121,9 +123,9 @@ std::shared_ptr<std::map<uint32_t, EvalKey<Element>>> SchemeBase<Element>::EvalS
 
 template <typename Element>
 std::shared_ptr<std::map<uint32_t, EvalKey<Element>>> SchemeBase<Element>::EvalSumColsKeyGen(
-    const PrivateKey<Element> privateKey, std::vector<uint32_t>& indices) const {
+    const PrivateKey<Element> privateKey, std::vector<uint32_t>& indices, uint32_t levels) const {
     VerifyAdvancedSHEEnabled(__func__);
-    auto evalKeyMap = m_AdvancedSHE->EvalSumColsKeyGen(privateKey, indices);
+    auto evalKeyMap = m_AdvancedSHE->EvalSumColsKeyGen(privateKey, indices, levels);
     for (auto& key : *evalKeyMap)
         key.second->SetKeyTag(privateKey->GetKeyTag());
     return evalKeyMap;
@@ -312,9 +314,9 @@ EvalKey<Element> SchemeBase<Element>::MultiAddEvalMultKeys(EvalKey<Element> eval
 
 template <typename Element>
 std::shared_ptr<std::map<uint32_t, EvalKey<Element>>> SchemeBase<Element>::EvalAutomorphismKeyGen(
-    const PrivateKey<Element> privateKey, const std::vector<uint32_t>& indexList) const {
+    const PrivateKey<Element> privateKey, const std::vector<uint32_t>& indexList, uint32_t levels) const {
     VerifyLeveledSHEEnabled(__func__);
-    auto evalKeyMap = m_LeveledSHE->EvalAutomorphismKeyGen(privateKey, indexList);
+    auto evalKeyMap = m_LeveledSHE->EvalAutomorphismKeyGen(privateKey, indexList, levels);
     for (auto& key : *evalKeyMap)
         key.second->SetKeyTag(privateKey->GetKeyTag());
     return evalKeyMap;

--- a/src/pke/lib/schemerns/rns-cryptoparameters.cpp
+++ b/src/pke/lib/schemerns/rns-cryptoparameters.cpp
@@ -116,16 +116,8 @@ void CryptoParametersRNS::PrecomputeCRTTables(KeySwitchTechnique ksTech, Scaling
         for (uint32_t j = 0; j < m_numPartQ; j++) {
             auto startTower = j * a;
             auto endTower   = ((j + 1) * a - 1 < sizeQ) ? (j + 1) * a - 1 : sizeQ - 1;
-            std::vector<std::shared_ptr<ILNativeParams>> params =
-                GetElementParams()->GetParamPartition(startTower, endTower);
-            std::vector<NativeInteger> moduli(params.size());
-            std::vector<NativeInteger> roots(params.size());
-            for (uint32_t i = 0; i < params.size(); i++) {
-                moduli[i] = params[i]->GetModulus();
-                roots[i]  = params[i]->GetRootOfUnity();
-            }
-            m_paramsPartQ[j] =
-                std::make_shared<ILDCRTParams<BigInteger>>(params[0]->GetCyclotomicOrder(), moduli, roots);
+            auto params      = GetElementParams()->GetParamPartition(startTower, endTower);
+            m_paramsPartQ[j] = std::make_shared<ILDCRTParams<BigInteger>>(params[0]->GetCyclotomicOrder(), params);
         }
 
         // Find number and size of individual special primes.
@@ -191,30 +183,15 @@ void CryptoParametersRNS::PrecomputeCRTTables(KeySwitchTechnique ksTech, Scaling
         // Store the created moduli and roots in m_paramsP
         m_paramsP = std::make_shared<ILDCRTParams<BigInteger>>(2 * n, moduliP, rootsP);
 
-        // Create the moduli and roots for the extended CRT basis QP
-        std::vector<NativeInteger> moduliQP(sizeQ + sizeP);
-        std::vector<NativeInteger> rootsQP(sizeQ + sizeP);
-        for (size_t i = 0; i < sizeQ; i++) {
-            moduliQP[i] = moduliQ[i];
-            rootsQP[i]  = rootsQ[i];
-        }
-        for (size_t i = 0; i < sizeP; i++) {
-            moduliQP[sizeQ + i] = moduliP[i];
-            rootsQP[sizeQ + i]  = rootsP[i];
-        }
-
-        m_paramsQP = std::make_shared<ILDCRTParams<BigInteger>>(2 * n, moduliQP, rootsQP);
+        // Create the extended CRT basis QP
+        m_paramsQP = std::make_shared<ILDCRTParams<BigInteger>>(*GetElementParams(), static_cast<uint32_t>(sizeQ),
+                                                                *m_paramsP, static_cast<uint32_t>(sizeP));
 
         // Precompute params for first 1..sizeQ towers of Q for KeySwitchDown (avoids per-call allocation).
         m_paramsQlHybrid.resize(sizeQ);
-        std::vector<NativeInteger> moduliQl, rootsQl;
-        moduliQl.reserve(sizeQ);
-        rootsQl.reserve(sizeQ);
-        for (size_t i = 0; i < sizeQ; ++i) {
-            moduliQl.push_back(moduliQ[i]);
-            rootsQl.push_back(rootsQ[i]);
-            m_paramsQlHybrid[i] = std::make_shared<ILDCRTParams<BigInteger>>(2 * n, moduliQl, rootsQl);
-        }
+        for (size_t i = 0; i < sizeQ; ++i)
+            m_paramsQlHybrid[i] =
+                std::make_shared<ILDCRTParams<BigInteger>>(*GetElementParams(), static_cast<uint32_t>(i + 1));
 
         // Pre-compute CRT::FFT values for P
         ChineseRemainderTransformFTT<NativeVector>().PreCompute(rootsP, 2 * n, moduliP);

--- a/src/pke/lib/schemerns/rns-multiparty.cpp
+++ b/src/pke/lib/schemerns/rns-multiparty.cpp
@@ -63,17 +63,9 @@ Ciphertext<DCRTPoly> MultipartyRNS::MultipartyDecryptLead(ConstCiphertext<DCRTPo
         DugType dug;
         auto params                            = cv[0].GetParams();
         auto cyclOrder                         = params->GetCyclotomicOrder();
-        std::vector<NativeInteger> moduliFirst = {params->GetParams()[0]->GetModulus()};
-        std::vector<NativeInteger> rootsFirst  = {params->GetParams()[0]->GetRootOfUnity()};
-        auto paramsFirst = std::make_shared<ILDCRTParams<BigInteger>>(cyclOrder, moduliFirst, rootsFirst);
-        std::vector<NativeInteger> moduliAllButFirst(sizeQl - 1);
-        std::vector<NativeInteger> rootsAllButFirst(sizeQl - 1);
-        for (size_t i = 1; i < sizeQl; i++) {
-            moduliAllButFirst[i - 1] = params->GetParams()[i]->GetModulus();
-            rootsAllButFirst[i - 1]  = params->GetParams()[i]->GetRootOfUnity();
-        }
-        auto paramsAllButFirst =
-            std::make_shared<ILDCRTParams<BigInteger>>(cyclOrder, moduliAllButFirst, rootsAllButFirst);
+        auto paramsFirst       = std::make_shared<ILDCRTParams<BigInteger>>(*params, 1);
+        auto paramsAllButFirst = std::make_shared<ILDCRTParams<BigInteger>>(
+            cyclOrder, params->GetParamPartition(1, static_cast<uint32_t>(sizeQl) - 1));
         DCRTPoly e(dug, paramsAllButFirst, Format::EVALUATION);
 
         e.ExpandCRTBasisReverseOrder(params, paramsFirst, cryptoParams->GetMultipartyQHatInvModqAtIndex(sizeQl - 2),
@@ -325,12 +317,12 @@ void ExtendBasis(DCRTPoly& dcrtpoly, const std::shared_ptr<DCRTPoly::Params> par
     }
 
     std::vector<NativeInteger> moduliP(sizeP);
-    std::vector<NativeInteger> rootsP(sizeP);
-    for (size_t i = 0; i < sizeP; i++) {
+    for (size_t i = 0; i < sizeP; i++)
         moduliP[i] = paramsQP->GetParams()[i + sizeQ]->GetModulus();
-        rootsP[i]  = paramsQP->GetParams()[i + sizeQ]->GetRootOfUnity();
-    }
-    auto paramsP = std::make_shared<typename DCRTPoly::Params>(2 * paramsQ->GetRingDimension(), moduliP, rootsP);
+    // the P part may be empty when the bases coincide
+    auto towersP = (sizeQP > sizeQ) ? paramsQP->GetParamPartition(sizeQ, sizeQP - 1) :
+                                      std::vector<std::shared_ptr<typename DCRTPoly::Params::ILNativeParams>>{};
+    auto paramsP = std::make_shared<typename DCRTPoly::Params>(paramsQP->GetCyclotomicOrder(), towersP);
 
     // Does all RNS precomputations
     std::vector<NativeInteger> QHatInvModq(sizeQ);

--- a/src/pke/unittest/UnitTestEvalKeyLevels.cpp
+++ b/src/pke/unittest/UnitTestEvalKeyLevels.cpp
@@ -40,13 +40,18 @@
  */
 
 #include "cryptocontext.h"
+#include "cryptocontext-ser.h"
 #include "gen-cryptocontext.h"
 #include "gtest/gtest.h"
+#include "key/key-ser.h"
 #include "scheme/bgvrns/gen-cryptocontext-bgvrns.h"
+#include "scheme/bgvrns/bgvrns-ser.h"
 #include "scheme/bfvrns/gen-cryptocontext-bfvrns.h"
 #include "scheme/ckksrns/gen-cryptocontext-ckksrns.h"
+#include "scheme/ckksrns/ckksrns-ser.h"
 #include "UnitTestUtils.h"
 
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -472,6 +477,52 @@ TEST(UTGENERAL_EVAL_KEY_LEVELS, EvalSumKeysAtLevel) {
             }
 
             CryptoContextImpl<DCRTPoly>::ClearEvalAutomorphismKeys();
+        }
+        catch (std::exception& e) {
+            std::cerr << "Exception thrown from " << failmsg << ": " << e.what() << std::endl;
+            EXPECT_TRUE(0 == 1) << failmsg;
+        }
+        catch (...) {
+            UNIT_TEST_HANDLE_ALL_EXCEPTIONS;
+        }
+    }
+}
+
+// reduced and compressed keys survive a serialization round trip and still key-switch
+// correctly at their level
+TEST(UTGENERAL_EVAL_KEY_LEVELS, SerializeReducedKeys) {
+    setupSignals();
+    OpenFHEParallelControls.UnitTestStart();
+
+    constexpr uint32_t levels = 2;
+    for (const auto& [scheme, ksTech] : TEST_CASES) {
+        const std::string failmsg = "SerializeReducedKeys " + TestLabel(scheme, ksTech);
+        try {
+            // deserialized keys resolve their cryptocontext through the factory registry;
+            // clear it so they attach to the context created below
+            CryptoContextFactory<DCRTPoly>::ReleaseAllContexts();
+            auto cc  = MakeContext(scheme, ksTech);
+            auto kp  = cc->KeyGen();
+            auto kp2 = cc->KeyGen();
+
+            auto keyReduced    = cc->KeySwitchGen(kp.secretKey, kp2.secretKey, levels);
+            auto keyCompressed = cc->CompressEvalKey(cc->KeySwitchGen(kp.secretKey, kp2.secretKey), levels);
+
+            for (const auto& key : {keyReduced, keyCompressed}) {
+                std::stringstream ss;
+                Serial::Serialize(key, ss, SerType::BINARY);
+                EvalKey<DCRTPoly> keyDeser;
+                Serial::Deserialize(keyDeser, ss, SerType::BINARY);
+                ASSERT_TRUE(keyDeser != nullptr) << failmsg;
+                EXPECT_EQ(keyDeser->GetAVector()[0].GetNumOfElements(), key->GetAVector()[0].GetNumOfElements())
+                    << failmsg;
+
+                auto ptxt       = MakeTestPlaintext(scheme, cc);
+                auto ct         = cc->Encrypt(kp.publicKey, ptxt);
+                auto ctReduced  = DropCiphertextLevels(scheme, cc, ct, levels);
+                auto ctSwitched = cc->KeySwitch(ctReduced, keyDeser);
+                CheckDecryption(scheme, cc, kp2.secretKey, ctSwitched, ptxt, 0, failmsg);
+            }
         }
         catch (std::exception& e) {
             std::cerr << "Exception thrown from " << failmsg << ": " << e.what() << std::endl;

--- a/src/pke/unittest/UnitTestEvalKeyLevels.cpp
+++ b/src/pke/unittest/UnitTestEvalKeyLevels.cpp
@@ -1,0 +1,552 @@
+//==================================================================================
+// BSD 2-Clause License
+//
+// Copyright (c) 2014-2026, NJIT, Duality Technologies Inc. and other contributors
+//
+// All rights reserved.
+//
+// Author TPOC: contact@openfhe.org
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//==================================================================================
+
+/*
+  Tests for generating evaluation keys at a specified level and for compressing existing
+  evaluation keys (https://github.com/openfheorg/openfhe-development/issues/413):
+  - Eval*KeyGen with a nonzero number of dropped levels produces keys with fewer RNS limbs
+    that work on ciphertexts at (or above) that level and are rejected below it.
+  - CompressEvalKey reduces the number of RNS limbs of an existing key.
+  - The cryptocontext automorphism key map keeps the key with the most towers when keys
+    for the same index are inserted repeatedly.
+ */
+
+#include "cryptocontext.h"
+#include "gen-cryptocontext.h"
+#include "gtest/gtest.h"
+#include "scheme/bgvrns/gen-cryptocontext-bgvrns.h"
+#include "scheme/bfvrns/gen-cryptocontext-bfvrns.h"
+#include "scheme/ckksrns/gen-cryptocontext-ckksrns.h"
+#include "UnitTestUtils.h"
+
+#include <string>
+#include <vector>
+
+using namespace lbcrypto;
+
+namespace {
+
+constexpr uint32_t MULT_DEPTH = 4;
+constexpr uint32_t RING_DIM   = 1 << 8;
+constexpr size_t VEC_SIZE     = 8;
+
+CryptoContext<DCRTPoly> MakeCKKSContext(KeySwitchTechnique ksTech) {
+    CCParams<CryptoContextCKKSRNS> parameters;
+    parameters.SetMultiplicativeDepth(MULT_DEPTH);
+    parameters.SetScalingModSize(45);
+    parameters.SetScalingTechnique(FIXEDMANUAL);
+    parameters.SetSecurityLevel(HEStd_NotSet);
+    parameters.SetRingDim(RING_DIM);
+    parameters.SetKeySwitchTechnique(ksTech);
+    // BV key switching with full RNS digits adds noise on the order of the RNS moduli,
+    // which CKKS cannot absorb at this scale; use digit decomposition instead (this also
+    // exercises the digit-window path of the level-aware key generation)
+    if (ksTech == BV)
+        parameters.SetDigitSize(15);
+
+    auto cc = GenCryptoContext(parameters);
+    cc->Enable(PKE);
+    cc->Enable(KEYSWITCH);
+    cc->Enable(LEVELEDSHE);
+    return cc;
+}
+
+CryptoContext<DCRTPoly> MakeBGVContext(KeySwitchTechnique ksTech) {
+    CCParams<CryptoContextBGVRNS> parameters;
+    parameters.SetMultiplicativeDepth(MULT_DEPTH);
+    parameters.SetPlaintextModulus(65537);
+    parameters.SetScalingTechnique(FIXEDMANUAL);
+    parameters.SetSecurityLevel(HEStd_NotSet);
+    parameters.SetRingDim(RING_DIM);
+    parameters.SetKeySwitchTechnique(ksTech);
+
+    auto cc = GenCryptoContext(parameters);
+    cc->Enable(PKE);
+    cc->Enable(KEYSWITCH);
+    cc->Enable(LEVELEDSHE);
+    return cc;
+}
+
+enum class TestScheme { CKKS, BGV };
+
+CryptoContext<DCRTPoly> MakeContext(TestScheme scheme, KeySwitchTechnique ksTech) {
+    return (scheme == TestScheme::CKKS) ? MakeCKKSContext(ksTech) : MakeBGVContext(ksTech);
+}
+
+// a separate context for the EvalSum tests: EvalSum(Rows/Cols) requires a batch size, which
+// changes the packing (and so the rotation semantics) of the other tests
+CryptoContext<DCRTPoly> MakeSumContext(TestScheme scheme, KeySwitchTechnique ksTech) {
+    CryptoContext<DCRTPoly> cc;
+    if (scheme == TestScheme::CKKS) {
+        CCParams<CryptoContextCKKSRNS> parameters;
+        parameters.SetMultiplicativeDepth(MULT_DEPTH);
+        parameters.SetScalingModSize(45);
+        parameters.SetScalingTechnique(FIXEDMANUAL);
+        parameters.SetSecurityLevel(HEStd_NotSet);
+        parameters.SetRingDim(RING_DIM);
+        parameters.SetKeySwitchTechnique(ksTech);
+        parameters.SetBatchSize(VEC_SIZE);
+        if (ksTech == BV)
+            parameters.SetDigitSize(15);
+        cc = GenCryptoContext(parameters);
+    }
+    else {
+        CCParams<CryptoContextBGVRNS> parameters;
+        parameters.SetMultiplicativeDepth(MULT_DEPTH);
+        parameters.SetPlaintextModulus(65537);
+        parameters.SetScalingTechnique(FIXEDMANUAL);
+        parameters.SetSecurityLevel(HEStd_NotSet);
+        parameters.SetRingDim(RING_DIM);
+        parameters.SetKeySwitchTechnique(ksTech);
+        parameters.SetBatchSize(VEC_SIZE);
+        cc = GenCryptoContext(parameters);
+    }
+    cc->Enable(PKE);
+    cc->Enable(KEYSWITCH);
+    cc->Enable(LEVELEDSHE);
+    cc->Enable(ADVANCEDSHE);
+    return cc;
+}
+
+Plaintext MakeTestPlaintext(TestScheme scheme, const CryptoContext<DCRTPoly>& cc) {
+    if (scheme == TestScheme::CKKS) {
+        std::vector<double> x = {0.25, 0.5, 0.75, 1.0, 2.0, 3.0, 4.0, 5.0};
+        return cc->MakeCKKSPackedPlaintext(x);
+    }
+    std::vector<int64_t> x = {1, 2, 3, 4, 5, 6, 7, 8};
+    return cc->MakePackedPlaintext(x);
+}
+
+// drops `levels` RNS limbs from the ciphertext without changing the encrypted value
+Ciphertext<DCRTPoly> DropCiphertextLevels(TestScheme scheme, const CryptoContext<DCRTPoly>& cc,
+                                          ConstCiphertext<DCRTPoly>& ciphertext, uint32_t levels) {
+    if (scheme == TestScheme::CKKS)
+        return cc->LevelReduce(ciphertext, nullptr, levels);
+
+    auto result = ciphertext->Clone();
+    for (uint32_t i = 0; i < levels; ++i)
+        result = cc->ModReduce(result);
+    return result;
+}
+
+// checks the decryption of `ciphertext` against the values of `expected` shifted left by
+// `shift` (vacated positions are checked against zero, matching the zero padding of the
+// encoded test vector)
+void CheckDecryption(TestScheme scheme, const CryptoContext<DCRTPoly>& cc, const PrivateKey<DCRTPoly>& secretKey,
+                     ConstCiphertext<DCRTPoly>& ciphertext, const Plaintext& expected, uint32_t shift,
+                     const std::string& failmsg) {
+    Plaintext result;
+    cc->Decrypt(secretKey, ciphertext, &result);
+    result->SetLength(VEC_SIZE);
+
+    if (scheme == TestScheme::CKKS) {
+        const auto expectedVals = expected->GetRealPackedValue();
+        const auto resultVals   = result->GetRealPackedValue();
+        for (size_t i = 0; i < VEC_SIZE; ++i) {
+            double expectedVal = (i + shift < VEC_SIZE) ? expectedVals[i + shift] : 0.0;
+            EXPECT_TRUE(checkEquality(resultVals[i], expectedVal, EPSILON_HIGH)) << failmsg << " at slot " << i;
+        }
+    }
+    else {
+        const auto expectedVals = expected->GetPackedValue();
+        const auto resultVals   = result->GetPackedValue();
+        for (size_t i = 0; i < VEC_SIZE; ++i) {
+            int64_t expectedVal = (i + shift < VEC_SIZE) ? expectedVals[i + shift] : 0;
+            EXPECT_EQ(resultVals[i], expectedVal) << failmsg << " at slot " << i;
+        }
+    }
+}
+
+uint32_t GetAutomorphismKeyTowers(const std::string& keyTag) {
+    const auto& keyMap = CryptoContextImpl<DCRTPoly>::GetEvalAutomorphismKeyMap(keyTag);
+    return keyMap.begin()->second->GetAVector()[0].GetNumOfElements();
+}
+
+std::string TestLabel(TestScheme scheme, KeySwitchTechnique ksTech) {
+    std::string label = (scheme == TestScheme::CKKS) ? "CKKS" : "BGV";
+    return label + ((ksTech == HYBRID) ? "/HYBRID" : "/BV");
+}
+
+const std::vector<std::pair<TestScheme, KeySwitchTechnique>> TEST_CASES = {
+    {TestScheme::CKKS, HYBRID},
+    {TestScheme::CKKS, BV},
+    {TestScheme::BGV, HYBRID},
+    {TestScheme::BGV, BV},
+};
+
+}  // anonymous namespace
+
+// rotation keys generated at a level work for ciphertexts at that level and are rejected
+// for ciphertexts with more towers
+TEST(UTGENERAL_EVAL_KEY_LEVELS, RotationKeysAtLevel) {
+    setupSignals();
+    OpenFHEParallelControls.UnitTestStart();
+
+    constexpr uint32_t levels = 2;
+    for (const auto& [scheme, ksTech] : TEST_CASES) {
+        const std::string failmsg = "RotationKeysAtLevel " + TestLabel(scheme, ksTech);
+        try {
+            CryptoContextImpl<DCRTPoly>::ClearEvalAutomorphismKeys();
+            auto cc = MakeContext(scheme, ksTech);
+            auto kp = cc->KeyGen();
+
+            // a reduced key must have exactly `levels` fewer towers than a full key
+            cc->EvalRotateKeyGen(kp.secretKey, {1}, levels);
+            const uint32_t reducedTowers = GetAutomorphismKeyTowers(kp.secretKey->GetKeyTag());
+
+            auto ptxt      = MakeTestPlaintext(scheme, cc);
+            auto ct        = cc->Encrypt(kp.publicKey, ptxt);
+            auto ctReduced = DropCiphertextLevels(scheme, cc, ct, levels);
+
+            auto ctRot = cc->EvalRotate(ctReduced, 1);
+            CheckDecryption(scheme, cc, kp.secretKey, ctRot, ptxt, 1, failmsg);
+
+            // a ciphertext with more towers than the key must be rejected
+            EXPECT_THROW(cc->EvalRotate(ct, 1), OpenFHEException) << failmsg;
+
+            // a full key generated for another secret key has `levels` more towers
+            CryptoContextImpl<DCRTPoly>::ClearEvalAutomorphismKeys();
+            auto kp2 = cc->KeyGen();
+            cc->EvalRotateKeyGen(kp2.secretKey, {1});
+            const uint32_t fullTowers = GetAutomorphismKeyTowers(kp2.secretKey->GetKeyTag());
+            EXPECT_EQ(reducedTowers + levels, fullTowers) << failmsg;
+
+            CryptoContextImpl<DCRTPoly>::ClearEvalAutomorphismKeys();
+        }
+        catch (std::exception& e) {
+            std::cerr << "Exception thrown from " << failmsg << ": " << e.what() << std::endl;
+            EXPECT_TRUE(0 == 1) << failmsg;
+        }
+        catch (...) {
+            UNIT_TEST_HANDLE_ALL_EXCEPTIONS;
+        }
+    }
+}
+
+// for duplicate rotation indices, the automorphism key map keeps the key with the most towers
+TEST(UTGENERAL_EVAL_KEY_LEVELS, KeyMapKeepsMostTowers) {
+    setupSignals();
+    OpenFHEParallelControls.UnitTestStart();
+
+    constexpr uint32_t levels = 2;
+    for (const auto& [scheme, ksTech] : TEST_CASES) {
+        const std::string failmsg = "KeyMapKeepsMostTowers " + TestLabel(scheme, ksTech);
+        try {
+            CryptoContextImpl<DCRTPoly>::ClearEvalAutomorphismKeys();
+            auto cc = MakeContext(scheme, ksTech);
+            auto kp = cc->KeyGen();
+
+            cc->EvalRotateKeyGen(kp.secretKey, {1}, levels);
+            const uint32_t reducedTowers = GetAutomorphismKeyTowers(kp.secretKey->GetKeyTag());
+
+            // requesting a full key for the same index must replace the reduced key
+            cc->EvalRotateKeyGen(kp.secretKey, {1});
+            const uint32_t fullTowers = GetAutomorphismKeyTowers(kp.secretKey->GetKeyTag());
+            EXPECT_EQ(reducedTowers + levels, fullTowers) << failmsg;
+
+            // requesting a reduced key again must keep the full key
+            cc->EvalRotateKeyGen(kp.secretKey, {1}, levels);
+            EXPECT_EQ(fullTowers, GetAutomorphismKeyTowers(kp.secretKey->GetKeyTag())) << failmsg;
+
+            // the retained full key must work for a freshly encrypted ciphertext
+            auto ptxt  = MakeTestPlaintext(scheme, cc);
+            auto ct    = cc->Encrypt(kp.publicKey, ptxt);
+            auto ctRot = cc->EvalRotate(ct, 1);
+            CheckDecryption(scheme, cc, kp.secretKey, ctRot, ptxt, 1, failmsg);
+
+            CryptoContextImpl<DCRTPoly>::ClearEvalAutomorphismKeys();
+        }
+        catch (std::exception& e) {
+            std::cerr << "Exception thrown from " << failmsg << ": " << e.what() << std::endl;
+            EXPECT_TRUE(0 == 1) << failmsg;
+        }
+        catch (...) {
+            UNIT_TEST_HANDLE_ALL_EXCEPTIONS;
+        }
+    }
+}
+
+// relinearization keys generated at a level work for multiplications at that level and are
+// rejected for ciphertexts with more towers
+TEST(UTGENERAL_EVAL_KEY_LEVELS, EvalMultKeyAtLevel) {
+    setupSignals();
+    OpenFHEParallelControls.UnitTestStart();
+
+    constexpr uint32_t levels = 2;
+    for (const auto& [scheme, ksTech] : TEST_CASES) {
+        const std::string failmsg = "EvalMultKeyAtLevel " + TestLabel(scheme, ksTech);
+        try {
+            CryptoContextImpl<DCRTPoly>::ClearEvalMultKeys();
+            auto cc = MakeContext(scheme, ksTech);
+            auto kp = cc->KeyGen();
+
+            cc->EvalMultKeyGen(kp.secretKey, levels);
+
+            Plaintext ptxt;
+            if (scheme == TestScheme::CKKS) {
+                std::vector<double> x = {0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0};
+                ptxt                  = cc->MakeCKKSPackedPlaintext(x);
+            }
+            else {
+                std::vector<int64_t> x = {1, 2, 3, 4, 5, 6, 7, 8};
+                ptxt                   = cc->MakePackedPlaintext(x);
+            }
+            auto ct        = cc->Encrypt(kp.publicKey, ptxt);
+            auto ctReduced = DropCiphertextLevels(scheme, cc, ct, levels);
+
+            auto ctMult = cc->EvalMult(ctReduced, ctReduced);
+            Plaintext result;
+            cc->Decrypt(kp.secretKey, ctMult, &result);
+            result->SetLength(VEC_SIZE);
+            if (scheme == TestScheme::CKKS) {
+                const auto vals     = ptxt->GetRealPackedValue();
+                const auto resultVals = result->GetRealPackedValue();
+                for (size_t i = 0; i < VEC_SIZE; ++i)
+                    EXPECT_TRUE(checkEquality(resultVals[i], vals[i] * vals[i], EPSILON_HIGH))
+                        << failmsg << " at slot " << i;
+            }
+            else {
+                const auto vals       = ptxt->GetPackedValue();
+                const auto resultVals = result->GetPackedValue();
+                for (size_t i = 0; i < VEC_SIZE; ++i)
+                    EXPECT_EQ(resultVals[i], vals[i] * vals[i]) << failmsg << " at slot " << i;
+            }
+
+            // a ciphertext with more towers than the relinearization key must be rejected
+            EXPECT_THROW(cc->EvalMult(ct, ct), OpenFHEException) << failmsg;
+
+            // requesting a full relinearization key must replace the reduced key
+            cc->EvalMultKeyGen(kp.secretKey);
+            auto ctMultFull = cc->EvalMult(ct, ct);
+            cc->Decrypt(kp.secretKey, ctMultFull, &result);
+            result->SetLength(VEC_SIZE);
+
+            CryptoContextImpl<DCRTPoly>::ClearEvalMultKeys();
+        }
+        catch (std::exception& e) {
+            std::cerr << "Exception thrown from " << failmsg << ": " << e.what() << std::endl;
+            EXPECT_TRUE(0 == 1) << failmsg;
+        }
+        catch (...) {
+            UNIT_TEST_HANDLE_ALL_EXCEPTIONS;
+        }
+    }
+}
+
+// CompressEvalKey reduces the number of RNS limbs of an existing key-switching key, and the
+// compressed key still switches correctly at the reduced level
+TEST(UTGENERAL_EVAL_KEY_LEVELS, CompressEvalKey) {
+    setupSignals();
+    OpenFHEParallelControls.UnitTestStart();
+
+    constexpr uint32_t levels = 2;
+    for (const auto& [scheme, ksTech] : TEST_CASES) {
+        const std::string failmsg = "CompressEvalKey " + TestLabel(scheme, ksTech);
+        try {
+            auto cc  = MakeContext(scheme, ksTech);
+            auto kp  = cc->KeyGen();
+            auto kp2 = cc->KeyGen();
+
+            auto evalKey           = cc->KeySwitchGen(kp.secretKey, kp2.secretKey);
+            auto evalKeyCompressed = cc->CompressEvalKey(evalKey, levels);
+
+            EXPECT_EQ(evalKey->GetAVector()[0].GetNumOfElements(),
+                      evalKeyCompressed->GetAVector()[0].GetNumOfElements() + levels)
+                << failmsg;
+
+            auto ptxt      = MakeTestPlaintext(scheme, cc);
+            auto ct        = cc->Encrypt(kp.publicKey, ptxt);
+            auto ctReduced = DropCiphertextLevels(scheme, cc, ct, levels);
+
+            // the compressed key switches a reduced ciphertext to the second secret key
+            auto ctSwitched = cc->KeySwitch(ctReduced, evalKeyCompressed);
+            CheckDecryption(scheme, cc, kp2.secretKey, ctSwitched, ptxt, 0, failmsg);
+
+            // a ciphertext with more towers than the compressed key must be rejected
+            EXPECT_THROW(cc->KeySwitch(ct, evalKeyCompressed), OpenFHEException) << failmsg;
+
+            // compressing by at least the number of available limbs must be rejected
+            const uint32_t sizeQ = cc->GetElementParams()->GetParams().size();
+            EXPECT_THROW(cc->CompressEvalKey(evalKey, sizeQ), OpenFHEException) << failmsg;
+        }
+        catch (std::exception& e) {
+            std::cerr << "Exception thrown from " << failmsg << ": " << e.what() << std::endl;
+            EXPECT_TRUE(0 == 1) << failmsg;
+        }
+        catch (...) {
+            UNIT_TEST_HANDLE_ALL_EXCEPTIONS;
+        }
+    }
+}
+
+// EvalSum keys generated at a level work for ciphertexts at that level and are rejected for
+// ciphertexts with more towers; EvalSumRows/EvalSumCols keys are generated with reduced towers
+TEST(UTGENERAL_EVAL_KEY_LEVELS, EvalSumKeysAtLevel) {
+    setupSignals();
+    OpenFHEParallelControls.UnitTestStart();
+
+    constexpr uint32_t levels = 2;
+    for (const auto& [scheme, ksTech] : TEST_CASES) {
+        const std::string failmsg = "EvalSumKeysAtLevel " + TestLabel(scheme, ksTech);
+        try {
+            CryptoContextImpl<DCRTPoly>::ClearEvalAutomorphismKeys();
+            auto cc = MakeSumContext(scheme, ksTech);
+            auto kp = cc->KeyGen();
+
+            cc->EvalSumKeyGen(kp.secretKey, levels);
+
+            // every key in the generated map must have the reduced number of towers
+            const uint32_t reducedTowers = GetAutomorphismKeyTowers(kp.secretKey->GetKeyTag());
+            for (const auto& [indx, key] : CryptoContextImpl<DCRTPoly>::GetEvalAutomorphismKeyMap(
+                     kp.secretKey->GetKeyTag())) {
+                EXPECT_EQ(key->GetAVector()[0].GetNumOfElements(), reducedTowers)
+                    << failmsg << " at index " << indx;
+            }
+
+            auto ptxt      = MakeTestPlaintext(scheme, cc);
+            auto ct        = cc->Encrypt(kp.publicKey, ptxt);
+            auto ctReduced = DropCiphertextLevels(scheme, cc, ct, levels);
+
+            auto ctSum = cc->EvalSum(ctReduced, VEC_SIZE);
+            Plaintext result;
+            cc->Decrypt(kp.secretKey, ctSum, &result);
+            result->SetLength(VEC_SIZE);
+            if (scheme == TestScheme::CKKS) {
+                const auto vals = ptxt->GetRealPackedValue();
+                double expected = 0.0;
+                for (size_t i = 0; i < VEC_SIZE; ++i)
+                    expected += vals[i];
+                EXPECT_TRUE(checkEquality(result->GetRealPackedValue()[0], expected, EPSILON_HIGH)) << failmsg;
+            }
+            else {
+                const auto vals  = ptxt->GetPackedValue();
+                int64_t expected = 0;
+                for (size_t i = 0; i < VEC_SIZE; ++i)
+                    expected += vals[i];
+                EXPECT_EQ(result->GetPackedValue()[0], expected) << failmsg;
+            }
+
+            // a ciphertext with more towers than the keys must be rejected
+            EXPECT_THROW(cc->EvalSum(ct, VEC_SIZE), OpenFHEException) << failmsg;
+
+            // EvalSumRows/EvalSumCols key generation is supported for CKKS only; check that the
+            // returned key maps also have the reduced number of towers
+            if (scheme == TestScheme::CKKS) {
+                auto rowKeys = cc->EvalSumRowsKeyGen(kp.secretKey, VEC_SIZE / 2, 0, levels);
+                for (const auto& [indx, key] : *rowKeys)
+                    EXPECT_EQ(key->GetAVector()[0].GetNumOfElements(), reducedTowers)
+                        << failmsg << " (rows) at index " << indx;
+
+                auto colKeys = cc->EvalSumColsKeyGen(kp.secretKey, levels);
+                for (const auto& [indx, key] : *colKeys)
+                    EXPECT_EQ(key->GetAVector()[0].GetNumOfElements(), reducedTowers)
+                        << failmsg << " (cols) at index " << indx;
+            }
+
+            CryptoContextImpl<DCRTPoly>::ClearEvalAutomorphismKeys();
+        }
+        catch (std::exception& e) {
+            std::cerr << "Exception thrown from " << failmsg << ": " << e.what() << std::endl;
+            EXPECT_TRUE(0 == 1) << failmsg;
+        }
+        catch (...) {
+            UNIT_TEST_HANDLE_ALL_EXCEPTIONS;
+        }
+    }
+}
+
+// generating keys at a level equal to (or above) the number of RNS limbs must be rejected
+TEST(UTGENERAL_EVAL_KEY_LEVELS, LevelsOutOfRange) {
+    setupSignals();
+    OpenFHEParallelControls.UnitTestStart();
+
+    for (const auto& [scheme, ksTech] : TEST_CASES) {
+        const std::string failmsg = "LevelsOutOfRange " + TestLabel(scheme, ksTech);
+        try {
+            CryptoContextImpl<DCRTPoly>::ClearEvalAutomorphismKeys();
+            auto cc = MakeContext(scheme, ksTech);
+            auto kp = cc->KeyGen();
+
+            const uint32_t sizeQ = cc->GetElementParams()->GetParams().size();
+            EXPECT_THROW(cc->EvalRotateKeyGen(kp.secretKey, {1}, sizeQ), OpenFHEException) << failmsg;
+            EXPECT_THROW(cc->EvalMultKeyGen(kp.secretKey, sizeQ), OpenFHEException) << failmsg;
+
+            CryptoContextImpl<DCRTPoly>::ClearEvalAutomorphismKeys();
+            CryptoContextImpl<DCRTPoly>::ClearEvalMultKeys();
+        }
+        catch (std::exception& e) {
+            std::cerr << "Exception thrown from " << failmsg << ": " << e.what() << std::endl;
+            EXPECT_TRUE(0 == 1) << failmsg;
+        }
+        catch (...) {
+            UNIT_TEST_HANDLE_ALL_EXCEPTIONS;
+        }
+    }
+}
+
+// key generation at a nonzero level is not supported for BFV
+TEST(UTGENERAL_EVAL_KEY_LEVELS, BFVNotSupported) {
+    setupSignals();
+    OpenFHEParallelControls.UnitTestStart();
+
+    const std::string failmsg = "BFVNotSupported";
+    try {
+        CCParams<CryptoContextBFVRNS> parameters;
+        parameters.SetMultiplicativeDepth(MULT_DEPTH);
+        parameters.SetPlaintextModulus(65537);
+        parameters.SetSecurityLevel(HEStd_NotSet);
+        parameters.SetRingDim(RING_DIM);
+
+        auto cc = GenCryptoContext(parameters);
+        cc->Enable(PKE);
+        cc->Enable(KEYSWITCH);
+        cc->Enable(LEVELEDSHE);
+
+        auto kp = cc->KeyGen();
+        EXPECT_THROW(cc->EvalRotateKeyGen(kp.secretKey, {1}, 1), OpenFHEException) << failmsg;
+        EXPECT_THROW(cc->EvalMultKeyGen(kp.secretKey, 1), OpenFHEException) << failmsg;
+        EXPECT_THROW(cc->EvalSumKeyGen(kp.secretKey, 1), OpenFHEException) << failmsg;
+        auto kp2     = cc->KeyGen();
+        auto evalKey = cc->KeySwitchGen(kp.secretKey, kp2.secretKey);
+        EXPECT_THROW(cc->CompressEvalKey(evalKey, 1), OpenFHEException) << failmsg;
+
+        // level 0 keeps working for BFV
+        cc->EvalMultKeyGen(kp.secretKey);
+        CryptoContextImpl<DCRTPoly>::ClearEvalMultKeys();
+    }
+    catch (std::exception& e) {
+        std::cerr << "Exception thrown from " << failmsg << ": " << e.what() << std::endl;
+        EXPECT_TRUE(0 == 1) << failmsg;
+    }
+    catch (...) {
+        UNIT_TEST_HANDLE_ALL_EXCEPTIONS;
+    }
+}


### PR DESCRIPTION
Implements #413: evaluation keys can now be generated with fewer RNS limbs — sized to the
ciphertexts they will actually touch — and existing keys can be compressed in place.

> **Draft.** The core capability is complete and fully tested. Before marking ready for
> review, we plan to integrate it with the bootstrapping/FBT key generation paths (see the
> checklist at the bottom) so the savings apply to the largest key sets OpenFHE produces.

## What this adds

**API** (all new arguments default to 0 = current behavior; BGV and CKKS, BV and HYBRID
key switching; BFV throws for `levels > 0` per the issue):

```cpp
cc->EvalRotateKeyGen(sk, {1, -1, 8}, levels);        // also EvalAtIndex/EvalAutomorphismKeyGen
cc->EvalMultKeyGen(sk, levels);                      // also EvalMultKeysGen
cc->EvalSumKeyGen(sk, levels);                       // also EvalSumRows/EvalSumColsKeyGen
cc->KeySwitchGen(sk1, sk2, levels);
auto small = cc->CompressEvalKey(evalKey, levels);   // drop limbs from an existing key
```

## Potential Additions

- BFV support
- Bootstrapping integration: split FindBootstrapRotationIndices by transform stage inside ckksrns-fhe and generate the SlotsToCoeffs-only rotation keys at their stage's level (StC runs near the bottom of the modulus chain). Estimated ~60% off the StC subset, roughly a third of the whole bootstrapping key set; the CtS keys must stay (near) full-size since they run right after the modulus raise. Per-stage levels are derivable internally from the level budget — no user-facing API change.
- StC-first bootstrapping and CKKS FBT: in these flavors the StC transform runs on the depleted input ciphertext, so its keys can approach the size floor (a single digit over a few limbs). Apply the same per-stage generation there.
- Scheme switching (CKKS↔FHEW): the switching and rotation keys generated by EvalCKKStoFHEWKeyGen/EvalSchemeSwitchingKeyGen are applied at a fixed reduced level near the bottom of the chain — natural candidates for the levels argument.
- Documentation updates (readthedocs keyswitch/bootstrapping pages).